### PR TITLE
Add relative zoom for OTIO timeline clips

### DIFF
--- a/docs/view.md
+++ b/docs/view.md
@@ -28,6 +28,19 @@ out from the **View** menu and the zoom control on the **View** tool bar.
 
 Locations: **View** menu, **View** tool bar, **View** tool
 
+### Relative timeline zoom
+
+OpenTimelineIO timelines can contain clips with different image resolutions.
+Enable **Timeline Relative Zoom** to preserve the apparent zoom and normalized
+view center when playback moves between those clips. This keeps clips with the
+same aspect ratio at the same displayed size while still allowing manual zoom
+and pan adjustments.
+
+The option is available only for OTIO and OTIOZ timelines. Regular media files
+keep the standard view behavior.
+
+Locations: **View** menu, **View** tool bar
+
 ## Color channels
 
 Individual color channels can be isolated to inspect them.

--- a/etc/Icons/ViewTimelineRelativeZoom.svg
+++ b/etc/Icons/ViewTimelineRelativeZoom.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="20" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+  <g fill="none" stroke="#f0f0f0" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+    <rect x="2.5" y="4.5" width="15" height="11" rx="1"/>
+    <rect x="5.5" y="6.75" width="9" height="6.5" rx="0.5"/>
+    <path d="M3 2.5h4M3 2.5v3M17 17.5h-4M17 17.5v-3"/>
+  </g>
+</svg>

