### PR TITLE
Guard empty file selection paths

### DIFF
--- a/lib/djv/App/FileMenu.cpp
+++ b/lib/djv/App/FileMenu.cpp
@@ -195,9 +195,12 @@ namespace djv
             if (auto app = p.app.lock())
             {
                 auto a = app->getFilesModel()->getA();
-                for (size_t i = 0; i < p.layersActions.size(); ++i)
+                if (a)
                 {
-                    p.menus["Layers"]->setChecked(p.layersActions[i], i == a->videoLayer);
+                    for (size_t i = 0; i < p.layersActions.size(); ++i)
+                    {
+                        p.menus["Layers"]->setChecked(p.layersActions[i], i == a->videoLayer);
+                    }
                 }
             }
         }

--- a/lib/djv/Models/FilesModel.cpp
+++ b/lib/djv/Models/FilesModel.cpp
@@ -408,7 +408,7 @@ namespace djv
                 index = 0;
             }
             p.b->clear();
-            if (index >= 0 && index <= p.files->getSize())
+            if (index >= 0 && index < p.files->getSize())
             {
                 p.b->pushBack(p.files->getItem(index));
             }
@@ -434,7 +434,7 @@ namespace djv
                 index = static_cast<int>(p.files->getSize()) - 1;
             }
             p.b->clear();
-            if (index >= 0 && index <= p.files->getSize())
+            if (index >= 0 && index < p.files->getSize())
             {
                 p.b->pushBack(p.files->getItem(index));
             }
@@ -550,8 +550,8 @@ namespace djv
                             {
                                 index = p.files->getSize() - 1;
                             }
+                            b.push_back(p.files->getItem(index));
                         }
-                        b.push_back(p.files->getItem(index));
                     }
                     break;
                 }


### PR DESCRIPTION
## Summary

- Guard B-file navigation so empty file lists do not request an out-of-range item.
- Avoid selecting a default compare B item when there is no active A file.
- Avoid dereferencing a null A file while updating the file layer menu state.

## Validation

- `git diff --check upstream/main...HEAD`
- SuperBuild configure smoke with Visual Studio 17 2022: `cmake -S ./etc/SuperBuild -B <temp> ...`

No full DJV build was run in this PR worktree.