--- a/lib/djv/App/CMakeLists.txt
+++ b/lib/djv/App/CMakeLists.txt
@@ -30,6 +30,7 @@ set(HEADERS
     MessagesTool.h
     PlaybackActions.h
     PlaybackMenu.h
+    RelativeView.h
     SecondaryWindow.h
     SettingsTool.h
     StatusBar.h
@@ -83,6 +84,7 @@ set(SOURCE
     MessagesTool.cpp
     PlaybackActions.cpp
     PlaybackMenu.cpp
+    RelativeView.cpp
     SecondaryWindow.cpp
     SettingsTool.cpp
     StatusBar.cpp

--- a/lib/djv/App/MainWindow.cpp
+++ b/lib/djv/App/MainWindow.cpp
@@ -63,6 +63,7 @@
 namespace djv_resource
 {
     extern std::vector<uint8_t> DJV_Icon;
+    extern std::vector<uint8_t> ViewTimelineRelativeZoom;
 }
 
 namespace djv
@@ -147,6 +148,9 @@ namespace djv
 
             auto iconSystem = context->getSystem<ftk::IconSystem>();
             iconSystem->add("DJV_Icon", djv_resource::DJV_Icon);
+            iconSystem->add(
+                "ViewTimelineRelativeZoom",
+                djv_resource::ViewTimelineRelativeZoom);
             setIcon(iconSystem->get("DJV_Icon", 1.0));
 
             p.app = app;

--- a/lib/djv/App/RelativeView.cpp
+++ b/lib/djv/App/RelativeView.cpp
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the DJV project.
+
+#include <djv/App/RelativeView.h>
+
+#include <algorithm>
+#include <cmath>
+
+namespace djv
+{
+    namespace app
+    {
+        namespace
+        {
+            bool isValid(const ftk::Size2I& value)
+            {
+                return value.w > 0 && value.h > 0;
+            }
+        }
+
+        double getFitZoom(
+            const ftk::Size2I& viewportSize,
+            const ftk::Size2I& renderSize)
+        {
+            if (!isValid(viewportSize) || !isValid(renderSize))
+            {
+                return 0.0;
+            }
+            return std::min(
+                viewportSize.w / static_cast<double>(renderSize.w),
+                viewportSize.h / static_cast<double>(renderSize.h));
+        }
+
+        bool getRelativeView(
+            const ftk::Size2I& previousViewportSize,
+            const ftk::Size2I& currentViewportSize,
+            const ftk::Size2I& previousRenderSize,
+            const ftk::Size2I& currentRenderSize,
+            const ftk::V2I& previousPos,
+            double previousZoom,
+            const ftk::RangeD& zoomRange,
+            RelativeView& out)
+        {
+            const double previousFitZoom = getFitZoom(
+                previousViewportSize,
+                previousRenderSize);
+            const double currentFitZoom = getFitZoom(
+                currentViewportSize,
+                currentRenderSize);
+            if (previousFitZoom <= 0.0 || currentFitZoom <= 0.0 ||
+                previousZoom <= 0.0 || !std::isfinite(previousZoom))
+            {
+                return false;
+            }
+
+            const double relativeZoom = previousZoom / previousFitZoom;
+            const double currentZoom = std::clamp(
+                currentFitZoom * relativeZoom,
+                zoomRange.min(),
+                zoomRange.max());
+            if (currentZoom <= 0.0 || !std::isfinite(currentZoom))
+            {
+                return false;
+            }
+
+            const double previousViewportCenterX = previousViewportSize.w / 2.0;
+            const double previousViewportCenterY = previousViewportSize.h / 2.0;
+            const double normalizedCenterX =
+                (previousViewportCenterX - previousPos.x) /
+                previousZoom /
+                previousRenderSize.w;
+            const double normalizedCenterY =
+                (previousViewportCenterY - previousPos.y) /
+                previousZoom /
+                previousRenderSize.h;
+
+            const double currentViewportCenterX = currentViewportSize.w / 2.0;
+            const double currentViewportCenterY = currentViewportSize.h / 2.0;
+            out.pos = ftk::V2I(
+                static_cast<int>(std::lround(
+                    currentViewportCenterX -
+                    normalizedCenterX * currentRenderSize.w * currentZoom)),
+                static_cast<int>(std::lround(
+                    currentViewportCenterY -
+                    normalizedCenterY * currentRenderSize.h * currentZoom)));
+            out.zoom = currentZoom;
+            return true;
+        }
+    }
+}

--- a/lib/djv/App/RelativeView.h
+++ b/lib/djv/App/RelativeView.h
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the DJV project.
+
+#pragma once
+
+#include <ftk/Core/Range.h>
+#include <ftk/Core/Size.h>
+#include <ftk/Core/Vector.h>
+
+namespace djv
+{
+    namespace app
+    {
+        //! A viewport transform expressed for a specific render size.
+        struct RelativeView
+        {
+            ftk::V2I pos;
+            double zoom = 1.0;
+        };
+
+        //! Return the zoom that fits a render size inside a viewport.
+        double getFitZoom(const ftk::Size2I&, const ftk::Size2I&);
+
+        //! Transfer a view between render and viewport sizes while preserving
+        //! its zoom relative to fit and its normalized center.
+        bool getRelativeView(
+            const ftk::Size2I& previousViewportSize,
+            const ftk::Size2I& currentViewportSize,
+            const ftk::Size2I& previousRenderSize,
+            const ftk::Size2I& currentRenderSize,
+            const ftk::V2I& previousPos,
+            double previousZoom,
+            const ftk::RangeD& zoomRange,
+            RelativeView&);
+    }
+}

--- a/lib/djv/App/ViewActions.cpp
+++ b/lib/djv/App/ViewActions.cpp
@@ -6,6 +6,7 @@
 #include <djv/App/App.h>
 #include <djv/App/MainWindow.h>
 #include <djv/App/Viewport.h>
+#include <djv/Models/SettingsModel.h>
 #include <djv/Models/ViewportModel.h>
 
 #include <ftk/Core/Format.h>
@@ -19,6 +20,8 @@ namespace djv
         struct ViewActions::Private
         {
             std::shared_ptr<ftk::Observer<bool> > frameViewObserver;
+            std::shared_ptr<ftk::Observer<bool> > timelinePlayerObserver;
+            std::shared_ptr<ftk::Observer<models::TimelineSettings> > timelineSettingsObserver;
             std::shared_ptr<ftk::Observer<tl::DisplayOptions> > displayOptionsObserver;
             std::shared_ptr<ftk::Observer<models::AspectRatioOptions> > aspectRatioOptionsObserver;
             std::shared_ptr<ftk::Observer<tl::BackgroundOptions> > bgOptionsObserver;
@@ -35,6 +38,7 @@ namespace djv
             FTK_P();
 
             auto mainWindowWeak = std::weak_ptr<MainWindow>(mainWindow);
+            auto appWeak = std::weak_ptr<App>(app);
             _actions["Frame"] = ftk::Action::create(
                 "Frame",
                 "ViewFrame",
@@ -43,6 +47,19 @@ namespace djv
                     if (auto mainWindow = mainWindowWeak.lock())
                     {
                         mainWindow->getViewport()->setFrameView(value);
+                    }
+                });
+
+            _actions["TimelineRelativeZoom"] = ftk::Action::create(
+                "Timeline Relative Zoom",
+                "ViewTimelineRelativeZoom",
+                [appWeak](bool value)
+                {
+                    if (auto app = appWeak.lock())
+                    {
+                        auto settings = app->getSettingsModel()->getTimeline();
+                        settings.relativeZoom = value;
+                        app->getSettingsModel()->setTimeline(settings);
                     }
                 });
 
@@ -89,7 +106,6 @@ namespace djv
                     }
                 });
 
-            auto appWeak = std::weak_ptr<App>(app);
             _actions["Red"] = ftk::Action::create(
                 "Red Channel",
                 [appWeak](bool value)
@@ -248,6 +264,7 @@ namespace djv
             _tooltips =
             {
                 { "Frame",  "Frame the view to fit the image." },
+                { "TimelineRelativeZoom", "Preserve zoom and center relative to each clip when an OTIO timeline changes resolution." },
                 { "ZoomReset", "Reset the view zoom to 1:1." },
                 { "ZoomIn", "Zoom the view in." },
                 { "ZoomOut", "Zoom the view out." },
@@ -265,6 +282,20 @@ namespace djv
                 [this](bool value)
                 {
                     _actions["Frame"]->setChecked(value);
+                });
+
+            p.timelinePlayerObserver = ftk::Observer<bool>::create(
+                mainWindow->getViewport()->observeTimelinePlayer(),
+                [this](bool value)
+                {
+                    _actions["TimelineRelativeZoom"]->setEnabled(value);
+                });
+
+            p.timelineSettingsObserver = ftk::Observer<models::TimelineSettings>::create(
+                app->getSettingsModel()->observeTimeline(),
+                [this](const models::TimelineSettings& value)
+                {
+                    _actions["TimelineRelativeZoom"]->setChecked(value.relativeZoom);
                 });
 
             p.displayOptionsObserver = ftk::Observer<tl::DisplayOptions>::create(

--- a/lib/djv/App/ViewMenu.cpp
+++ b/lib/djv/App/ViewMenu.cpp
@@ -28,6 +28,7 @@ namespace djv
 
             auto actions = viewActions->getActions();
             addAction(actions["Frame"]);
+            addAction(actions["TimelineRelativeZoom"]);
             addAction(actions["ZoomReset"]);
             addAction(actions["ZoomIn"]);
             addAction(actions["ZoomOut"]);

--- a/lib/djv/App/ViewToolBar.cpp
+++ b/lib/djv/App/ViewToolBar.cpp
@@ -36,6 +36,7 @@ namespace djv
 
             auto actions = viewActions->getActions();
             addAction(actions["Frame"]);
+            addAction(actions["TimelineRelativeZoom"]);
 
             p.zoomEdit = ftk::DoubleEdit::create(context);
             auto viewport = mainWindow->getViewport();

--- a/lib/djv/App/Viewport.cpp
+++ b/lib/djv/App/Viewport.cpp
@@ -4,6 +4,7 @@
 #include <djv/App/Viewport.h>
 
 #include <djv/App/App.h>
+#include <djv/App/RelativeView.h>
 #include <djv/Models/ColorModel.h>
 #include <djv/Models/FilesModel.h>
 #include <djv/Models/SettingsModel.h>
@@ -20,12 +21,31 @@
 #include <ftk/UI/Spacer.h>
 #include <ftk/Core/Format.h>
 
+#include <algorithm>
+#include <cctype>
 #include <regex>
 
 namespace djv
 {
     namespace app
     {
+        namespace
+        {
+            bool isTimelinePath(const ftk::Path& path)
+            {
+                std::string ext = path.getExt();
+                std::transform(
+                    ext.begin(),
+                    ext.end(),
+                    ext.begin(),
+                    [](unsigned char value)
+                    {
+                        return static_cast<char>(std::tolower(value));
+                    });
+                return ext == ".otio" || ext == ".otioz";
+            }
+        }
+
         struct Viewport::Private
         {
             std::weak_ptr<App> app;
@@ -47,6 +67,9 @@ namespace djv
             std::shared_ptr<ftk::Observable<ftk::V2I> > pick;
             std::shared_ptr<ftk::Observable<ftk::V2I> > samplePos;
             std::shared_ptr<ftk::Observable<ftk::Color4F> > colorSample;
+            std::shared_ptr<ftk::Observable<bool> > timelinePlayer;
+            bool timelineRelativeZoom = false;
+            ftk::Size2I renderSize;
 
             std::shared_ptr<ftk::Label> fileNameLabel;
             std::shared_ptr<ftk::Label> cacheLabel;
@@ -75,6 +98,7 @@ namespace djv
             std::shared_ptr<ftk::Observer<models::HUDOptions> > hudOptionsObserver;
             std::shared_ptr<ftk::Observer<tl::TimeUnits> > timeUnitsObserver;
             std::shared_ptr<ftk::Observer<models::MouseSettings> > mouseSettingsObserver;
+            std::shared_ptr<ftk::Observer<models::TimelineSettings> > timelineSettingsObserver;
 
             enum class MouseMode
             {
@@ -103,6 +127,7 @@ namespace djv
             p.pick = ftk::Observable<ftk::V2I>::create();
             p.samplePos = ftk::Observable<ftk::V2I>::create();
             p.colorSample = ftk::Observable<ftk::Color4F>::create();
+            p.timelinePlayer = ftk::Observable<bool>::create(false);
 
             p.fileNameLabel = ftk::Label::create(context);
             p.fileNameLabel->setFont(ftk::FontType::Mono);
@@ -271,6 +296,13 @@ namespace djv
                     p.frameShuttleBinding = i != value.bindings.end() ? i->second : models::MouseActionBinding();
                     p.frameShuttleScale = value.frameShuttleScale;
                 });
+
+            p.timelineSettingsObserver = ftk::Observer<models::TimelineSettings>::create(
+                app->getSettingsModel()->observeTimeline(),
+                [this](const models::TimelineSettings& value)
+                {
+                    _p->timelineRelativeZoom = value.relativeZoom;
+                });
         }
 
         Viewport::Viewport() :
@@ -305,6 +337,16 @@ namespace djv
             return _p->colorSample;
         }
 
+        bool Viewport::isTimelinePlayer() const
+        {
+            return _p->timelinePlayer->get();
+        }
+
+        std::shared_ptr<ftk::IObservable<bool> > Viewport::observeTimelinePlayer() const
+        {
+            return _p->timelinePlayer;
+        }
+
         void Viewport::pick(const ftk::V2I& imagePos)
         {
             FTK_P();
@@ -326,6 +368,8 @@ namespace djv
         {
             tl::ui::Viewport::setPlayer(player);
             FTK_P();
+            p.renderSize = ftk::Size2I();
+            p.timelinePlayer->setIfChanged(player && isTimelinePath(player->getPath()));
             if (player)
             {
                 p.path = player->getPath();
@@ -343,6 +387,17 @@ namespace djv
                     [this](const std::vector<tl::VideoFrame>& value)
                     {
                         _p->videoFramesSize = value.size();
+                        const ftk::Size2I renderSize = tl::getRenderSize(
+                            getCompareOptions().compare,
+                            value);
+                        if (renderSize.w > 0 && renderSize.h > 0)
+                        {
+                            const ftk::Size2I viewportSize = getGeometry().size();
+                            _relativeZoomUpdate(
+                                viewportSize,
+                                viewportSize,
+                                renderSize);
+                        }
                         _videoUpdate();
                     });
 
@@ -373,7 +428,17 @@ namespace djv
 
         void Viewport::setGeometry(const ftk::Box2I& value)
         {
+            const ftk::Size2I previousViewportSize = getGeometry().size();
             tl::ui::Viewport::setGeometry(value);
+            const ftk::Size2I currentViewportSize = value.size();
+            if (previousViewportSize != currentViewportSize &&
+                _p->renderSize.w > 0 && _p->renderSize.h > 0)
+            {
+                _relativeZoomUpdate(
+                    previousViewportSize,
+                    currentViewportSize,
+                    _p->renderSize);
+            }
             FTK_P();
             p.hudLayout->setGeometry(value);
         }
@@ -454,6 +519,34 @@ namespace djv
             tl::ui::Viewport::mouseReleaseEvent(event);
             FTK_P();
             p.mouse = Private::MouseData();
+        }
+
+        void Viewport::_relativeZoomUpdate(
+            const ftk::Size2I& previousViewportSize,
+            const ftk::Size2I& currentViewportSize,
+            const ftk::Size2I& renderSize)
+        {
+            FTK_P();
+            if (p.timelineRelativeZoom &&
+                p.timelinePlayer->get() &&
+                !hasFrameView() &&
+                p.renderSize.w > 0 && p.renderSize.h > 0)
+            {
+                RelativeView view;
+                if (getRelativeView(
+                    previousViewportSize,
+                    currentViewportSize,
+                    p.renderSize,
+                    renderSize,
+                    getViewPos(),
+                    getZoom(),
+                    getZoomRange(),
+                    view))
+                {
+                    setViewPosAndZoom(view.pos, view.zoom);
+                }
+            }
+            p.renderSize = renderSize;
         }
 
         void Viewport::_videoUpdate()

--- a/lib/djv/App/Viewport.h
+++ b/lib/djv/App/Viewport.h
@@ -45,6 +45,12 @@ namespace djv
             //! action would. Used by the documentation screenshot capture.
             void pick(const ftk::V2I& imagePos);
 
+            //! Get whether the current player contains an editorial timeline.
+            bool isTimelinePlayer() const;
+
+            //! Observe whether the current player contains an editorial timeline.
+            std::shared_ptr<ftk::IObservable<bool> > observeTimelinePlayer() const;
+
             void setPlayer(const std::shared_ptr<tl::Player>&) override;
 
             ftk::Size2I getSizeHint() const override;
@@ -54,6 +60,10 @@ namespace djv
             void mouseReleaseEvent(ftk::MouseClickEvent&) override;
 
         private:
+            void _relativeZoomUpdate(
+                const ftk::Size2I&,
+                const ftk::Size2I&,
+                const ftk::Size2I&);
             void _videoUpdate();
             void _hudUpdate();
             void _hudLayout();

--- a/lib/djv/Models/SettingsModel.cpp
+++ b/lib/djv/Models/SettingsModel.cpp
@@ -376,6 +376,7 @@ namespace djv
             return
                 minimize == other.minimize &&
                 frameView == other.frameView &&
+                relativeZoom == other.relativeZoom &&
                 scrollBars == other.scrollBars &&
                 autoScroll == other.autoScroll &&
                 stopOnScrub == other.stopOnScrub &&
@@ -1019,6 +1020,7 @@ namespace djv
         {
             json["Minimize"] = value.minimize;
             json["FrameView"] = value.frameView;
+            json["RelativeZoom"] = value.relativeZoom;
             json["ScrollBars"] = value.scrollBars;
             json["AutoScroll"] = value.autoScroll;
             json["StopOnScrub"] = value.stopOnScrub;
@@ -1164,6 +1166,11 @@ namespace djv
         {
             json.at("Minimize").get_to(value.minimize);
             json.at("FrameView").get_to(value.frameView);
+            const auto relativeZoom = json.find("RelativeZoom");
+            if (relativeZoom != json.end())
+            {
+                relativeZoom->get_to(value.relativeZoom);
+            }
             json.at("ScrollBars").get_to(value.scrollBars);
             json.at("AutoScroll").get_to(value.autoScroll);
             json.at("StopOnScrub").get_to(value.stopOnScrub);

--- a/lib/djv/Models/SettingsModel.h
+++ b/lib/djv/Models/SettingsModel.h
@@ -248,6 +248,7 @@ namespace djv
         {
             bool minimize = true;
             bool frameView = true;
+            bool relativeZoom = false;
             bool scrollBars = true;
             bool autoScroll = true;
             bool stopOnScrub = false;

--- a/lib/djv/Resource/CMakeLists.txt
+++ b/lib/djv/Resource/CMakeLists.txt
@@ -1,7 +1,8 @@
 set(HEADERS)
 set(SOURCE)
 set(RESOURCES
-    etc/Icons/DJV_Icon.svg)
+    etc/Icons/DJV_Icon.svg
+    etc/Icons/ViewTimelineRelativeZoom.svg)
 foreach(RESOURCE ${RESOURCES})
     get_filename_component(RESOURCE_BASE ${RESOURCE} NAME_WE)
     add_custom_command(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,1 +1,8 @@
 add_subdirectory(djv-test)
+
+add_executable(djvRelativeViewTest RelativeViewTest.cpp)
+target_link_libraries(djvRelativeViewTest djvApp)
+set_target_properties(djvRelativeViewTest PROPERTIES FOLDER tests)
+add_test(
+    NAME djvRelativeViewTest
+    COMMAND $<TARGET_FILE:djvRelativeViewTest>)

--- a/tests/RelativeViewTest.cpp
+++ b/tests/RelativeViewTest.cpp
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the DJV project.
+
+#include <djv/App/RelativeView.h>
+#include <djv/Models/SettingsModel.h>
+
+#include <nlohmann/json.hpp>
+
+#include <cmath>
+#include <iostream>
+#include <string>
+
+namespace
+{
+    int failures = 0;
+
+    void check(bool value, const std::string& message)
+    {
+        if (!value)
+        {
+            ++failures;
+            std::cerr << "FAIL: " << message << '\n';
+        }
+    }
+
+    bool close(double a, double b, double epsilon = 0.000001)
+    {
+        return std::abs(a - b) <= epsilon;
+    }
+}
+
+int main()
+{
+    const ftk::RangeD zoomRange(0.01, 100.0);
+
+    // Exact fit transfers between same-aspect clips with different resolutions.
+    {
+        djv::app::RelativeView view;
+        const bool ok = djv::app::getRelativeView(
+            ftk::Size2I(1280, 720),
+            ftk::Size2I(1280, 720),
+            ftk::Size2I(1920, 1080),
+            ftk::Size2I(640, 360),
+            ftk::V2I(0, 0),
+            2.0 / 3.0,
+            zoomRange,
+            view);
+        check(ok, "same-aspect fit transfer succeeds");
+        check(close(view.zoom, 2.0), "640x360 clip receives a 2x fit zoom");
+        check(view.pos == ftk::V2I(0, 0), "same-aspect fit remains centered");
+        check(
+            close(1920.0 * (2.0 / 3.0), 640.0 * view.zoom),
+            "different resolutions have the same displayed width");
+    }
+
+    // A custom relative zoom remains custom instead of snapping back to fit.
+    {
+        djv::app::RelativeView view;
+        const bool ok = djv::app::getRelativeView(
+            ftk::Size2I(1280, 720),
+            ftk::Size2I(1280, 720),
+            ftk::Size2I(1920, 1080),
+            ftk::Size2I(640, 360),
+            ftk::V2I(-320, -180),
+            1.0,
+            zoomRange,
+            view);
+        check(ok, "custom zoom transfer succeeds");
+        check(close(view.zoom, 3.0), "custom zoom keeps its factor relative to fit");
+        check(view.pos == ftk::V2I(-320, -180), "normalized center is preserved");
+    }
+
+    // Unusual aspect ratios still preserve the same fit-relative scale.
+    {
+        djv::app::RelativeView view;
+        const bool ok = djv::app::getRelativeView(
+            ftk::Size2I(1280, 720),
+            ftk::Size2I(1280, 720),
+            ftk::Size2I(1920, 1080),
+            ftk::Size2I(1080, 1920),
+            ftk::V2I(-320, -180),
+            1.0,
+            zoomRange,
+            view);
+        check(ok, "landscape-to-portrait transfer succeeds");
+        check(close(view.zoom, 0.5625), "portrait clip keeps 150% of fit");
+        check(view.pos == ftk::V2I(336, -180), "portrait clip keeps the normalized center");
+    }
+
+    // Resizing the viewport also preserves the semantic zoom level.
+    {
+        djv::app::RelativeView view;
+        const bool ok = djv::app::getRelativeView(
+            ftk::Size2I(1280, 720),
+            ftk::Size2I(1000, 800),
+            ftk::Size2I(640, 360),
+            ftk::Size2I(640, 360),
+            ftk::V2I(0, 0),
+            2.0,
+            zoomRange,
+            view);
+        check(ok, "viewport resize transfer succeeds");
+        check(close(view.zoom, 1.5625), "viewport resize recomputes fit-relative zoom");
+        check(view.pos == ftk::V2I(0, 119), "resized view remains centered");
+    }
+
+    // Invalid input must not mutate a live view.
+    {
+        djv::app::RelativeView view;
+        check(
+            !djv::app::getRelativeView(
+                ftk::Size2I(),
+                ftk::Size2I(1280, 720),
+                ftk::Size2I(1920, 1080),
+                ftk::Size2I(640, 360),
+                ftk::V2I(),
+                1.0,
+                zoomRange,
+                view),
+            "invalid viewport size is rejected");
+    }
+
+    // The new setting must round-trip while old settings remain compatible.
+    {
+        djv::models::TimelineSettings settings;
+        settings.relativeZoom = true;
+        nlohmann::json json;
+        djv::models::to_json(json, settings);
+        check(json.at("RelativeZoom").get<bool>(), "relative zoom is serialized");
+
+        djv::models::TimelineSettings restored;
+        djv::models::from_json(json, restored);
+        check(restored.relativeZoom, "relative zoom round-trips");
+
+        json.erase("RelativeZoom");
+        djv::models::TimelineSettings legacy;
+        djv::models::from_json(json, legacy);
+        check(!legacy.relativeZoom, "legacy settings default to absolute zoom");
+    }
+
+    if (failures)
+    {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+    std::cout << "All relative view tests passed\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary

- add an opt-in **Timeline Relative Zoom** action for `.otio` and `.otioz` players
- preserve apparent zoom and normalized view center when adjacent clips use different image resolutions
- keep regular media files and the existing Frame View behavior unchanged
- persist the setting with backward-compatible JSON loading
- isolate the transform math in a small helper with focused tests

## Motivation

An editorial timeline can contain clips with the same aspect ratio but different pixel dimensions. With one absolute zoom value, switching from a 1920x1080 clip to a 640x360 clip changes the apparent size even though both clips should occupy the same portion of the viewport.

This change stores zoom relative to each clip's fit scale. When the render size changes, DJV transfers the view using the ratio between the previous and new fit scales, while preserving the normalized center. Frame View still performs its existing exact fit; the new mode handles custom zoom and pan outside Frame View.

## Scope and maintenance

- The action is enabled only for OTIO/OTIOZ players.
- The transform is implemented in `RelativeView` rather than embedded in event handling.
- Timeline detection is limited to the player path extension; no new timeline parser or media dependency is introduced.
- Existing settings files without `RelativeZoom` continue to load with the feature disabled.
- This branch contains one commit based directly on current `upstream/main`.

## Tests

`djvRelativeViewTest` covers:

- equal-aspect clips with different resolutions
- custom zoom relative to fit
- landscape-to-portrait changes
- viewport resizing
- invalid geometry
- settings JSON round-trip and legacy settings compatibility

Local integration evidence:

- the focused test passes in the Windows DJV integration build
- a 1280x720 clip and a 640x360 clip produced identical displayed bounds (0 px width and height delta) while zoom changed by approximately 2x
- `git diff --check` passes and the public diff contains no private paths or local workflow files

The clean upstream Windows build currently stops in tlRender dependencies before compiling DJV because the available local dependency prefix lacks FFmpeg headers and does not match the current OpenTimelineIO/nlohmann pair. This PR is intentionally a draft until GitHub CI provides the clean dependency build result.