### PR TITLE
Forward Windows file opens to the running DJV instance

### DIFF
--- a/lib/djv/App/App.cpp
+++ b/lib/djv/App/App.cpp
@@ -20,6 +20,7 @@
 #include <djv/App/SysLogTool.h>
 #include <djv/App/ViewTool.h>
 #include <djv/App/Viewport.h>
+#include <djv/App/WindowsOpenBroker.h>
 #include <djv/UI/SeparateAudioDialog.h>
 #include <djv/Models/AppInfoModel.h>
 #include <djv/Models/AudioModel.h>
@@ -54,8 +55,18 @@
 #include <ftk/Core/OS.h>
 #include <ftk/Core/Timer.h>
 
+#include <cstdlib>
+#include <deque>
 #include <filesystem>
+#include <mutex>
 #include <optional>
+
+#if defined(_WIN32)
+#    if !defined(NOMINMAX)
+#        define NOMINMAX
+#    endif
+#    include <windows.h>
+#endif // _WIN32
 
 namespace djv
 {
@@ -138,6 +149,110 @@ namespace djv
                 }
                 return out;
             }
+
+            bool hasNonForwardableOptions(const CmdLine& value)
+            {
+                return
+                    value.audioFileName->found() ||
+                    value.compareFileName->found() ||
+                    value.compare->found() ||
+                    value.wipeCenter->found() ||
+                    value.wipeRotation->found() ||
+                    value.speed->found() ||
+                    value.playback->found() ||
+                    value.loop->found() ||
+                    value.timeUnits->found() ||
+                    value.seek->found() ||
+                    value.inPoint->found() ||
+                    value.outPoint->found() ||
+                    value.ocioFileName->found() ||
+                    value.ocioInput->found() ||
+                    value.ocioDisplay->found() ||
+                    value.ocioView->found() ||
+                    value.ocioLook->found() ||
+                    value.lutFileName->found() ||
+                    value.lutOrder->found() ||
+#if defined(TLRENDER_USD)
+                    value.usdRenderWidth->found() ||
+                    value.usdComplexity->found() ||
+                    value.usdDrawMode->found() ||
+                    value.usdEnableLighting->found() ||
+                    value.usdSRGB->found() ||
+                    value.usdStageCacheCount->found() ||
+                    value.usdDiskCacheGB->found() ||
+#endif // TLRENDER_USD
+                    value.logFileName->found() ||
+                    value.resetSettings->found() ||
+                    value.settingsFileName->found() ||
+                    value.version->found() ||
+                    value.sysInfo->found() ||
+                    value.listCommands->found() ||
+                    value.command->found() ||
+                    value.debugLoop->found() ||
+                    value.captureManifest->found() ||
+                    value.captureShot->found() ||
+                    value.captureOutput->found();
+            }
+
+            WindowsOpenBrokerOptions getWindowsOpenBrokerOptions()
+            {
+                WindowsOpenBrokerOptions out;
+                if (const char* value = std::getenv("DJV_SINGLE_INSTANCE_ID"))
+                {
+                    if (*value)
+                    {
+                        out.applicationId = value;
+                    }
+                }
+                return out;
+            }
+
+#if defined(_WIN32)
+            struct ActivationWindowData
+            {
+                DWORD processId = 0;
+                HWND window = nullptr;
+            };
+
+            BOOL CALLBACK findActivationWindow(HWND window, LPARAM value)
+            {
+                auto data = reinterpret_cast<ActivationWindowData*>(value);
+                DWORD processId = 0;
+                GetWindowThreadProcessId(window, &processId);
+                if (processId == data->processId &&
+                    IsWindowVisible(window) &&
+                    nullptr == GetWindow(window, GW_OWNER))
+                {
+                    data->window = window;
+                    return FALSE;
+                }
+                return TRUE;
+            }
+
+            void requestCurrentProcessWindowAttention()
+            {
+                ActivationWindowData data;
+                data.processId = GetCurrentProcessId();
+                EnumWindows(findActivationWindow, reinterpret_cast<LPARAM>(&data));
+                if (!data.window)
+                {
+                    return;
+                }
+                if (IsIconic(data.window))
+                {
+                    ShowWindow(data.window, SW_RESTORE);
+                }
+                if (!SetForegroundWindow(data.window))
+                {
+                    FLASHWINFO flash = {};
+                    flash.cbSize = sizeof(flash);
+                    flash.hwnd = data.window;
+                    flash.dwFlags = FLASHW_TRAY | FLASHW_TIMERNOFG;
+                    flash.uCount = 3;
+                    FlashWindowEx(&flash);
+                }
+            }
+#endif // _WIN32
         }
 
         struct App::Private
@@ -170,6 +285,11 @@ namespace djv
             std::shared_ptr<MainWindow> mainWindow;
             std::shared_ptr<SecondaryWindow> secondaryWindow;
             std::shared_ptr<ui::SeparateAudioDialog> separateAudioDialog;
+
+            std::unique_ptr<WindowsOpenBroker> windowsOpenBroker;
+            std::mutex windowsOpenMutex;
+            std::deque<std::vector<std::string> > windowsOpenQueue;
+            std::shared_ptr<ftk::Timer> windowsOpenTimer;
 
             std::shared_ptr<ftk::Observer<tl::PlayerCacheOptions> > cacheObserver;
             std::shared_ptr<ftk::Observer<models::ImageSeqSettings> > imageSeqObserver;
@@ -455,7 +575,17 @@ namespace djv
         {}
 
         App::~App()
-        {}
+        {
+            FTK_P();
+            if (p.windowsOpenTimer)
+            {
+                p.windowsOpenTimer->stop();
+            }
+            if (p.windowsOpenBroker)
+            {
+                p.windowsOpenBroker->stop();
+            }
+        }
 
         std::shared_ptr<App> App::create(
             const std::shared_ptr<ftk::Context>& context,
@@ -836,6 +966,67 @@ namespace djv
         {
             FTK_P();
 
+#if defined(_WIN32)
+            const WindowsOpenBrokerOptions brokerOptions =
+                getWindowsOpenBrokerOptions();
+            p.windowsOpenBroker.reset(new WindowsOpenBroker(brokerOptions));
+            const auto brokerStart = p.windowsOpenBroker->start(
+                [this](
+                    const std::vector<std::string>& paths,
+                    std::string& message)
+                {
+                    FTK_P();
+                    std::lock_guard<std::mutex> lock(p.windowsOpenMutex);
+                    if (p.windowsOpenQueue.size() >= 16)
+                    {
+                        message = "The DJV open-request queue is full.";
+                        return false;
+                    }
+                    p.windowsOpenQueue.push_back(paths);
+                    return true;
+                });
+            if (WindowsOpenBrokerStartStatus::AlreadyRunning == brokerStart.status)
+            {
+                const bool canForward =
+                    !p.cmdLine.inputs->getList().empty() &&
+                    !hasNonForwardableOptions(p.cmdLine) &&
+                    !getColorStyleCmdLineOption()->found() &&
+                    !getDisplayScaleCmdLineOption()->found();
+                if (canForward)
+                {
+                    const auto forwarded = WindowsOpenBroker::forward(
+                        p.cmdLine.inputs->getList(),
+                        std::filesystem::current_path().u8string(),
+                        brokerOptions);
+                    if (WindowsOpenForwardStatus::Forwarded == forwarded.status ||
+                        WindowsOpenForwardStatus::DeliveryUnknown == forwarded.status)
+                    {
+                        if (WindowsOpenForwardStatus::DeliveryUnknown == forwarded.status)
+                        {
+                            std::cerr <<
+                                "WARNING: The existing DJV instance may have received "
+                                "the files, but its acknowledgement was lost. "
+                                "The request will not be repeated." << std::endl;
+                        }
+                        p.windowsOpenBroker.reset();
+                        return;
+                    }
+                    std::cerr <<
+                        "WARNING: Cannot forward files to the existing DJV "
+                        "instance; opening an independent window: " <<
+                        forwarded.error << std::endl;
+                }
+                p.windowsOpenBroker.reset();
+            }
+            else if (WindowsOpenBrokerStartStatus::Started != brokerStart.status)
+            {
+                std::cerr <<
+                    "WARNING: Secure single-instance file opening is unavailable: " <<
+                    brokerStart.error << std::endl;
+                p.windowsOpenBroker.reset();
+            }
+#endif // _WIN32
+
             p.fileLogSystem = ftk::FileLogSystem::create(_context, p.logFile);
 
             if (p.cmdLine.settingsFileName->found())
@@ -866,6 +1057,18 @@ namespace djv
             }
             
             _mainWindowInit();
+
+            if (p.windowsOpenBroker && p.windowsOpenBroker->isRunning())
+            {
+                p.windowsOpenTimer = ftk::Timer::create(_context);
+                p.windowsOpenTimer->setRepeating(true);
+                p.windowsOpenTimer->start(
+                    std::chrono::milliseconds(50),
+                    [this]
+                    {
+                        _windowsOpenPoll();
+                    });
+            }
 
             if (p.cmdLine.listCommands->found())
             {
@@ -990,6 +1193,29 @@ namespace djv
             }
 
             ftk::App::run();
+        }
+
+        void App::_windowsOpenPoll()
+        {
+            FTK_P();
+            std::vector<std::string> paths;
+            {
+                std::lock_guard<std::mutex> lock(p.windowsOpenMutex);
+                if (p.windowsOpenQueue.empty())
+                {
+                    return;
+                }
+                paths = std::move(p.windowsOpenQueue.front());
+                p.windowsOpenQueue.pop_front();
+            }
+
+            for (const auto& path : paths)
+            {
+                open(ftk::Path(path));
+            }
+#if defined(_WIN32)
+            requestCurrentProcessWindowAttention();
+#endif // _WIN32
         }
 
         void App::_modelsInit()

--- a/lib/djv/App/App.h
+++ b/lib/djv/App/App.h
@@ -166,6 +166,8 @@ namespace djv
             std::filesystem::path _getLogFilePath();
             std::filesystem::path _getSettingsPath();
 
+            void _windowsOpenPoll();
+
             void _filesUpdate(const std::vector<std::shared_ptr<models::FilesModelItem> >&);
             void _activeUpdate(const std::vector<std::shared_ptr<models::FilesModelItem> >&);
             // Reopen the active files. When the timeline is about to be a

--- a/lib/djv/App/CMakeLists.txt
+++ b/lib/djv/App/CMakeLists.txt
@@ -49,7 +49,8 @@ set(HEADERS
     WindowMenu.h
     WindowToolBar.h
     ViewTool.h
-    Viewport.h)
+    Viewport.h
+    WindowsOpenBroker.h)
 set(HEADERS_PRIVATE)
 
 set(SOURCE
@@ -103,7 +104,8 @@ set(SOURCE
     WindowMenu.cpp
     WindowToolBar.cpp
     ViewTool.cpp
-    Viewport.cpp)
+    Viewport.cpp
+    WindowsOpenBroker.cpp)
 
 add_library(djvApp ${HEADERS} ${HEADERS_PRIVATE} ${SOURCE})
 target_link_libraries(djvApp djvUI)

--- a/lib/djv/App/WindowsOpenBroker.cpp
+++ b/lib/djv/App/WindowsOpenBroker.cpp
@@ -1,0 +1,2431 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the DJV project.
+
+#include <djv/App/WindowsOpenBroker.h>
+
+#include <algorithm>
+#include <atomic>
+#include <condition_variable>
+#include <cstring>
+#include <cstdlib>
+#include <exception>
+#include <filesystem>
+#include <iomanip>
+#include <limits>
+#include <mutex>
+#include <sstream>
+#include <thread>
+#include <utility>
+
+#if defined(_WIN32)
+#    if !defined(NOMINMAX)
+#        define NOMINMAX
+#    endif
+#    include <windows.h>
+#    include <aclapi.h>
+#    include <sddl.h>
+
+#    pragma comment(lib, "Advapi32.lib")
+#endif // _WIN32
+
+namespace djv
+{
+    namespace app
+    {
+        namespace
+        {
+            constexpr uint8_t protocolMagic[] = { 'D', 'J', 'V', 'O' };
+            constexpr uint16_t requestMessageType = 1;
+            constexpr uint16_t responseMessageType = 2;
+            constexpr size_t protocolHeaderBytes = 20;
+            constexpr uint8_t responseReceipt = 0xA5;
+
+            enum class ResponseCode : uint32_t
+            {
+                Accepted = 0,
+                InvalidRequest = 1,
+                Unauthorized = 2,
+                CallbackRejected = 3,
+                ServerStopping = 4,
+                InternalError = 5,
+                ProtocolError = 6,
+                PayloadTooLarge = 7
+            };
+
+            void appendU16(std::vector<uint8_t>& out, uint16_t value)
+            {
+                out.push_back(static_cast<uint8_t>(value & 0xFFU));
+                out.push_back(static_cast<uint8_t>((value >> 8U) & 0xFFU));
+            }
+
+            void appendU32(std::vector<uint8_t>& out, uint32_t value)
+            {
+                for (unsigned int i = 0; i < 4; ++i)
+                {
+                    out.push_back(static_cast<uint8_t>((value >> (i * 8U)) & 0xFFU));
+                }
+            }
+
+            void appendU64(std::vector<uint8_t>& out, uint64_t value)
+            {
+                for (unsigned int i = 0; i < 8; ++i)
+                {
+                    out.push_back(static_cast<uint8_t>((value >> (i * 8U)) & 0xFFU));
+                }
+            }
+
+            bool readU16(
+                const std::vector<uint8_t>& data,
+                size_t& offset,
+                uint16_t& value)
+            {
+                if (offset > data.size() || data.size() - offset < 2)
+                {
+                    return false;
+                }
+                value =
+                    static_cast<uint16_t>(data[offset]) |
+                    static_cast<uint16_t>(data[offset + 1]) << 8U;
+                offset += 2;
+                return true;
+            }
+
+            bool readU32(
+                const std::vector<uint8_t>& data,
+                size_t& offset,
+                uint32_t& value)
+            {
+                if (offset > data.size() || data.size() - offset < 4)
+                {
+                    return false;
+                }
+                value = 0;
+                for (unsigned int i = 0; i < 4; ++i)
+                {
+                    value |= static_cast<uint32_t>(data[offset + i]) << (i * 8U);
+                }
+                offset += 4;
+                return true;
+            }
+
+            bool readU64(
+                const std::vector<uint8_t>& data,
+                size_t& offset,
+                uint64_t& value)
+            {
+                if (offset > data.size() || data.size() - offset < 8)
+                {
+                    return false;
+                }
+                value = 0;
+                for (unsigned int i = 0; i < 8; ++i)
+                {
+                    value |= static_cast<uint64_t>(data[offset + i]) << (i * 8U);
+                }
+                offset += 8;
+                return true;
+            }
+
+            bool validateOptions(
+                const WindowsOpenBrokerOptions& options,
+                std::string& error)
+            {
+                if (options.applicationId.empty() || options.applicationId.size() > 256)
+                {
+                    error = "The application identifier must contain 1-256 UTF-8 bytes";
+                    return false;
+                }
+                if (std::string::npos != options.applicationId.find('\0'))
+                {
+                    error = "The application identifier contains an embedded NUL";
+                    return false;
+                }
+                const auto maxTimeout = std::chrono::hours(1);
+                if (options.connectTimeout.count() <= 0 ||
+                    options.ioTimeout.count() <= 0 ||
+                    options.startTimeout.count() <= 0 ||
+                    options.connectTimeout > maxTimeout ||
+                    options.ioTimeout > maxTimeout ||
+                    options.startTimeout > maxTimeout)
+                {
+                    error = "Broker timeouts must be between 1 millisecond and 1 hour";
+                    return false;
+                }
+                return true;
+            }
+
+#if defined(_WIN32)
+            struct Handle
+            {
+                Handle() = default;
+                explicit Handle(HANDLE value) : value(value) {}
+                ~Handle()
+                {
+                    reset();
+                }
+
+                Handle(const Handle&) = delete;
+                Handle& operator=(const Handle&) = delete;
+
+                Handle(Handle&& other) noexcept : value(other.release()) {}
+                Handle& operator=(Handle&& other) noexcept
+                {
+                    if (this != &other)
+                    {
+                        reset(other.release());
+                    }
+                    return *this;
+                }
+
+                explicit operator bool() const noexcept
+                {
+                    return value && INVALID_HANDLE_VALUE != value;
+                }
+
+                HANDLE get() const noexcept
+                {
+                    return value;
+                }
+
+                HANDLE release() noexcept
+                {
+                    const HANDLE out = value;
+                    value = nullptr;
+                    return out;
+                }
+
+                void reset(HANDLE newValue = nullptr) noexcept
+                {
+                    if (value && INVALID_HANDLE_VALUE != value)
+                    {
+                        ::CloseHandle(value);
+                    }
+                    value = newValue;
+                }
+
+                HANDLE value = nullptr;
+            };
+
+            struct LocalMemory
+            {
+                ~LocalMemory()
+                {
+                    if (value)
+                    {
+                        ::LocalFree(value);
+                    }
+                }
+
+                LocalMemory(const LocalMemory&) = delete;
+                LocalMemory& operator=(const LocalMemory&) = delete;
+                LocalMemory() = default;
+
+                HLOCAL value = nullptr;
+            };
+
+            bool utf8ToWide(
+                const std::string& value,
+                std::wstring& out,
+                std::string& error)
+            {
+                if (std::string::npos != value.find('\0'))
+                {
+                    error = "UTF-8 text contains an embedded NUL";
+                    return false;
+                }
+                if (value.empty())
+                {
+                    out.clear();
+                    return true;
+                }
+                if (value.size() > static_cast<size_t>((std::numeric_limits<int>::max)()))
+                {
+                    error = "UTF-8 text is too large";
+                    return false;
+                }
+                const int size = ::MultiByteToWideChar(
+                    CP_UTF8,
+                    MB_ERR_INVALID_CHARS,
+                    value.data(),
+                    static_cast<int>(value.size()),
+                    nullptr,
+                    0);
+                if (size <= 0)
+                {
+                    error = "Text is not valid UTF-8";
+                    return false;
+                }
+                std::wstring tmp(static_cast<size_t>(size), L'\0');
+                if (::MultiByteToWideChar(
+                        CP_UTF8,
+                        MB_ERR_INVALID_CHARS,
+                        value.data(),
+                        static_cast<int>(value.size()),
+                        tmp.data(),
+                        size) != size)
+                {
+                    error = "UTF-8 conversion failed";
+                    return false;
+                }
+                out = std::move(tmp);
+                return true;
+            }
+
+            bool wideToUtf8(
+                const std::wstring& value,
+                std::string& out,
+                std::string& error)
+            {
+                if (value.empty())
+                {
+                    out.clear();
+                    return true;
+                }
+                if (value.size() > static_cast<size_t>((std::numeric_limits<int>::max)()))
+                {
+                    error = "UTF-16 text is too large";
+                    return false;
+                }
+                const int size = ::WideCharToMultiByte(
+                    CP_UTF8,
+                    WC_ERR_INVALID_CHARS,
+                    value.data(),
+                    static_cast<int>(value.size()),
+                    nullptr,
+                    0,
+                    nullptr,
+                    nullptr);
+                if (size <= 0)
+                {
+                    error = "Text contains invalid UTF-16";
+                    return false;
+                }
+                std::string tmp(static_cast<size_t>(size), '\0');
+                if (::WideCharToMultiByte(
+                        CP_UTF8,
+                        WC_ERR_INVALID_CHARS,
+                        value.data(),
+                        static_cast<int>(value.size()),
+                        tmp.data(),
+                        size,
+                        nullptr,
+                        nullptr) != size)
+                {
+                    error = "UTF-16 conversion failed";
+                    return false;
+                }
+                out = std::move(tmp);
+                return true;
+            }
+
+            std::string windowsError(const char* context, DWORD code)
+            {
+                LPWSTR text = nullptr;
+                const DWORD count = ::FormatMessageW(
+                    FORMAT_MESSAGE_ALLOCATE_BUFFER |
+                        FORMAT_MESSAGE_FROM_SYSTEM |
+                        FORMAT_MESSAGE_IGNORE_INSERTS,
+                    nullptr,
+                    code,
+                    0,
+                    reinterpret_cast<LPWSTR>(&text),
+                    0,
+                    nullptr);
+                std::wstring wide;
+                if (count && text)
+                {
+                    wide.assign(text, text + count);
+                    ::LocalFree(text);
+                    while (!wide.empty() &&
+                           (wide.back() == L'\r' ||
+                            wide.back() == L'\n' ||
+                            wide.back() == L' '))
+                    {
+                        wide.pop_back();
+                    }
+                }
+                std::string message;
+                std::string conversionError;
+                if (!wide.empty())
+                {
+                    wideToUtf8(wide, message, conversionError);
+                }
+                std::ostringstream stream;
+                stream << context << " failed with Windows error " << code;
+                if (!message.empty())
+                {
+                    stream << ": " << message;
+                }
+                return stream.str();
+            }
+
+            bool getTokenUserSid(
+                HANDLE token,
+                std::vector<uint8_t>& sid,
+                std::string& error)
+            {
+                DWORD size = 0;
+                ::GetTokenInformation(token, TokenUser, nullptr, 0, &size);
+                if (!size || ERROR_INSUFFICIENT_BUFFER != ::GetLastError())
+                {
+                    error = windowsError("GetTokenInformation(size)", ::GetLastError());
+                    return false;
+                }
+                std::vector<uint8_t> buffer(size);
+                if (!::GetTokenInformation(
+                        token,
+                        TokenUser,
+                        buffer.data(),
+                        size,
+                        &size))
+                {
+                    error = windowsError("GetTokenInformation", ::GetLastError());
+                    return false;
+                }
+                const auto tokenUser = reinterpret_cast<const TOKEN_USER*>(buffer.data());
+                if (!::IsValidSid(tokenUser->User.Sid))
+                {
+                    error = "The access token contains an invalid user SID";
+                    return false;
+                }
+                const DWORD sidBytes = ::GetLengthSid(tokenUser->User.Sid);
+                sid.resize(sidBytes);
+                if (!::CopySid(sidBytes, sid.data(), tokenUser->User.Sid))
+                {
+                    error = windowsError("CopySid", ::GetLastError());
+                    return false;
+                }
+                return true;
+            }
+
+            bool getTokenLogonSid(
+                HANDLE token,
+                std::vector<uint8_t>& sid,
+                std::string& error)
+            {
+                DWORD size = 0;
+                ::GetTokenInformation(token, TokenGroups, nullptr, 0, &size);
+                if (!size || ERROR_INSUFFICIENT_BUFFER != ::GetLastError())
+                {
+                    error = windowsError(
+                        "GetTokenInformation(groups size)", ::GetLastError());
+                    return false;
+                }
+                std::vector<uint8_t> buffer(size);
+                if (!::GetTokenInformation(
+                        token,
+                        TokenGroups,
+                        buffer.data(),
+                        size,
+                        &size))
+                {
+                    error = windowsError(
+                        "GetTokenInformation(groups)", ::GetLastError());
+                    return false;
+                }
+                const auto groups =
+                    reinterpret_cast<const TOKEN_GROUPS*>(buffer.data());
+                for (DWORD i = 0; i < groups->GroupCount; ++i)
+                {
+                    const auto& group = groups->Groups[i];
+                    if (SE_GROUP_LOGON_ID ==
+                        (group.Attributes & SE_GROUP_LOGON_ID))
+                    {
+                        if (!::IsValidSid(group.Sid))
+                        {
+                            error = "The access token contains an invalid logon SID";
+                            return false;
+                        }
+                        const DWORD sidBytes = ::GetLengthSid(group.Sid);
+                        sid.resize(sidBytes);
+                        if (!::CopySid(sidBytes, sid.data(), group.Sid))
+                        {
+                            error = windowsError("CopySid(logon)", ::GetLastError());
+                            return false;
+                        }
+                        return true;
+                    }
+                }
+                error = "The access token does not contain a logon SID";
+                return false;
+            }
+
+            bool getProcessUserSid(
+                HANDLE process,
+                std::vector<uint8_t>& sid,
+                std::string& error)
+            {
+                HANDLE rawToken = nullptr;
+                if (!::OpenProcessToken(process, TOKEN_QUERY, &rawToken))
+                {
+                    error = windowsError("OpenProcessToken", ::GetLastError());
+                    return false;
+                }
+                Handle token(rawToken);
+                return getTokenUserSid(token.get(), sid, error);
+            }
+
+            bool getProcessLogonSid(
+                HANDLE process,
+                std::vector<uint8_t>& sid,
+                std::string& error)
+            {
+                HANDLE rawToken = nullptr;
+                if (!::OpenProcessToken(process, TOKEN_QUERY, &rawToken))
+                {
+                    error = windowsError(
+                        "OpenProcessToken(logon)", ::GetLastError());
+                    return false;
+                }
+                Handle token(rawToken);
+                return getTokenLogonSid(token.get(), sid, error);
+            }
+
+            bool sidToString(
+                PSID sid,
+                std::wstring& out,
+                std::string& error)
+            {
+                LPWSTR raw = nullptr;
+                if (!::ConvertSidToStringSidW(sid, &raw))
+                {
+                    error = windowsError("ConvertSidToStringSidW", ::GetLastError());
+                    return false;
+                }
+                LocalMemory memory;
+                memory.value = raw;
+                out = raw;
+                return true;
+            }
+
+            uint64_t stableIdentityHash(
+                const std::string& applicationId,
+                const std::wstring& sid,
+                uint32_t sessionId)
+            {
+                uint64_t value = 14695981039346656037ULL;
+                const auto add = [&value](uint8_t byte)
+                {
+                    value ^= byte;
+                    value *= 1099511628211ULL;
+                };
+                for (const unsigned char byte : applicationId)
+                {
+                    add(byte);
+                }
+                add(0);
+                for (const wchar_t character : sid)
+                {
+                    add(static_cast<uint8_t>(character & 0xFF));
+                    add(static_cast<uint8_t>((character >> 8) & 0xFF));
+                }
+                add(0);
+                for (unsigned int i = 0; i < 4; ++i)
+                {
+                    add(static_cast<uint8_t>((sessionId >> (i * 8U)) & 0xFFU));
+                }
+                return value;
+            }
+
+            bool makeSecurityAttributes(
+                const std::wstring& sid,
+                SECURITY_ATTRIBUTES& attributes,
+                LocalMemory& storage,
+                std::string& error)
+            {
+                const std::wstring sddl = L"D:P(A;;GA;;;" + sid + L")";
+                PSECURITY_DESCRIPTOR descriptor = nullptr;
+                if (!::ConvertStringSecurityDescriptorToSecurityDescriptorW(
+                        sddl.c_str(),
+                        SDDL_REVISION_1,
+                        &descriptor,
+                        nullptr))
+                {
+                    error = windowsError(
+                        "ConvertStringSecurityDescriptorToSecurityDescriptorW",
+                        ::GetLastError());
+                    return false;
+                }
+                storage.value = descriptor;
+                attributes.nLength = sizeof(attributes);
+                attributes.lpSecurityDescriptor = descriptor;
+                attributes.bInheritHandle = FALSE;
+                return true;
+            }
+
+#if defined(DJV_WINDOWS_OPEN_BROKER_TESTING)
+            std::atomic<WindowsOpenBrokerRevertToSelfTestHook>
+                revertToSelfTestHook(nullptr);
+            std::atomic<WindowsOpenBrokerFailStopTestHook>
+                failStopTestHook(nullptr);
+#endif // DJV_WINDOWS_OPEN_BROKER_TESTING
+
+            bool brokerRevertToSelf()
+            {
+#if defined(DJV_WINDOWS_OPEN_BROKER_TESTING)
+                if (const auto hook = revertToSelfTestHook.load())
+                {
+                    return hook();
+                }
+#endif // DJV_WINDOWS_OPEN_BROKER_TESTING
+                return 0 != ::RevertToSelf();
+            }
+
+            [[noreturn]] void securityFailStop(const std::string& message)
+            {
+#if defined(DJV_WINDOWS_OPEN_BROKER_TESTING)
+                if (const auto hook = failStopTestHook.load())
+                {
+                    // Test hooks must throw. If one returns, the production
+                    // fail-stop path remains authoritative.
+                    hook(message);
+                }
+#else // DJV_WINDOWS_OPEN_BROKER_TESTING
+                (void)message;
+#endif // DJV_WINDOWS_OPEN_BROKER_TESTING
+                ::TerminateProcess(::GetCurrentProcess(), ERROR_ACCESS_DENIED);
+                std::abort();
+            }
+
+            bool isForbiddenDevicePath(const std::filesystem::path& path)
+            {
+                std::wstring value = path.native();
+                std::transform(
+                    value.begin(),
+                    value.end(),
+                    value.begin(),
+                    [](wchar_t character)
+                    {
+                        return static_cast<wchar_t>(::towlower(character));
+                    });
+                return
+                    0 == value.rfind(L"\\\\.\\", 0) ||
+                    0 == value.rfind(L"\\\\?\\globalroot\\", 0) ||
+                    0 == value.rfind(L"\\\\?\\pipe\\", 0) ||
+                    0 == value.rfind(L"\\??\\", 0);
+            }
+
+            struct ProtocolHeader
+            {
+                uint16_t version = 0;
+                uint16_t type = 0;
+                uint32_t payloadBytes = 0;
+                uint64_t requestId = 0;
+            };
+
+            std::vector<uint8_t> encodeHeader(const ProtocolHeader& header)
+            {
+                std::vector<uint8_t> out;
+                out.reserve(protocolHeaderBytes);
+                out.insert(
+                    out.end(),
+                    std::begin(protocolMagic),
+                    std::end(protocolMagic));
+                appendU16(out, header.version);
+                appendU16(out, header.type);
+                appendU32(out, header.payloadBytes);
+                appendU64(out, header.requestId);
+                return out;
+            }
+
+            bool decodeHeader(
+                const std::vector<uint8_t>& data,
+                ProtocolHeader& header,
+                std::string& error)
+            {
+                if (data.size() != protocolHeaderBytes)
+                {
+                    error = "Protocol header has the wrong size";
+                    return false;
+                }
+                if (0 != std::memcmp(data.data(), protocolMagic, sizeof(protocolMagic)))
+                {
+                    error = "Protocol magic does not match";
+                    return false;
+                }
+                size_t offset = sizeof(protocolMagic);
+                if (!readU16(data, offset, header.version) ||
+                    !readU16(data, offset, header.type) ||
+                    !readU32(data, offset, header.payloadBytes) ||
+                    !readU64(data, offset, header.requestId) ||
+                    offset != data.size())
+                {
+                    error = "Protocol header is truncated";
+                    return false;
+                }
+                return true;
+            }
+
+            bool encodeRequestPayload(
+                const std::vector<std::string>& paths,
+                const std::string& cwd,
+                std::vector<uint8_t>& out,
+                std::string& error)
+            {
+                if (paths.empty() || paths.size() > WindowsOpenBroker::maxPathCount)
+                {
+                    error = "An open request must contain 1-128 paths";
+                    return false;
+                }
+                if (cwd.size() > WindowsOpenBroker::maxPathBytes)
+                {
+                    error = "The working directory exceeds the protocol limit";
+                    return false;
+                }
+                out.clear();
+                out.reserve(8 + cwd.size() + paths.size() * 8);
+                appendU32(out, static_cast<uint32_t>(cwd.size()));
+                appendU32(out, static_cast<uint32_t>(paths.size()));
+                out.insert(out.end(), cwd.begin(), cwd.end());
+                for (const auto& path : paths)
+                {
+                    if (path.empty() || path.size() > WindowsOpenBroker::maxPathBytes)
+                    {
+                        error = "A path is empty or exceeds the protocol limit";
+                        return false;
+                    }
+                    if (out.size() > WindowsOpenBroker::maxPayloadBytes - 4 - path.size())
+                    {
+                        error = "The open request exceeds the protocol payload limit";
+                        return false;
+                    }
+                    appendU32(out, static_cast<uint32_t>(path.size()));
+                    out.insert(out.end(), path.begin(), path.end());
+                }
+                if (out.size() > WindowsOpenBroker::maxPayloadBytes)
+                {
+                    error = "The open request exceeds the protocol payload limit";
+                    return false;
+                }
+                return true;
+            }
+
+            bool decodeRequestPayload(
+                const std::vector<uint8_t>& payload,
+                std::vector<std::string>& paths,
+                std::string& cwd,
+                std::string& error)
+            {
+                size_t offset = 0;
+                uint32_t cwdBytes = 0;
+                uint32_t pathCount = 0;
+                if (!readU32(payload, offset, cwdBytes) ||
+                    !readU32(payload, offset, pathCount))
+                {
+                    error = "The request payload is truncated";
+                    return false;
+                }
+                if (cwdBytes > WindowsOpenBroker::maxPathBytes ||
+                    pathCount == 0 ||
+                    pathCount > WindowsOpenBroker::maxPathCount)
+                {
+                    error = "The request declares an invalid path count or working directory";
+                    return false;
+                }
+                if (offset > payload.size() || payload.size() - offset < cwdBytes)
+                {
+                    error = "The working directory is truncated";
+                    return false;
+                }
+                cwd.assign(
+                    reinterpret_cast<const char*>(payload.data() + offset),
+                    cwdBytes);
+                offset += cwdBytes;
+
+                std::vector<std::string> decoded;
+                decoded.reserve(pathCount);
+                for (uint32_t i = 0; i < pathCount; ++i)
+                {
+                    uint32_t pathBytes = 0;
+                    if (!readU32(payload, offset, pathBytes) ||
+                        pathBytes == 0 ||
+                        pathBytes > WindowsOpenBroker::maxPathBytes ||
+                        offset > payload.size() ||
+                        payload.size() - offset < pathBytes)
+                    {
+                        error = "A request path is empty, oversized, or truncated";
+                        return false;
+                    }
+                    decoded.emplace_back(
+                        reinterpret_cast<const char*>(payload.data() + offset),
+                        pathBytes);
+                    offset += pathBytes;
+                }
+                if (offset != payload.size())
+                {
+                    error = "The request payload contains trailing bytes";
+                    return false;
+                }
+                paths = std::move(decoded);
+                return true;
+            }
+
+            std::vector<uint8_t> encodeResponsePayload(
+                ResponseCode code,
+                std::string message)
+            {
+                std::wstring validation;
+                std::string validationError;
+                if (!utf8ToWide(message, validation, validationError))
+                {
+                    message = "The server produced a non-UTF-8 response";
+                }
+                if (message.size() > WindowsOpenBroker::maxResponseMessageBytes)
+                {
+                    message = "The server response exceeded the message limit";
+                }
+                std::vector<uint8_t> out;
+                out.reserve(8 + message.size());
+                appendU32(out, static_cast<uint32_t>(code));
+                appendU32(out, static_cast<uint32_t>(message.size()));
+                out.insert(out.end(), message.begin(), message.end());
+                return out;
+            }
+
+            bool decodeResponsePayload(
+                const std::vector<uint8_t>& payload,
+                ResponseCode& code,
+                std::string& message,
+                std::string& error)
+            {
+                size_t offset = 0;
+                uint32_t rawCode = 0;
+                uint32_t messageBytes = 0;
+                if (!readU32(payload, offset, rawCode) ||
+                    !readU32(payload, offset, messageBytes) ||
+                    messageBytes > WindowsOpenBroker::maxResponseMessageBytes ||
+                    offset > payload.size() ||
+                    payload.size() - offset != messageBytes)
+                {
+                    error = "The response payload is malformed";
+                    return false;
+                }
+                if (rawCode > static_cast<uint32_t>(ResponseCode::PayloadTooLarge))
+                {
+                    error = "The response contains an unknown status code";
+                    return false;
+                }
+                message.assign(
+                    reinterpret_cast<const char*>(payload.data() + offset),
+                    messageBytes);
+                std::wstring validation;
+                if (!utf8ToWide(message, validation, error))
+                {
+                    error = "The response message is not valid UTF-8";
+                    return false;
+                }
+                code = static_cast<ResponseCode>(rawCode);
+                return true;
+            }
+
+            enum class IOStatus
+            {
+                Complete,
+                Stopped,
+                Timeout,
+                Disconnected,
+                Error
+            };
+
+            DWORD remainingMilliseconds(
+                const std::chrono::steady_clock::time_point& deadline)
+            {
+                const auto now = std::chrono::steady_clock::now();
+                if (now >= deadline)
+                {
+                    return 0;
+                }
+                const auto remaining = std::chrono::duration_cast<std::chrono::milliseconds>(
+                    deadline - now);
+                const auto value = (std::max)(int64_t(1), remaining.count());
+                return static_cast<DWORD>((std::min)(
+                    value,
+                    static_cast<int64_t>((std::numeric_limits<DWORD>::max)() - 1)));
+            }
+
+            IOStatus transferOnce(
+                HANDLE pipe,
+                bool write,
+                uint8_t* data,
+                DWORD requested,
+                DWORD& transferred,
+                HANDLE stopEvent,
+                const std::chrono::steady_clock::time_point& deadline,
+                std::string& error)
+            {
+                Handle event(::CreateEventW(nullptr, TRUE, FALSE, nullptr));
+                if (!event)
+                {
+                    error = windowsError("CreateEventW", ::GetLastError());
+                    return IOStatus::Error;
+                }
+                OVERLAPPED overlapped = {};
+                overlapped.hEvent = event.get();
+                transferred = 0;
+                const BOOL immediate = write ?
+                    ::WriteFile(pipe, data, requested, &transferred, &overlapped) :
+                    ::ReadFile(pipe, data, requested, &transferred, &overlapped);
+                if (immediate)
+                {
+                    return transferred ? IOStatus::Complete : IOStatus::Disconnected;
+                }
+
+                const DWORD operationError = ::GetLastError();
+                if (ERROR_BROKEN_PIPE == operationError ||
+                    ERROR_PIPE_NOT_CONNECTED == operationError ||
+                    ERROR_NO_DATA == operationError)
+                {
+                    return IOStatus::Disconnected;
+                }
+                if (ERROR_IO_PENDING != operationError)
+                {
+                    error = windowsError(write ? "WriteFile" : "ReadFile", operationError);
+                    return IOStatus::Error;
+                }
+
+                const DWORD timeout = remainingMilliseconds(deadline);
+                if (!timeout)
+                {
+                    ::CancelIoEx(pipe, &overlapped);
+                    if (::GetOverlappedResult(
+                            pipe, &overlapped, &transferred, TRUE) &&
+                        transferred)
+                    {
+                        // Completion won the cancellation race. Reporting a
+                        // timeout here could make a caller retry a delivered
+                        // request.
+                        return IOStatus::Complete;
+                    }
+                    return IOStatus::Timeout;
+                }
+                HANDLE waitHandles[2] = { event.get(), nullptr };
+                DWORD handleCount = 1;
+                if (stopEvent)
+                {
+                    waitHandles[0] = stopEvent;
+                    waitHandles[1] = event.get();
+                    handleCount = 2;
+                }
+                const DWORD waitResult = ::WaitForMultipleObjects(
+                    handleCount,
+                    waitHandles,
+                    FALSE,
+                    timeout);
+                if ((stopEvent && WAIT_OBJECT_0 == waitResult) ||
+                    WAIT_TIMEOUT == waitResult)
+                {
+                    const bool stopped = stopEvent && WAIT_OBJECT_0 == waitResult;
+                    ::CancelIoEx(pipe, &overlapped);
+                    const BOOL completed = ::GetOverlappedResult(
+                        pipe, &overlapped, &transferred, TRUE);
+                    if (!stopped && completed && transferred)
+                    {
+                        return IOStatus::Complete;
+                    }
+                    return stopped ? IOStatus::Stopped : IOStatus::Timeout;
+                }
+                const DWORD eventIndex = stopEvent ? WAIT_OBJECT_0 + 1 : WAIT_OBJECT_0;
+                if (eventIndex != waitResult)
+                {
+                    ::CancelIoEx(pipe, &overlapped);
+                    ::GetOverlappedResult(pipe, &overlapped, &transferred, TRUE);
+                    error = windowsError("WaitForMultipleObjects", ::GetLastError());
+                    return IOStatus::Error;
+                }
+                if (!::GetOverlappedResult(pipe, &overlapped, &transferred, FALSE))
+                {
+                    const DWORD resultError = ::GetLastError();
+                    if (ERROR_OPERATION_ABORTED == resultError && stopEvent &&
+                        WAIT_OBJECT_0 == ::WaitForSingleObject(stopEvent, 0))
+                    {
+                        return IOStatus::Stopped;
+                    }
+                    if (ERROR_BROKEN_PIPE == resultError ||
+                        ERROR_PIPE_NOT_CONNECTED == resultError ||
+                        ERROR_NO_DATA == resultError)
+                    {
+                        return IOStatus::Disconnected;
+                    }
+                    error = windowsError("GetOverlappedResult", resultError);
+                    return IOStatus::Error;
+                }
+                return transferred ? IOStatus::Complete : IOStatus::Disconnected;
+            }
+
+            IOStatus transferExact(
+                HANDLE pipe,
+                bool write,
+                uint8_t* data,
+                size_t size,
+                HANDLE stopEvent,
+                std::chrono::milliseconds timeout,
+                std::string& error)
+            {
+                const auto deadline = std::chrono::steady_clock::now() + timeout;
+                size_t offset = 0;
+                while (offset < size)
+                {
+                    if (std::chrono::steady_clock::now() >= deadline)
+                    {
+                        return IOStatus::Timeout;
+                    }
+                    const DWORD requested = static_cast<DWORD>((std::min)(
+                        size - offset,
+                        static_cast<size_t>(64U * 1024U)));
+                    DWORD transferred = 0;
+                    const IOStatus status = transferOnce(
+                        pipe,
+                        write,
+                        data + offset,
+                        requested,
+                        transferred,
+                        stopEvent,
+                        deadline,
+                        error);
+                    if (IOStatus::Complete != status)
+                    {
+                        return status;
+                    }
+                    offset += transferred;
+                }
+                return IOStatus::Complete;
+            }
+
+            IOStatus writeBytes(
+                HANDLE pipe,
+                const std::vector<uint8_t>& data,
+                HANDLE stopEvent,
+                std::chrono::milliseconds timeout,
+                std::string& error)
+            {
+                if (data.empty())
+                {
+                    return IOStatus::Complete;
+                }
+                return transferExact(
+                    pipe,
+                    true,
+                    const_cast<uint8_t*>(data.data()),
+                    data.size(),
+                    stopEvent,
+                    timeout,
+                    error);
+            }
+
+            IOStatus readBytes(
+                HANDLE pipe,
+                std::vector<uint8_t>& data,
+                HANDLE stopEvent,
+                std::chrono::milliseconds timeout,
+                std::string& error)
+            {
+                if (data.empty())
+                {
+                    return IOStatus::Complete;
+                }
+                return transferExact(
+                    pipe,
+                    false,
+                    data.data(),
+                    data.size(),
+                    stopEvent,
+                    timeout,
+                    error);
+            }
+
+            bool writeResponse(
+                HANDLE pipe,
+                uint64_t requestId,
+                ResponseCode code,
+                const std::string& message,
+                HANDLE stopEvent,
+                std::chrono::milliseconds timeout,
+                std::string& error)
+            {
+                const auto payload = encodeResponsePayload(code, message);
+                const auto header = encodeHeader({
+                    WindowsOpenBroker::protocolVersion,
+                    responseMessageType,
+                    static_cast<uint32_t>(payload.size()),
+                    requestId });
+                if (IOStatus::Complete != writeBytes(
+                        pipe, header, stopEvent, timeout, error))
+                {
+                    return false;
+                }
+                if (IOStatus::Complete != writeBytes(
+                        pipe, payload, stopEvent, timeout, error))
+                {
+                    return false;
+                }
+
+                // DisconnectNamedPipe discards unread server output. The
+                // bounded receipt proves that the client consumed the complete
+                // response before this pipe instance is disconnected/reused.
+                std::vector<uint8_t> receipt(1);
+                if (IOStatus::Complete != readBytes(
+                        pipe, receipt, stopEvent, timeout, error))
+                {
+                    return false;
+                }
+                if (responseReceipt != receipt.front())
+                {
+                    error = "The client response receipt is invalid";
+                    return false;
+                }
+                return true;
+            }
+
+            bool getCurrentSessionId(uint32_t& sessionId, std::string& error)
+            {
+                DWORD value = 0;
+                if (!::ProcessIdToSessionId(::GetCurrentProcessId(), &value))
+                {
+                    error = windowsError("ProcessIdToSessionId", ::GetLastError());
+                    return false;
+                }
+                sessionId = value;
+                return true;
+            }
+
+            bool verifyClientIdentity(
+                HANDLE pipe,
+                uint32_t expectedSessionId,
+                std::string& error)
+            {
+                using GetClientSessionId = BOOL(WINAPI*)(HANDLE, PULONG);
+                const HMODULE kernel = ::GetModuleHandleW(L"kernel32.dll");
+                if (!kernel)
+                {
+                    error = windowsError("GetModuleHandleW(kernel32)", ::GetLastError());
+                    return false;
+                }
+                const auto getClientSessionId = reinterpret_cast<GetClientSessionId>(
+                    ::GetProcAddress(
+                        kernel,
+                        "GetNamedPipeClientSessionId"));
+                if (!getClientSessionId)
+                {
+                    error = "GetNamedPipeClientSessionId is unavailable";
+                    return false;
+                }
+                ULONG clientSessionId = 0;
+                if (!getClientSessionId(pipe, &clientSessionId) ||
+                    clientSessionId != expectedSessionId)
+                {
+                    error = "The named-pipe client belongs to a different logon session";
+                    return false;
+                }
+
+                if (!::ImpersonateNamedPipeClient(pipe))
+                {
+                    error = windowsError("ImpersonateNamedPipeClient", ::GetLastError());
+                    return false;
+                }
+                HANDLE rawClientToken = nullptr;
+                const BOOL opened = ::OpenThreadToken(
+                    ::GetCurrentThread(),
+                    TOKEN_QUERY,
+                    TRUE,
+                    &rawClientToken);
+                const DWORD tokenError = opened ? ERROR_SUCCESS : ::GetLastError();
+                const bool reverted = brokerRevertToSelf();
+                const DWORD revertError = reverted ? ERROR_SUCCESS : ::GetLastError();
+                Handle clientToken(rawClientToken);
+                if (!reverted)
+                {
+                    error = windowsError("RevertToSelf", revertError);
+                    // Microsoft requires process shutdown here: continuing may
+                    // execute later requests under the client's token.
+                    securityFailStop(error);
+                }
+                if (!opened)
+                {
+                    error = windowsError("OpenThreadToken", tokenError);
+                    return false;
+                }
+                std::vector<uint8_t> clientSid;
+                std::vector<uint8_t> currentSid;
+                std::vector<uint8_t> clientLogonSid;
+                std::vector<uint8_t> currentLogonSid;
+                if (!getTokenUserSid(clientToken.get(), clientSid, error) ||
+                    !getProcessUserSid(::GetCurrentProcess(), currentSid, error) ||
+                    !getTokenLogonSid(clientToken.get(), clientLogonSid, error) ||
+                    !getProcessLogonSid(
+                        ::GetCurrentProcess(), currentLogonSid, error))
+                {
+                    return false;
+                }
+                if (!::EqualSid(clientSid.data(), currentSid.data()))
+                {
+                    error = "The named-pipe client belongs to a different user";
+                    return false;
+                }
+                if (!::EqualSid(clientLogonSid.data(), currentLogonSid.data()))
+                {
+                    error = "The named-pipe client belongs to a different logon";
+                    return false;
+                }
+                return true;
+            }
+
+            bool verifyServerIdentity(
+                HANDLE pipe,
+                uint32_t expectedSessionId,
+                std::string& error)
+            {
+                using GetServerProcessId = BOOL(WINAPI*)(HANDLE, PULONG);
+                using GetServerSessionId = BOOL(WINAPI*)(HANDLE, PULONG);
+                const HMODULE kernel = ::GetModuleHandleW(L"kernel32.dll");
+                if (!kernel)
+                {
+                    error = windowsError("GetModuleHandleW(kernel32)", ::GetLastError());
+                    return false;
+                }
+                const auto getServerProcessId = reinterpret_cast<GetServerProcessId>(
+                    ::GetProcAddress(kernel, "GetNamedPipeServerProcessId"));
+                const auto getServerSessionId = reinterpret_cast<GetServerSessionId>(
+                    ::GetProcAddress(kernel, "GetNamedPipeServerSessionId"));
+                if (!getServerProcessId || !getServerSessionId)
+                {
+                    error = "Named-pipe server identity APIs are unavailable";
+                    return false;
+                }
+                ULONG serverPid = 0;
+                ULONG serverSessionId = 0;
+                if (!getServerProcessId(pipe, &serverPid) || !serverPid ||
+                    !getServerSessionId(pipe, &serverSessionId) ||
+                    serverSessionId != expectedSessionId)
+                {
+                    error = "The named-pipe server has an unexpected process or session identity";
+                    return false;
+                }
+                Handle process(::OpenProcess(
+                    PROCESS_QUERY_LIMITED_INFORMATION,
+                    FALSE,
+                    serverPid));
+                if (!process)
+                {
+                    error = windowsError("OpenProcess(server)", ::GetLastError());
+                    return false;
+                }
+                std::vector<uint8_t> serverSid;
+                std::vector<uint8_t> currentSid;
+                std::vector<uint8_t> serverLogonSid;
+                std::vector<uint8_t> currentLogonSid;
+                if (!getProcessUserSid(process.get(), serverSid, error) ||
+                    !getProcessUserSid(::GetCurrentProcess(), currentSid, error) ||
+                    !getProcessLogonSid(process.get(), serverLogonSid, error) ||
+                    !getProcessLogonSid(
+                        ::GetCurrentProcess(), currentLogonSid, error))
+                {
+                    return false;
+                }
+                if (!::EqualSid(serverSid.data(), currentSid.data()))
+                {
+                    error = "The named-pipe server belongs to a different user";
+                    return false;
+                }
+                if (!::EqualSid(serverLogonSid.data(), currentLogonSid.data()))
+                {
+                    error = "The named-pipe server belongs to a different logon";
+                    return false;
+                }
+                return true;
+            }
+
+            enum class ConnectStatus
+            {
+                Connected,
+                Stopped,
+                Error
+            };
+
+            ConnectStatus connectServerPipe(
+                HANDLE pipe,
+                HANDLE stopEvent,
+                std::string& error)
+            {
+                Handle event(::CreateEventW(nullptr, TRUE, FALSE, nullptr));
+                if (!event)
+                {
+                    error = windowsError("CreateEventW(connect)", ::GetLastError());
+                    return ConnectStatus::Error;
+                }
+                OVERLAPPED overlapped = {};
+                overlapped.hEvent = event.get();
+                if (::ConnectNamedPipe(pipe, &overlapped))
+                {
+                    return ConnectStatus::Connected;
+                }
+                const DWORD connectError = ::GetLastError();
+                if (ERROR_PIPE_CONNECTED == connectError)
+                {
+                    return ConnectStatus::Connected;
+                }
+                if (ERROR_IO_PENDING != connectError)
+                {
+                    error = windowsError("ConnectNamedPipe", connectError);
+                    return ConnectStatus::Error;
+                }
+                HANDLE handles[2] = { stopEvent, event.get() };
+                const DWORD waitResult = ::WaitForMultipleObjects(2, handles, FALSE, INFINITE);
+                if (WAIT_OBJECT_0 == waitResult)
+                {
+                    ::CancelIoEx(pipe, &overlapped);
+                    DWORD ignored = 0;
+                    ::GetOverlappedResult(pipe, &overlapped, &ignored, TRUE);
+                    return ConnectStatus::Stopped;
+                }
+                if (WAIT_OBJECT_0 + 1 != waitResult)
+                {
+                    ::CancelIoEx(pipe, &overlapped);
+                    DWORD ignored = 0;
+                    ::GetOverlappedResult(pipe, &overlapped, &ignored, TRUE);
+                    error = windowsError("WaitForMultipleObjects(connect)", ::GetLastError());
+                    return ConnectStatus::Error;
+                }
+                DWORD ignored = 0;
+                if (!::GetOverlappedResult(pipe, &overlapped, &ignored, FALSE))
+                {
+                    const DWORD resultError = ::GetLastError();
+                    if (ERROR_OPERATION_ABORTED == resultError &&
+                        WAIT_OBJECT_0 == ::WaitForSingleObject(stopEvent, 0))
+                    {
+                        return ConnectStatus::Stopped;
+                    }
+                    error = windowsError("GetOverlappedResult(connect)", resultError);
+                    return ConnectStatus::Error;
+                }
+                return ConnectStatus::Connected;
+            }
+#endif // _WIN32
+        }
+
+        class WindowsOpenBroker::Private
+        {
+        public:
+            explicit Private(const WindowsOpenBrokerOptions& value) :
+                options(value)
+            {}
+
+            void setLastError(const std::string& value)
+            {
+                std::lock_guard<std::mutex> lock(errorMutex);
+                lastError = value;
+            }
+
+            std::string getLastError() const
+            {
+                std::lock_guard<std::mutex> lock(errorMutex);
+                return lastError;
+            }
+
+#if defined(_WIN32)
+            void handleClient(HANDLE pipe)
+            {
+                uint64_t requestId = 0;
+                std::string error;
+                if (!verifyClientIdentity(pipe, identity.sessionId, error))
+                {
+                    setLastError(error);
+                    writeResponse(
+                        pipe,
+                        requestId,
+                        ResponseCode::Unauthorized,
+                        "The client identity was rejected",
+                        stopEvent.get(),
+                        options.ioTimeout,
+                        error);
+                    return;
+                }
+
+                std::vector<uint8_t> rawHeader(protocolHeaderBytes);
+                const IOStatus headerStatus = readBytes(
+                    pipe,
+                    rawHeader,
+                    stopEvent.get(),
+                    options.ioTimeout,
+                    error);
+                if (IOStatus::Complete != headerStatus)
+                {
+                    if (IOStatus::Stopped != headerStatus &&
+                        IOStatus::Disconnected != headerStatus)
+                    {
+                        setLastError(error.empty() ? "Request header read timed out" : error);
+                    }
+                    return;
+                }
+
+                ProtocolHeader header;
+                if (!decodeHeader(rawHeader, header, error))
+                {
+                    setLastError(error);
+                    writeResponse(
+                        pipe,
+                        requestId,
+                        ResponseCode::ProtocolError,
+                        error,
+                        stopEvent.get(),
+                        options.ioTimeout,
+                        error);
+                    return;
+                }
+                requestId = header.requestId;
+                if (WindowsOpenBroker::protocolVersion != header.version ||
+                    requestMessageType != header.type)
+                {
+                    error = "Unsupported protocol version or message type";
+                    setLastError(error);
+                    writeResponse(
+                        pipe,
+                        requestId,
+                        ResponseCode::ProtocolError,
+                        error,
+                        stopEvent.get(),
+                        options.ioTimeout,
+                        error);
+                    return;
+                }
+                if (header.payloadBytes > WindowsOpenBroker::maxPayloadBytes)
+                {
+                    error = "Request payload exceeds the protocol limit";
+                    setLastError(error);
+                    writeResponse(
+                        pipe,
+                        requestId,
+                        ResponseCode::PayloadTooLarge,
+                        error,
+                        stopEvent.get(),
+                        options.ioTimeout,
+                        error);
+                    return;
+                }
+
+                std::vector<uint8_t> payload(header.payloadBytes);
+                const IOStatus payloadStatus = readBytes(
+                    pipe,
+                    payload,
+                    stopEvent.get(),
+                    options.ioTimeout,
+                    error);
+                if (IOStatus::Complete != payloadStatus)
+                {
+                    if (IOStatus::Stopped != payloadStatus &&
+                        IOStatus::Disconnected != payloadStatus)
+                    {
+                        setLastError(error.empty() ? "Request payload read timed out" : error);
+                    }
+                    return;
+                }
+
+                std::vector<std::string> rawPaths;
+                std::string cwd;
+                if (!decodeRequestPayload(payload, rawPaths, cwd, error))
+                {
+                    setLastError(error);
+                    writeResponse(
+                        pipe,
+                        requestId,
+                        ResponseCode::InvalidRequest,
+                        error,
+                        stopEvent.get(),
+                        options.ioTimeout,
+                        error);
+                    return;
+                }
+                std::vector<std::string> paths;
+                if (!WindowsOpenBroker::normalizePaths(
+                        rawPaths, cwd, paths, error))
+                {
+                    setLastError(error);
+                    writeResponse(
+                        pipe,
+                        requestId,
+                        ResponseCode::InvalidRequest,
+                        error,
+                        stopEvent.get(),
+                        options.ioTimeout,
+                        error);
+                    return;
+                }
+                if (stopping.load())
+                {
+                    writeResponse(
+                        pipe,
+                        requestId,
+                        ResponseCode::ServerStopping,
+                        "The server is stopping",
+                        stopEvent.get(),
+                        options.ioTimeout,
+                        error);
+                    return;
+                }
+
+                std::string callbackMessage;
+                bool accepted = false;
+                try
+                {
+                    accepted = callback(paths, callbackMessage);
+                }
+                catch (const std::exception& exception)
+                {
+                    setLastError(std::string("Open callback exception: ") + exception.what());
+                    writeResponse(
+                        pipe,
+                        requestId,
+                        ResponseCode::InternalError,
+                        "The server callback failed",
+                        stopEvent.get(),
+                        options.ioTimeout,
+                        error);
+                    return;
+                }
+                catch (...)
+                {
+                    setLastError("Open callback threw an unknown exception");
+                    writeResponse(
+                        pipe,
+                        requestId,
+                        ResponseCode::InternalError,
+                        "The server callback failed",
+                        stopEvent.get(),
+                        options.ioTimeout,
+                        error);
+                    return;
+                }
+                const ResponseCode responseCode = accepted ?
+                    ResponseCode::Accepted :
+                    ResponseCode::CallbackRejected;
+                if (!accepted && callbackMessage.empty())
+                {
+                    callbackMessage = "The open request was rejected";
+                }
+                if (!writeResponse(
+                        pipe,
+                        requestId,
+                        responseCode,
+                        callbackMessage,
+                        stopEvent.get(),
+                        options.ioTimeout,
+                        error) &&
+                    !stopping.load())
+                {
+                    setLastError(error.empty() ? "Writing the response failed" : error);
+                }
+            }
+
+            void run()
+            {
+                SECURITY_ATTRIBUTES attributes = {};
+                LocalMemory descriptor;
+                std::string error;
+                if (!makeSecurityAttributes(
+                        identity.logonSid,
+                        attributes,
+                        descriptor,
+                        error))
+                {
+                    setLastError(error);
+                    serverStarted = false;
+                    ::SetEvent(readyEvent.get());
+                    return;
+                }
+                constexpr DWORD rejectRemoteClients = 0x00000008UL;
+                Handle pipe(::CreateNamedPipeW(
+                    identity.pipeName.c_str(),
+                    PIPE_ACCESS_DUPLEX |
+                        FILE_FLAG_OVERLAPPED |
+                        FILE_FLAG_FIRST_PIPE_INSTANCE,
+                    PIPE_TYPE_BYTE |
+                        PIPE_READMODE_BYTE |
+                        PIPE_WAIT |
+                        rejectRemoteClients,
+                    1,
+                    64U * 1024U,
+                    64U * 1024U,
+                    0,
+                    &attributes));
+                if (!pipe || INVALID_HANDLE_VALUE == pipe.get())
+                {
+                    setLastError(windowsError("CreateNamedPipeW", ::GetLastError()));
+                    serverStarted = false;
+                    ::SetEvent(readyEvent.get());
+                    return;
+                }
+                {
+                    std::lock_guard<std::mutex> lock(pipeMutex);
+                    activePipe = pipe.get();
+                }
+                serverStarted = true;
+                running = true;
+                ::SetEvent(readyEvent.get());
+
+                while (!stopping.load())
+                {
+                    error.clear();
+                    const ConnectStatus status = connectServerPipe(
+                        pipe.get(), stopEvent.get(), error);
+                    if (ConnectStatus::Stopped == status)
+                    {
+                        break;
+                    }
+                    if (ConnectStatus::Error == status)
+                    {
+                        if (!stopping.load())
+                        {
+                            setLastError(error);
+                        }
+                        break;
+                    }
+                    if (!stopping.load())
+                    {
+                        handleClient(pipe.get());
+                    }
+                    if (!::DisconnectNamedPipe(pipe.get()))
+                    {
+                        const DWORD disconnectError = ::GetLastError();
+                        if (ERROR_PIPE_NOT_CONNECTED != disconnectError && !stopping.load())
+                        {
+                            setLastError(windowsError(
+                                "DisconnectNamedPipe", disconnectError));
+                        }
+                    }
+                }
+                {
+                    std::lock_guard<std::mutex> lock(pipeMutex);
+                    activePipe = nullptr;
+                }
+                running = false;
+            }
+
+            Handle stopEvent;
+            Handle readyEvent;
+            Handle exitEvent;
+            Handle primaryMutex;
+            std::thread worker;
+            std::mutex lifecycleMutex;
+            std::condition_variable lifecycleCV;
+            std::thread::id workerThreadId;
+            bool workerDetached = false;
+            bool joinInProgress = false;
+            bool cleanupComplete = true;
+            std::mutex pipeMutex;
+            HANDLE activePipe = nullptr;
+            std::atomic<bool> running = false;
+            std::atomic<bool> stopping = false;
+            std::atomic<bool> serverStarted = false;
+#else // _WIN32
+            bool running = false;
+#endif // _WIN32
+
+            WindowsOpenBrokerOptions options;
+            WindowsOpenBrokerIdentity identity;
+            Callback callback;
+            mutable std::mutex errorMutex;
+            std::string lastError;
+        };
+
+        WindowsOpenBroker::WindowsOpenBroker(
+            const WindowsOpenBrokerOptions& options) :
+            _p(std::make_shared<Private>(options))
+        {
+            std::string error;
+            resolveIdentity(options, _p->identity, error);
+            if (!error.empty())
+            {
+                _p->setLastError(error);
+            }
+        }
+
+        WindowsOpenBroker::~WindowsOpenBroker()
+        {
+            stop();
+        }
+
+        WindowsOpenBrokerStartResult WindowsOpenBroker::start(Callback callback)
+        {
+            WindowsOpenBrokerStartResult out;
+            std::string error;
+            if (!validateOptions(_p->options, error) || !callback)
+            {
+                out.status = WindowsOpenBrokerStartStatus::InvalidOptions;
+                out.error = error.empty() ? "The broker callback is empty" : error;
+                return out;
+            }
+#if defined(_WIN32)
+            std::unique_lock<std::mutex> lifecycleLock(_p->lifecycleMutex);
+            if (_p->workerDetached)
+            {
+                if (!_p->exitEvent ||
+                    WAIT_OBJECT_0 != ::WaitForSingleObject(_p->exitEvent.get(), 0))
+                {
+                    out.status = WindowsOpenBrokerStartStatus::AlreadyRunning;
+                    out.error = "The detached broker worker is still stopping";
+                    return out;
+                }
+                lifecycleLock.unlock();
+                stop();
+                lifecycleLock.lock();
+            }
+            if (_p->worker.joinable() || _p->running.load() ||
+                _p->joinInProgress || !_p->cleanupComplete)
+            {
+                out.status = WindowsOpenBrokerStartStatus::AlreadyRunning;
+                out.error = "This broker object is already running";
+                return out;
+            }
+            if (!resolveIdentity(_p->options, _p->identity, error))
+            {
+                out.status = WindowsOpenBrokerStartStatus::SecurityError;
+                out.error = error;
+                _p->setLastError(error);
+                return out;
+            }
+            SECURITY_ATTRIBUTES attributes = {};
+            LocalMemory descriptor;
+            if (!makeSecurityAttributes(
+                    _p->identity.logonSid,
+                    attributes,
+                    descriptor,
+                    error))
+            {
+                out.status = WindowsOpenBrokerStartStatus::SecurityError;
+                out.error = error;
+                _p->setLastError(error);
+                return out;
+            }
+            _p->stopEvent.reset(::CreateEventW(nullptr, TRUE, FALSE, nullptr));
+            _p->readyEvent.reset(::CreateEventW(nullptr, TRUE, FALSE, nullptr));
+            _p->exitEvent.reset(::CreateEventW(nullptr, TRUE, FALSE, nullptr));
+            if (!_p->stopEvent || !_p->readyEvent || !_p->exitEvent)
+            {
+                out.status = WindowsOpenBrokerStartStatus::IOError;
+                out.error = windowsError("CreateEventW(start)", ::GetLastError());
+                _p->setLastError(out.error);
+                _p->stopEvent.reset();
+                _p->readyEvent.reset();
+                _p->exitEvent.reset();
+                return out;
+            }
+            const HANDLE rawMutex = ::CreateMutexW(
+                &attributes,
+                FALSE,
+                _p->identity.mutexName.c_str());
+            if (!rawMutex)
+            {
+                const DWORD mutexError = ::GetLastError();
+                out.status = ERROR_ACCESS_DENIED == mutexError ?
+                    WindowsOpenBrokerStartStatus::SecurityError :
+                    WindowsOpenBrokerStartStatus::IOError;
+                out.error = windowsError("CreateMutexW", mutexError);
+                _p->setLastError(out.error);
+                _p->stopEvent.reset();
+                _p->readyEvent.reset();
+                _p->exitEvent.reset();
+                return out;
+            }
+            _p->primaryMutex.reset(rawMutex);
+            if (ERROR_ALREADY_EXISTS == ::GetLastError())
+            {
+                _p->primaryMutex.reset();
+                _p->stopEvent.reset();
+                _p->readyEvent.reset();
+                _p->exitEvent.reset();
+                out.status = WindowsOpenBrokerStartStatus::AlreadyRunning;
+                out.error = "Another broker already owns the per-logon primary slot";
+                return out;
+            }
+            _p->callback = std::move(callback);
+            _p->stopping = false;
+            _p->serverStarted = false;
+            _p->workerDetached = false;
+            _p->joinInProgress = false;
+            _p->cleanupComplete = false;
+            try
+            {
+                const auto state = _p;
+                _p->worker = std::thread(
+                    [state]
+                    {
+                        try
+                        {
+                            state->run();
+                        }
+                        catch (const std::exception& exception)
+                        {
+                            state->setLastError(
+                                std::string("Broker worker exception: ") +
+                                exception.what());
+                        }
+                        catch (...)
+                        {
+                            state->setLastError(
+                                "Broker worker threw an unknown exception");
+                        }
+                        {
+                            std::lock_guard<std::mutex> lock(state->pipeMutex);
+                            state->activePipe = nullptr;
+                        }
+                        state->running = false;
+                        state->serverStarted = false;
+                        if (state->readyEvent)
+                        {
+                            ::SetEvent(state->readyEvent.get());
+                        }
+                        if (state->exitEvent)
+                        {
+                            ::SetEvent(state->exitEvent.get());
+                        }
+                    });
+                _p->workerThreadId = _p->worker.get_id();
+            }
+            catch (const std::exception& exception)
+            {
+                out.status = WindowsOpenBrokerStartStatus::IOError;
+                out.error = std::string("Starting the broker thread failed: ") +
+                    exception.what();
+                _p->setLastError(out.error);
+                _p->primaryMutex.reset();
+                _p->stopEvent.reset();
+                _p->readyEvent.reset();
+                _p->exitEvent.reset();
+                _p->workerThreadId = std::thread::id();
+                _p->cleanupComplete = true;
+                _p->lifecycleCV.notify_all();
+                return out;
+            }
+            const DWORD waitResult = ::WaitForSingleObject(
+                _p->readyEvent.get(),
+                static_cast<DWORD>(_p->options.startTimeout.count()));
+            if (WAIT_OBJECT_0 != waitResult || !_p->serverStarted.load())
+            {
+                out.status = WindowsOpenBrokerStartStatus::IOError;
+                out.error = WAIT_TIMEOUT == waitResult ?
+                    "The broker server did not become ready before the timeout" :
+                    _p->getLastError();
+                if (out.error.empty())
+                {
+                    out.error = windowsError("WaitForSingleObject(start)", ::GetLastError());
+                }
+                lifecycleLock.unlock();
+                stop();
+                return out;
+            }
+            out.status = WindowsOpenBrokerStartStatus::Started;
+            return out;
+#else // _WIN32
+            (void)callback;
+            out.status = WindowsOpenBrokerStartStatus::Unsupported;
+            out.error = "The single-instance open broker is only available on Windows";
+            return out;
+#endif // _WIN32
+        }
+
+        void WindowsOpenBroker::stop() noexcept
+        {
+#if defined(_WIN32)
+            const auto state = _p;
+            std::thread workerToJoin;
+            HANDLE detachedExitEvent = nullptr;
+            bool ownsCleanup = false;
+            bool returnAfterCancel = false;
+
+            state->stopping = true;
+            {
+                std::unique_lock<std::mutex> lock(state->lifecycleMutex);
+                if (state->cleanupComplete)
+                {
+                    return;
+                }
+                if (state->stopEvent)
+                {
+                    ::SetEvent(state->stopEvent.get());
+                }
+
+                const bool calledByWorker =
+                    state->workerThreadId == std::this_thread::get_id();
+                if (state->joinInProgress)
+                {
+                    // An external caller already owns the join. Waiting here
+                    // from the callback would deadlock that owner, which is
+                    // joining this thread, so the callback simply returns.
+                    if (calledByWorker)
+                    {
+                        returnAfterCancel = true;
+                    }
+                    else
+                    {
+                        state->lifecycleCV.wait(
+                            lock,
+                            [state] { return state->cleanupComplete; });
+                        return;
+                    }
+                }
+                else if (state->worker.joinable())
+                {
+                    if (calledByWorker)
+                    {
+                        // The thread owns a shared state reference. Detaching
+                        // makes callback-triggered destruction safe: state and
+                        // handles live until run() exits.
+                        try
+                        {
+                            state->worker.detach();
+                            state->workerDetached = true;
+                        }
+                        catch (...)
+                        {
+                            // detach() can only fail here if the guarded
+                            // std::thread invariant was violated. Leaving a
+                            // joinable worker to reach its destructor would
+                            // terminate later at a less diagnosable point.
+                            std::terminate();
+                        }
+                        returnAfterCancel = true;
+                    }
+                    else
+                    {
+                        workerToJoin = std::move(state->worker);
+                        state->joinInProgress = true;
+                        ownsCleanup = true;
+                    }
+                }
+                else if (state->workerDetached)
+                {
+                    if (calledByWorker)
+                    {
+                        return;
+                    }
+                    detachedExitEvent = state->exitEvent.get();
+                    state->joinInProgress = true;
+                    ownsCleanup = true;
+                }
+                else
+                {
+                    // A partially initialized lifecycle has no worker. This
+                    // caller still owns the one cleanup of its handles.
+                    state->joinInProgress = true;
+                    ownsCleanup = true;
+                }
+            }
+
+            {
+                std::lock_guard<std::mutex> lock(state->pipeMutex);
+                if (state->activePipe)
+                {
+                    ::CancelIoEx(state->activePipe, nullptr);
+                }
+            }
+            if (returnAfterCancel)
+            {
+                return;
+            }
+
+            if (workerToJoin.joinable())
+            {
+                try
+                {
+                    workerToJoin.join();
+                }
+                catch (const std::exception& exception)
+                {
+                    state->setLastError(
+                        std::string("Joining the broker worker failed: ") +
+                        exception.what());
+                    try
+                    {
+                        if (workerToJoin.joinable())
+                        {
+                            workerToJoin.detach();
+                        }
+                    }
+                    catch (...)
+                    {}
+                    if (state->exitEvent)
+                    {
+                        ::WaitForSingleObject(state->exitEvent.get(), INFINITE);
+                    }
+                }
+                catch (...)
+                {
+                    state->setLastError(
+                        "Joining the broker worker failed with an unknown exception");
+                    try
+                    {
+                        if (workerToJoin.joinable())
+                        {
+                            workerToJoin.detach();
+                        }
+                    }
+                    catch (...)
+                    {}
+                    if (state->exitEvent)
+                    {
+                        ::WaitForSingleObject(state->exitEvent.get(), INFINITE);
+                    }
+                }
+            }
+            else if (detachedExitEvent)
+            {
+                ::WaitForSingleObject(detachedExitEvent, INFINITE);
+            }
+
+            if (ownsCleanup)
+            {
+                Callback callbackToDestroy;
+                std::lock_guard<std::mutex> lock(state->lifecycleMutex);
+                state->workerDetached = false;
+                state->joinInProgress = false;
+                state->cleanupComplete = true;
+                state->workerThreadId = std::thread::id();
+                state->running = false;
+                state->primaryMutex.reset();
+                state->readyEvent.reset();
+                state->stopEvent.reset();
+                state->exitEvent.reset();
+                callbackToDestroy = std::move(state->callback);
+                state->lifecycleCV.notify_all();
+            }
+#else // _WIN32
+            _p->running = false;
+#endif // _WIN32
+        }
+
+        bool WindowsOpenBroker::isRunning() const noexcept
+        {
+#if defined(_WIN32)
+            return _p->running.load();
+#else // _WIN32
+            return _p->running;
+#endif // _WIN32
+        }
+
+        std::string WindowsOpenBroker::getLastError() const
+        {
+            return _p->getLastError();
+        }
+
+        const WindowsOpenBrokerIdentity& WindowsOpenBroker::getIdentity() const noexcept
+        {
+            return _p->identity;
+        }
+
+#if defined(DJV_WINDOWS_OPEN_BROKER_TESTING)
+        void setWindowsOpenBrokerSecurityTestHooks(
+            WindowsOpenBrokerRevertToSelfTestHook revertHook,
+            WindowsOpenBrokerFailStopTestHook failStopHook) noexcept
+        {
+#if defined(_WIN32)
+            revertToSelfTestHook.store(revertHook);
+            failStopTestHook.store(failStopHook);
+#else // _WIN32
+            (void)revertHook;
+            (void)failStopHook;
+#endif // _WIN32
+        }
+#endif // DJV_WINDOWS_OPEN_BROKER_TESTING
+
+        bool WindowsOpenBroker::resolveIdentity(
+            const WindowsOpenBrokerOptions& options,
+            WindowsOpenBrokerIdentity& out,
+            std::string& error)
+        {
+            if (!validateOptions(options, error))
+            {
+                return false;
+            }
+#if defined(_WIN32)
+            std::wstring applicationId;
+            if (!utf8ToWide(options.applicationId, applicationId, error))
+            {
+                return false;
+            }
+            std::vector<uint8_t> sid;
+            if (!getProcessUserSid(::GetCurrentProcess(), sid, error))
+            {
+                return false;
+            }
+            std::wstring sidString;
+            if (!sidToString(sid.data(), sidString, error))
+            {
+                return false;
+            }
+            std::vector<uint8_t> logonSid;
+            if (!getProcessLogonSid(::GetCurrentProcess(), logonSid, error))
+            {
+                return false;
+            }
+            std::wstring logonSidString;
+            if (!sidToString(logonSid.data(), logonSidString, error))
+            {
+                return false;
+            }
+            uint32_t sessionId = 0;
+            if (!getCurrentSessionId(sessionId, error))
+            {
+                return false;
+            }
+            const uint64_t hash = stableIdentityHash(
+                options.applicationId, logonSidString, sessionId);
+            std::wostringstream hashText;
+            hashText << std::hex << std::setw(16) << std::setfill(L'0') << hash;
+            out.pipeName = L"\\\\.\\pipe\\DJV.OpenBroker." + hashText.str();
+            out.mutexName = L"Local\\DJV.OpenBroker." + hashText.str();
+            out.userSid = std::move(sidString);
+            out.logonSid = std::move(logonSidString);
+            out.sessionId = sessionId;
+            out.rejectsRemoteClients = true;
+            return true;
+#else // _WIN32
+            (void)out;
+            error = "The single-instance open broker is only available on Windows";
+            return false;
+#endif // _WIN32
+        }
+
+        bool WindowsOpenBroker::normalizePaths(
+            const std::vector<std::string>& paths,
+            const std::string& workingDirectoryUtf8,
+            std::vector<std::string>& out,
+            std::string& error)
+        {
+            out.clear();
+            if (paths.empty() || paths.size() > maxPathCount)
+            {
+                error = "An open request must contain 1-128 paths";
+                return false;
+            }
+            if (workingDirectoryUtf8.size() > maxPathBytes)
+            {
+                error = "The working directory exceeds the path limit";
+                return false;
+            }
+#if defined(_WIN32)
+            std::filesystem::path cwd;
+            if (!workingDirectoryUtf8.empty())
+            {
+                std::wstring wideCwd;
+                if (!utf8ToWide(workingDirectoryUtf8, wideCwd, error))
+                {
+                    return false;
+                }
+                cwd = std::filesystem::path(wideCwd).lexically_normal();
+                if (!cwd.is_absolute() || isForbiddenDevicePath(cwd))
+                {
+                    error = "The working directory is not a safe absolute filesystem path";
+                    return false;
+                }
+            }
+            std::vector<std::string> normalized;
+            normalized.reserve(paths.size());
+            size_t totalBytes = 0;
+            for (const auto& pathUtf8 : paths)
+            {
+                if (pathUtf8.empty() || pathUtf8.size() > maxPathBytes)
+                {
+                    error = "A path is empty or exceeds the path limit";
+                    return false;
+                }
+                std::wstring widePath;
+                if (!utf8ToWide(pathUtf8, widePath, error))
+                {
+                    return false;
+                }
+                std::filesystem::path path(widePath);
+                if (isForbiddenDevicePath(path))
+                {
+                    error = "Device namespace paths are not accepted";
+                    return false;
+                }
+                if (!path.is_absolute())
+                {
+                    if (path.has_root_name() || path.has_root_directory())
+                    {
+                        error = "Drive-relative and root-relative paths are ambiguous";
+                        return false;
+                    }
+                    if (cwd.empty())
+                    {
+                        error = "A relative path requires an absolute working directory";
+                        return false;
+                    }
+                    path = cwd / path;
+                }
+                path = path.lexically_normal();
+                if (!path.is_absolute() || isForbiddenDevicePath(path))
+                {
+                    error = "A normalized path is not a safe absolute filesystem path";
+                    return false;
+                }
+                std::string value;
+                if (!wideToUtf8(path.native(), value, error) ||
+                    value.empty() ||
+                    value.size() > maxPathBytes)
+                {
+                    if (error.empty())
+                    {
+                        error = "A normalized path exceeds the path limit";
+                    }
+                    return false;
+                }
+                if (totalBytes > maxPayloadBytes - value.size())
+                {
+                    error = "The normalized paths exceed the payload limit";
+                    return false;
+                }
+                totalBytes += value.size();
+                normalized.push_back(std::move(value));
+            }
+            out = std::move(normalized);
+            return true;
+#else // _WIN32
+            (void)workingDirectoryUtf8;
+            error = "Windows path normalization is unavailable on this platform";
+            return false;
+#endif // _WIN32
+        }
+
+        WindowsOpenForwardResult WindowsOpenBroker::forward(
+            const std::vector<std::string>& paths,
+            const std::string& workingDirectoryUtf8,
+            const WindowsOpenBrokerOptions& options)
+        {
+            WindowsOpenForwardResult out;
+            std::string error;
+            if (!validateOptions(options, error))
+            {
+                out.status = WindowsOpenForwardStatus::InvalidArgument;
+                out.error = error;
+                return out;
+            }
+#if defined(_WIN32)
+            std::vector<std::string> normalized;
+            if (!normalizePaths(
+                    paths, workingDirectoryUtf8, normalized, error))
+            {
+                out.status = WindowsOpenForwardStatus::InvalidArgument;
+                out.error = error;
+                return out;
+            }
+            std::vector<uint8_t> payload;
+            if (!encodeRequestPayload(
+                    paths, workingDirectoryUtf8, payload, error))
+            {
+                out.status = WindowsOpenForwardStatus::InvalidArgument;
+                out.error = error;
+                return out;
+            }
+            WindowsOpenBrokerIdentity identity;
+            if (!resolveIdentity(options, identity, error))
+            {
+                out.status = WindowsOpenForwardStatus::SecurityError;
+                out.error = error;
+                return out;
+            }
+
+            const auto connectDeadline =
+                std::chrono::steady_clock::now() + options.connectTimeout;
+            Handle pipe;
+            bool primaryMarkerObserved = false;
+            while (std::chrono::steady_clock::now() < connectDeadline)
+            {
+                const HANDLE rawPipe = ::CreateFileW(
+                    identity.pipeName.c_str(),
+                    GENERIC_READ | GENERIC_WRITE,
+                    0,
+                    nullptr,
+                    OPEN_EXISTING,
+                    FILE_FLAG_OVERLAPPED |
+                        SECURITY_SQOS_PRESENT |
+                        SECURITY_IDENTIFICATION,
+                    nullptr);
+                if (INVALID_HANDLE_VALUE != rawPipe)
+                {
+                    pipe.reset(rawPipe);
+                    break;
+                }
+                const DWORD openError = ::GetLastError();
+                if (ERROR_FILE_NOT_FOUND == openError)
+                {
+                    Handle primaryMarker(::OpenMutexW(
+                        SYNCHRONIZE,
+                        FALSE,
+                        identity.mutexName.c_str()));
+                    if (!primaryMarker)
+                    {
+                        const DWORD markerError = ::GetLastError();
+                        if (ERROR_FILE_NOT_FOUND == markerError)
+                        {
+                            out.status = WindowsOpenForwardStatus::NoServer;
+                            out.error = "No per-user broker server is running";
+                            return out;
+                        }
+                        out.status = ERROR_ACCESS_DENIED == markerError ?
+                            WindowsOpenForwardStatus::SecurityError :
+                            WindowsOpenForwardStatus::IOError;
+                        out.error = windowsError("OpenMutexW(primary marker)", markerError);
+                        return out;
+                    }
+                    primaryMarkerObserved = true;
+                    ::Sleep((std::min)(DWORD(10), remainingMilliseconds(connectDeadline)));
+                    continue;
+                }
+                if (ERROR_ACCESS_DENIED == openError)
+                {
+                    out.status = WindowsOpenForwardStatus::SecurityError;
+                    out.error = windowsError("CreateFileW(pipe)", openError);
+                    return out;
+                }
+                if (ERROR_PIPE_BUSY != openError)
+                {
+                    out.status = WindowsOpenForwardStatus::IOError;
+                    out.error = windowsError("CreateFileW(pipe)", openError);
+                    return out;
+                }
+                primaryMarkerObserved = true;
+                const DWORD remaining = remainingMilliseconds(connectDeadline);
+                if (!remaining || !::WaitNamedPipeW(identity.pipeName.c_str(), remaining))
+                {
+                    const DWORD waitError = ::GetLastError();
+                    if (ERROR_SEM_TIMEOUT != waitError &&
+                        ERROR_FILE_NOT_FOUND != waitError)
+                    {
+                        out.status = WindowsOpenForwardStatus::IOError;
+                        out.error = windowsError("WaitNamedPipeW", waitError);
+                        return out;
+                    }
+                }
+            }
+            if (!pipe)
+            {
+                out.status = primaryMarkerObserved ?
+                    WindowsOpenForwardStatus::Timeout :
+                    WindowsOpenForwardStatus::NoServer;
+                out.error = primaryMarkerObserved ?
+                    "Timed out waiting for the broker server" :
+                    "No per-user broker server is running";
+                return out;
+            }
+            if (!verifyServerIdentity(pipe.get(), identity.sessionId, error))
+            {
+                out.status = WindowsOpenForwardStatus::SecurityError;
+                out.error = error;
+                return out;
+            }
+
+            static std::atomic<uint64_t> sequence(0);
+            const uint64_t requestId =
+                (::GetTickCount64() << 16U) ^
+                static_cast<uint64_t>(::GetCurrentProcessId()) ^
+                ++sequence;
+            const auto header = encodeHeader({
+                protocolVersion,
+                requestMessageType,
+                static_cast<uint32_t>(payload.size()),
+                requestId });
+            IOStatus status = writeBytes(
+                pipe.get(), header, nullptr, options.ioTimeout, error);
+            if (IOStatus::Complete == status)
+            {
+                status = writeBytes(
+                    pipe.get(), payload, nullptr, options.ioTimeout, error);
+            }
+            if (IOStatus::Complete != status)
+            {
+                out.status = IOStatus::Timeout == status ?
+                    WindowsOpenForwardStatus::Timeout :
+                    WindowsOpenForwardStatus::IOError;
+                out.error = error.empty() ? "Writing the open request failed" : error;
+                return out;
+            }
+
+            std::vector<uint8_t> rawHeader(protocolHeaderBytes);
+            status = readBytes(
+                pipe.get(), rawHeader, nullptr, options.ioTimeout, error);
+            if (IOStatus::Complete != status)
+            {
+                out.status = WindowsOpenForwardStatus::DeliveryUnknown;
+                out.error = error.empty() ? "Reading the broker ACK failed" : error;
+                return out;
+            }
+            ProtocolHeader responseHeader;
+            if (!decodeHeader(rawHeader, responseHeader, error) ||
+                protocolVersion != responseHeader.version ||
+                responseMessageType != responseHeader.type ||
+                requestId != responseHeader.requestId ||
+                responseHeader.payloadBytes > maxResponseMessageBytes + 8)
+            {
+                out.status = WindowsOpenForwardStatus::DeliveryUnknown;
+                out.error = error.empty() ? "The broker ACK header is invalid" : error;
+                return out;
+            }
+            std::vector<uint8_t> responsePayload(responseHeader.payloadBytes);
+            status = readBytes(
+                pipe.get(), responsePayload, nullptr, options.ioTimeout, error);
+            if (IOStatus::Complete != status)
+            {
+                out.status = WindowsOpenForwardStatus::DeliveryUnknown;
+                out.error = error.empty() ? "Reading the broker ACK payload failed" : error;
+                return out;
+            }
+            ResponseCode responseCode = ResponseCode::InternalError;
+            std::string responseMessage;
+            if (!decodeResponsePayload(
+                    responsePayload, responseCode, responseMessage, error))
+            {
+                // Release the server's bounded receipt wait even for malformed
+                // responses. The delivery state remains unknown.
+                const std::vector<uint8_t> receipt(1, responseReceipt);
+                std::string receiptError;
+                writeBytes(
+                    pipe.get(), receipt, nullptr, options.ioTimeout, receiptError);
+                out.status = WindowsOpenForwardStatus::DeliveryUnknown;
+                out.error = error;
+                return out;
+            }
+
+            // Receipt is server-side flow control, not part of delivery proof:
+            // the complete, correlated response above is authoritative.
+            const std::vector<uint8_t> receipt(1, responseReceipt);
+            std::string receiptError;
+            writeBytes(pipe.get(), receipt, nullptr, options.ioTimeout, receiptError);
+            if (ResponseCode::Accepted == responseCode)
+            {
+                out.status = WindowsOpenForwardStatus::Forwarded;
+                return out;
+            }
+            out.error = responseMessage.empty() ?
+                "The broker rejected the open request" :
+                responseMessage;
+            switch (responseCode)
+            {
+            case ResponseCode::CallbackRejected:
+            case ResponseCode::ServerStopping:
+                out.status = WindowsOpenForwardStatus::Rejected;
+                break;
+            case ResponseCode::Unauthorized:
+                out.status = WindowsOpenForwardStatus::SecurityError;
+                break;
+            case ResponseCode::InvalidRequest:
+            case ResponseCode::ProtocolError:
+            case ResponseCode::PayloadTooLarge:
+                out.status = WindowsOpenForwardStatus::ProtocolError;
+                break;
+            case ResponseCode::InternalError:
+                out.status = WindowsOpenForwardStatus::DeliveryUnknown;
+                break;
+            case ResponseCode::Accepted:
+                break;
+            }
+            return out;
+#else // _WIN32
+            (void)paths;
+            (void)workingDirectoryUtf8;
+            out.status = WindowsOpenForwardStatus::Unsupported;
+            out.error = "The single-instance open broker is only available on Windows";
+            return out;
+#endif // _WIN32
+        }
+    }
+}

--- a/lib/djv/App/WindowsOpenBroker.h
+++ b/lib/djv/App/WindowsOpenBroker.h
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the DJV project.
+
+#pragma once
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace djv
+{
+    namespace app
+    {
+        //! Options shared by the Windows single-instance server and client.
+        struct WindowsOpenBrokerOptions
+        {
+            //! Stable application identifier. It is hashed with the current
+            //! logon SID and Windows session; it is never used directly as an
+            //! operating-system object name.
+            std::string applicationId = "DJV";
+
+            //! Maximum time for a client to wait for the server pipe.
+            std::chrono::milliseconds connectTimeout =
+                std::chrono::milliseconds(1500);
+
+            //! Maximum time for each complete request or response transfer.
+            std::chrono::milliseconds ioTimeout =
+                std::chrono::milliseconds(2000);
+
+            //! Maximum time start() waits for the server pipe to become ready.
+            std::chrono::milliseconds startTimeout =
+                std::chrono::milliseconds(2000);
+        };
+
+        enum class WindowsOpenBrokerStartStatus
+        {
+            Started,
+            AlreadyRunning,
+            Unsupported,
+            InvalidOptions,
+            SecurityError,
+            IOError
+        };
+
+        struct WindowsOpenBrokerStartResult
+        {
+            WindowsOpenBrokerStartStatus status =
+                WindowsOpenBrokerStartStatus::IOError;
+            std::string error;
+
+            explicit operator bool() const noexcept
+            {
+                return WindowsOpenBrokerStartStatus::Started == status;
+            }
+        };
+
+        enum class WindowsOpenForwardStatus
+        {
+            Forwarded,
+            //! The complete request reached the server pipe, but no valid
+            //! terminal response was received. The callback may already have
+            //! run; callers must not retry or open locally by default.
+            DeliveryUnknown,
+            NoServer,
+            Rejected,
+            InvalidArgument,
+            Timeout,
+            ProtocolError,
+            SecurityError,
+            IOError,
+            Unsupported
+        };
+
+        struct WindowsOpenForwardResult
+        {
+            WindowsOpenForwardStatus status = WindowsOpenForwardStatus::IOError;
+            std::string error;
+
+            explicit operator bool() const noexcept
+            {
+                return WindowsOpenForwardStatus::Forwarded == status;
+            }
+        };
+
+        //! Inspectable, non-secret identity of the per-user broker objects.
+        struct WindowsOpenBrokerIdentity
+        {
+            std::wstring pipeName;
+            std::wstring mutexName;
+            std::wstring userSid;
+            //! Per-logon SID used by the object DACL. Unlike userSid, this SID
+            //! does not grant another RUNAS/RDP session of the same account.
+            std::wstring logonSid;
+            uint32_t sessionId = 0;
+            bool rejectsRemoteClients = false;
+        };
+
+        //! Secure, bounded single-instance open-request broker for Windows.
+        //!
+            //! The callback runs on the broker worker thread. It must only validate
+            //! and enqueue the request for the UI thread; it must not perform long
+            //! or blocking work. Returning false sends an explicit NACK to the
+            //! client. The optional message is capped before it crosses the pipe.
+            //! Calling stop(), or even destroying the broker, from the callback is
+            //! supported; the worker keeps its private state alive until it exits.
+        class WindowsOpenBroker
+        {
+        public:
+            using Callback = std::function<bool(
+                const std::vector<std::string>&,
+                std::string&)>;
+
+            static constexpr uint16_t protocolVersion = 1;
+            static constexpr size_t maxPathCount = 128;
+            static constexpr size_t maxPathBytes = 64U * 1024U;
+            static constexpr size_t maxPayloadBytes = 1024U * 1024U;
+            static constexpr size_t maxResponseMessageBytes = 4096;
+
+            explicit WindowsOpenBroker(
+                const WindowsOpenBrokerOptions& = WindowsOpenBrokerOptions());
+            ~WindowsOpenBroker();
+
+            WindowsOpenBroker(const WindowsOpenBroker&) = delete;
+            WindowsOpenBroker& operator=(const WindowsOpenBroker&) = delete;
+            WindowsOpenBroker(WindowsOpenBroker&&) = delete;
+            WindowsOpenBroker& operator=(WindowsOpenBroker&&) = delete;
+
+            //! Acquire the per-logon primary slot and start accepting requests.
+            WindowsOpenBrokerStartResult start(Callback);
+
+            //! Cancel pending pipe I/O and join the worker. This is idempotent.
+            void stop() noexcept;
+
+            bool isRunning() const noexcept;
+            std::string getLastError() const;
+            const WindowsOpenBrokerIdentity& getIdentity() const noexcept;
+
+            //! Forward paths to an existing broker and wait for ACK/NACK.
+            //!
+            //! Relative paths require an absolute UTF-8 working directory.
+            //! The server independently validates and normalizes all paths.
+            static WindowsOpenForwardResult forward(
+                const std::vector<std::string>& paths,
+                const std::string& workingDirectoryUtf8,
+                const WindowsOpenBrokerOptions& = WindowsOpenBrokerOptions());
+
+            //! Validate UTF-8 and resolve every input to a lexical absolute path.
+            static bool normalizePaths(
+                const std::vector<std::string>& paths,
+                const std::string& workingDirectoryUtf8,
+                std::vector<std::string>& out,
+                std::string& error);
+
+            //! Resolve the deterministic identity for diagnostics and tests.
+            static bool resolveIdentity(
+                const WindowsOpenBrokerOptions&,
+                WindowsOpenBrokerIdentity&,
+                std::string& error);
+
+        private:
+            class Private;
+            std::shared_ptr<Private> _p;
+        };
+
+#if defined(DJV_WINDOWS_OPEN_BROKER_TESTING)
+        //! Dependency injection for the fail-stop security regression.
+        //! This surface is absent from production builds.
+        using WindowsOpenBrokerRevertToSelfTestHook = bool(*)();
+        using WindowsOpenBrokerFailStopTestHook = void(*)(const std::string&);
+        void setWindowsOpenBrokerSecurityTestHooks(
+            WindowsOpenBrokerRevertToSelfTestHook,
+            WindowsOpenBrokerFailStopTestHook) noexcept;
+#endif // DJV_WINDOWS_OPEN_BROKER_TESTING
+    }
+}

--- a/lib/djv/AppTest/CMakeLists.txt
+++ b/lib/djv/AppTest/CMakeLists.txt
@@ -1,0 +1,17 @@
+add_executable(
+    djvWindowsOpenBrokerTest
+    WindowsOpenBrokerTest.cpp
+    ../App/WindowsOpenBroker.cpp)
+target_compile_definitions(
+    djvWindowsOpenBrokerTest
+    PRIVATE
+        DJV_WINDOWS_OPEN_BROKER_TEST_MAIN
+        DJV_WINDOWS_OPEN_BROKER_TESTING)
+target_include_directories(
+    djvWindowsOpenBrokerTest
+    PRIVATE ${PROJECT_SOURCE_DIR}/lib)
+set_target_properties(djvWindowsOpenBrokerTest PROPERTIES FOLDER tests)
+add_test(NAME djv-windows-open-broker COMMAND djvWindowsOpenBrokerTest)
+set_tests_properties(
+    djv-windows-open-broker
+    PROPERTIES LABELS "unit;app;windows;security" TIMEOUT 90)

--- a/lib/djv/AppTest/WindowsOpenBrokerTest.cpp
+++ b/lib/djv/AppTest/WindowsOpenBrokerTest.cpp
@@ -1,0 +1,1008 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the DJV project.
+
+#include <djv/AppTest/WindowsOpenBrokerTest.h>
+
+#include <djv/App/WindowsOpenBroker.h>
+
+#include <chrono>
+#include <atomic>
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <iostream>
+#include <limits>
+#include <mutex>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+#if defined(_WIN32)
+#    if !defined(NOMINMAX)
+#        define NOMINMAX
+#    endif
+#    include <windows.h>
+#    include <aclapi.h>
+#endif // _WIN32
+
+namespace djv
+{
+    namespace app_tests
+    {
+        namespace
+        {
+            void require(bool value, const char* expression, int line)
+            {
+                if (!value)
+                {
+                    std::ostringstream stream;
+                    stream << "Requirement failed at line " << line << ": " << expression;
+                    throw std::runtime_error(stream.str());
+                }
+            }
+
+#define DJV_BROKER_REQUIRE(EXPRESSION) \
+            require(!!(EXPRESSION), #EXPRESSION, __LINE__)
+
+#if defined(_WIN32)
+            class TestHandle
+            {
+            public:
+                TestHandle() = default;
+                explicit TestHandle(HANDLE value) : _value(value) {}
+                ~TestHandle()
+                {
+                    if (_value && INVALID_HANDLE_VALUE != _value)
+                    {
+                        ::CloseHandle(_value);
+                    }
+                }
+
+                TestHandle(const TestHandle&) = delete;
+                TestHandle& operator=(const TestHandle&) = delete;
+
+                TestHandle(TestHandle&& other) noexcept :
+                    _value(other.release())
+                {}
+
+                TestHandle& operator=(TestHandle&& other) noexcept
+                {
+                    if (this != &other)
+                    {
+                        if (_value && INVALID_HANDLE_VALUE != _value)
+                        {
+                            ::CloseHandle(_value);
+                        }
+                        _value = other.release();
+                    }
+                    return *this;
+                }
+
+                explicit operator bool() const noexcept
+                {
+                    return _value && INVALID_HANDLE_VALUE != _value;
+                }
+
+                HANDLE get() const noexcept
+                {
+                    return _value;
+                }
+
+                HANDLE release() noexcept
+                {
+                    const HANDLE out = _value;
+                    _value = nullptr;
+                    return out;
+                }
+
+            private:
+                HANDLE _value = nullptr;
+            };
+
+            std::string wideToUtf8(const std::wstring& value)
+            {
+                if (value.empty())
+                {
+                    return std::string();
+                }
+                const int size = ::WideCharToMultiByte(
+                    CP_UTF8,
+                    WC_ERR_INVALID_CHARS,
+                    value.data(),
+                    static_cast<int>(value.size()),
+                    nullptr,
+                    0,
+                    nullptr,
+                    nullptr);
+                DJV_BROKER_REQUIRE(size > 0);
+                std::string out(static_cast<size_t>(size), '\0');
+                DJV_BROKER_REQUIRE(size == ::WideCharToMultiByte(
+                    CP_UTF8,
+                    WC_ERR_INVALID_CHARS,
+                    value.data(),
+                    static_cast<int>(value.size()),
+                    out.data(),
+                    size,
+                    nullptr,
+                    nullptr));
+                return out;
+            }
+
+            std::wstring getTempPath()
+            {
+                const DWORD size = ::GetTempPathW(0, nullptr);
+                DJV_BROKER_REQUIRE(size > 0);
+                std::wstring out(size, L'\0');
+                const DWORD written = ::GetTempPathW(size, out.data());
+                DJV_BROKER_REQUIRE(written > 0 && written < size);
+                out.resize(written);
+                return out;
+            }
+
+            void appendU16(std::vector<uint8_t>& out, uint16_t value)
+            {
+                out.push_back(static_cast<uint8_t>(value & 0xFFU));
+                out.push_back(static_cast<uint8_t>((value >> 8U) & 0xFFU));
+            }
+
+            void appendU32(std::vector<uint8_t>& out, uint32_t value)
+            {
+                for (unsigned int i = 0; i < 4; ++i)
+                {
+                    out.push_back(static_cast<uint8_t>((value >> (i * 8U)) & 0xFFU));
+                }
+            }
+
+            void appendU64(std::vector<uint8_t>& out, uint64_t value)
+            {
+                for (unsigned int i = 0; i < 8; ++i)
+                {
+                    out.push_back(static_cast<uint8_t>((value >> (i * 8U)) & 0xFFU));
+                }
+            }
+
+            uint16_t readU16(const std::vector<uint8_t>& data, size_t& offset)
+            {
+                DJV_BROKER_REQUIRE(offset <= data.size() && data.size() - offset >= 2);
+                const uint16_t out =
+                    static_cast<uint16_t>(data[offset]) |
+                    static_cast<uint16_t>(data[offset + 1]) << 8U;
+                offset += 2;
+                return out;
+            }
+
+            uint32_t readU32(const std::vector<uint8_t>& data, size_t& offset)
+            {
+                DJV_BROKER_REQUIRE(offset <= data.size() && data.size() - offset >= 4);
+                uint32_t out = 0;
+                for (unsigned int i = 0; i < 4; ++i)
+                {
+                    out |= static_cast<uint32_t>(data[offset + i]) << (i * 8U);
+                }
+                offset += 4;
+                return out;
+            }
+
+            uint64_t readU64(const std::vector<uint8_t>& data, size_t& offset)
+            {
+                DJV_BROKER_REQUIRE(offset <= data.size() && data.size() - offset >= 8);
+                uint64_t out = 0;
+                for (unsigned int i = 0; i < 8; ++i)
+                {
+                    out |= static_cast<uint64_t>(data[offset + i]) << (i * 8U);
+                }
+                offset += 8;
+                return out;
+            }
+
+            std::vector<uint8_t> makeHeader(
+                uint32_t payloadBytes,
+                uint64_t requestId,
+                uint16_t version = app::WindowsOpenBroker::protocolVersion,
+                uint16_t type = 1)
+            {
+                std::vector<uint8_t> out = { 'D', 'J', 'V', 'O' };
+                appendU16(out, version);
+                appendU16(out, type);
+                appendU32(out, payloadBytes);
+                appendU64(out, requestId);
+                DJV_BROKER_REQUIRE(20 == out.size());
+                return out;
+            }
+
+            bool transfer(
+                HANDLE pipe,
+                bool write,
+                uint8_t* data,
+                size_t size,
+                DWORD timeout = 3000)
+            {
+                size_t offset = 0;
+                while (offset < size)
+                {
+                    TestHandle event(::CreateEventW(nullptr, TRUE, FALSE, nullptr));
+                    DJV_BROKER_REQUIRE(event);
+                    OVERLAPPED overlapped = {};
+                    overlapped.hEvent = event.get();
+                    const DWORD requested = static_cast<DWORD>((std::min)(
+                        size - offset,
+                        static_cast<size_t>(64U * 1024U)));
+                    DWORD transferred = 0;
+                    const BOOL immediate = write ?
+                        ::WriteFile(
+                            pipe,
+                            data + offset,
+                            requested,
+                            &transferred,
+                            &overlapped) :
+                        ::ReadFile(
+                            pipe,
+                            data + offset,
+                            requested,
+                            &transferred,
+                            &overlapped);
+                    if (!immediate)
+                    {
+                        const DWORD operationError = ::GetLastError();
+                        if (ERROR_IO_PENDING != operationError)
+                        {
+                            return false;
+                        }
+                        if (WAIT_OBJECT_0 != ::WaitForSingleObject(event.get(), timeout))
+                        {
+                            ::CancelIoEx(pipe, &overlapped);
+                            ::GetOverlappedResult(pipe, &overlapped, &transferred, TRUE);
+                            return false;
+                        }
+                        if (!::GetOverlappedResult(
+                                pipe, &overlapped, &transferred, FALSE))
+                        {
+                            return false;
+                        }
+                    }
+                    if (!transferred)
+                    {
+                        return false;
+                    }
+                    offset += transferred;
+                }
+                return true;
+            }
+
+            bool writeBytes(HANDLE pipe, const std::vector<uint8_t>& data)
+            {
+                return data.empty() || transfer(
+                    pipe,
+                    true,
+                    const_cast<uint8_t*>(data.data()),
+                    data.size());
+            }
+
+            bool readBytes(HANDLE pipe, std::vector<uint8_t>& data)
+            {
+                return data.empty() || transfer(
+                    pipe, false, data.data(), data.size());
+            }
+
+            TestHandle connectRaw(const std::wstring& pipeName)
+            {
+                const auto deadline =
+                    std::chrono::steady_clock::now() + std::chrono::seconds(3);
+                while (std::chrono::steady_clock::now() < deadline)
+                {
+                    const HANDLE pipe = ::CreateFileW(
+                        pipeName.c_str(),
+                        GENERIC_READ | GENERIC_WRITE | READ_CONTROL,
+                        0,
+                        nullptr,
+                        OPEN_EXISTING,
+                        FILE_FLAG_OVERLAPPED |
+                            SECURITY_SQOS_PRESENT |
+                            SECURITY_IDENTIFICATION,
+                        nullptr);
+                    if (INVALID_HANDLE_VALUE != pipe)
+                    {
+                        return TestHandle(pipe);
+                    }
+                    const DWORD error = ::GetLastError();
+                    if (ERROR_PIPE_BUSY == error)
+                    {
+                        ::WaitNamedPipeW(pipeName.c_str(), 100);
+                    }
+                    else if (ERROR_FILE_NOT_FOUND == error)
+                    {
+                        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+                return TestHandle();
+            }
+
+            uint32_t rawExchange(
+                const std::wstring& pipeName,
+                const std::vector<uint8_t>& request,
+                uint64_t expectedRequestId,
+                std::string& responseMessage)
+            {
+                TestHandle pipe = connectRaw(pipeName);
+                DJV_BROKER_REQUIRE(pipe);
+                DJV_BROKER_REQUIRE(writeBytes(pipe.get(), request));
+
+                std::vector<uint8_t> header(20);
+                DJV_BROKER_REQUIRE(readBytes(pipe.get(), header));
+                DJV_BROKER_REQUIRE(0 == std::memcmp(
+                    header.data(), "DJVO", 4));
+                size_t offset = 4;
+                DJV_BROKER_REQUIRE(
+                    app::WindowsOpenBroker::protocolVersion == readU16(header, offset));
+                DJV_BROKER_REQUIRE(2 == readU16(header, offset));
+                const uint32_t payloadBytes = readU32(header, offset);
+                DJV_BROKER_REQUIRE(expectedRequestId == readU64(header, offset));
+                DJV_BROKER_REQUIRE(20 == offset);
+                DJV_BROKER_REQUIRE(
+                    payloadBytes <= app::WindowsOpenBroker::maxResponseMessageBytes + 8);
+
+                std::vector<uint8_t> payload(payloadBytes);
+                DJV_BROKER_REQUIRE(readBytes(pipe.get(), payload));
+                const std::vector<uint8_t> receipt(1, 0xA5);
+                DJV_BROKER_REQUIRE(writeBytes(pipe.get(), receipt));
+
+                offset = 0;
+                const uint32_t responseCode = readU32(payload, offset);
+                const uint32_t messageBytes = readU32(payload, offset);
+                DJV_BROKER_REQUIRE(offset <= payload.size());
+                DJV_BROKER_REQUIRE(payload.size() - offset == messageBytes);
+                responseMessage.assign(
+                    reinterpret_cast<const char*>(payload.data() + offset),
+                    messageBytes);
+                return responseCode;
+            }
+
+            std::vector<uint8_t> currentUserSid()
+            {
+                HANDLE rawToken = nullptr;
+                DJV_BROKER_REQUIRE(::OpenProcessToken(
+                    ::GetCurrentProcess(), TOKEN_QUERY, &rawToken));
+                TestHandle token(rawToken);
+                DWORD size = 0;
+                ::GetTokenInformation(token.get(), TokenUser, nullptr, 0, &size);
+                DJV_BROKER_REQUIRE(size > 0 && ERROR_INSUFFICIENT_BUFFER == ::GetLastError());
+                std::vector<uint8_t> buffer(size);
+                DJV_BROKER_REQUIRE(::GetTokenInformation(
+                    token.get(), TokenUser, buffer.data(), size, &size));
+                const auto tokenUser = reinterpret_cast<const TOKEN_USER*>(buffer.data());
+                const DWORD sidBytes = ::GetLengthSid(tokenUser->User.Sid);
+                std::vector<uint8_t> out(sidBytes);
+                DJV_BROKER_REQUIRE(::CopySid(
+                    sidBytes, out.data(), tokenUser->User.Sid));
+                return out;
+            }
+
+            std::vector<uint8_t> currentLogonSid()
+            {
+                HANDLE rawToken = nullptr;
+                DJV_BROKER_REQUIRE(::OpenProcessToken(
+                    ::GetCurrentProcess(), TOKEN_QUERY, &rawToken));
+                TestHandle token(rawToken);
+                DWORD size = 0;
+                ::GetTokenInformation(token.get(), TokenGroups, nullptr, 0, &size);
+                DJV_BROKER_REQUIRE(
+                    size > 0 && ERROR_INSUFFICIENT_BUFFER == ::GetLastError());
+                std::vector<uint8_t> buffer(size);
+                DJV_BROKER_REQUIRE(::GetTokenInformation(
+                    token.get(), TokenGroups, buffer.data(), size, &size));
+                const auto groups =
+                    reinterpret_cast<const TOKEN_GROUPS*>(buffer.data());
+                for (DWORD i = 0; i < groups->GroupCount; ++i)
+                {
+                    const auto& group = groups->Groups[i];
+                    if (SE_GROUP_LOGON_ID ==
+                        (group.Attributes & SE_GROUP_LOGON_ID))
+                    {
+                        const DWORD sidBytes = ::GetLengthSid(group.Sid);
+                        std::vector<uint8_t> out(sidBytes);
+                        DJV_BROKER_REQUIRE(::CopySid(
+                            sidBytes, out.data(), group.Sid));
+                        return out;
+                    }
+                }
+                DJV_BROKER_REQUIRE(false);
+                return {};
+            }
+
+            void verifyLogonDacl(HANDLE handle)
+            {
+                PACL dacl = nullptr;
+                PSECURITY_DESCRIPTOR descriptor = nullptr;
+                const DWORD result = ::GetSecurityInfo(
+                    handle,
+                    SE_KERNEL_OBJECT,
+                    DACL_SECURITY_INFORMATION,
+                    nullptr,
+                    nullptr,
+                    &dacl,
+                    nullptr,
+                    &descriptor);
+                DJV_BROKER_REQUIRE(ERROR_SUCCESS == result);
+                DJV_BROKER_REQUIRE(descriptor);
+                DJV_BROKER_REQUIRE(dacl);
+
+                ACL_SIZE_INFORMATION info = {};
+                DJV_BROKER_REQUIRE(::GetAclInformation(
+                    dacl,
+                    &info,
+                    sizeof(info),
+                    AclSizeInformation));
+                DJV_BROKER_REQUIRE(1 == info.AceCount);
+                void* rawAce = nullptr;
+                DJV_BROKER_REQUIRE(::GetAce(dacl, 0, &rawAce));
+                const auto header = reinterpret_cast<const ACE_HEADER*>(rawAce);
+                DJV_BROKER_REQUIRE(ACCESS_ALLOWED_ACE_TYPE == header->AceType);
+                const auto ace = reinterpret_cast<const ACCESS_ALLOWED_ACE*>(rawAce);
+                const auto logonSid = currentLogonSid();
+                const auto userSid = currentUserSid();
+                DJV_BROKER_REQUIRE(::EqualSid(
+                    const_cast<DWORD*>(&ace->SidStart),
+                    const_cast<uint8_t*>(logonSid.data())));
+                DJV_BROKER_REQUIRE(!::EqualSid(
+                    const_cast<DWORD*>(&ace->SidStart),
+                    const_cast<uint8_t*>(userSid.data())));
+                DJV_BROKER_REQUIRE(0 != ace->Mask);
+
+                SECURITY_DESCRIPTOR_CONTROL control = 0;
+                DWORD revision = 0;
+                DJV_BROKER_REQUIRE(::GetSecurityDescriptorControl(
+                    descriptor, &control, &revision));
+                DJV_BROKER_REQUIRE(0 != (control & SE_DACL_PROTECTED));
+                ::LocalFree(descriptor);
+            }
+
+            void verifyMutexDacl(const app::WindowsOpenBrokerIdentity& identity)
+            {
+                TestHandle mutex(::OpenMutexW(
+                    READ_CONTROL,
+                    FALSE,
+                    identity.mutexName.c_str()));
+                DJV_BROKER_REQUIRE(mutex);
+                verifyLogonDacl(mutex.get());
+            }
+
+            std::string uniqueApplicationId(const char* suffix)
+            {
+                std::ostringstream stream;
+                stream << "DJV.WindowsOpenBrokerTest."
+                       << ::GetCurrentProcessId() << "." << suffix;
+                return stream.str();
+            }
+
+            void normalizationTest()
+            {
+                const std::filesystem::path cwd =
+                    std::filesystem::path(getTempPath()) / L"DJV-\u00E9";
+                const std::string cwdUtf8 = wideToUtf8(cwd.native());
+                const std::vector<std::string> paths = {
+                    std::string("plans\\s\xC3\xA9" "quence.mov"),
+                    std::string("..\\audio\\son.wav") };
+                std::vector<std::string> normalized;
+                std::string error;
+                DJV_BROKER_REQUIRE(app::WindowsOpenBroker::normalizePaths(
+                    paths, cwdUtf8, normalized, error));
+                DJV_BROKER_REQUIRE(2 == normalized.size());
+                DJV_BROKER_REQUIRE(
+                    wideToUtf8((cwd / L"plans\\s\u00E9quence.mov").lexically_normal().native()) ==
+                    normalized[0]);
+                DJV_BROKER_REQUIRE(
+                    wideToUtf8((cwd / L"..\\audio\\son.wav").lexically_normal().native()) ==
+                    normalized[1]);
+
+                DJV_BROKER_REQUIRE(!app::WindowsOpenBroker::normalizePaths(
+                    { "C:ambiguous.mov" }, cwdUtf8, normalized, error));
+                DJV_BROKER_REQUIRE(!app::WindowsOpenBroker::normalizePaths(
+                    { "\\root-relative.mov" }, cwdUtf8, normalized, error));
+                DJV_BROKER_REQUIRE(!app::WindowsOpenBroker::normalizePaths(
+                    { "\\\\.\\pipe\\not-a-media-file" }, cwdUtf8, normalized, error));
+                DJV_BROKER_REQUIRE(!app::WindowsOpenBroker::normalizePaths(
+                    { std::string("\xC3\x28", 2) }, cwdUtf8, normalized, error));
+                DJV_BROKER_REQUIRE(!app::WindowsOpenBroker::normalizePaths(
+                    std::vector<std::string>(
+                        app::WindowsOpenBroker::maxPathCount + 1,
+                        "C:\\file.mov"),
+                    cwdUtf8,
+                    normalized,
+                    error));
+                DJV_BROKER_REQUIRE(!app::WindowsOpenBroker::normalizePaths(
+                    { std::string(app::WindowsOpenBroker::maxPathBytes + 1, 'x') },
+                    cwdUtf8,
+                    normalized,
+                    error));
+            }
+
+            void identityAndRoundTripTest()
+            {
+                app::WindowsOpenBrokerOptions options;
+                options.applicationId = uniqueApplicationId("roundtrip");
+                options.connectTimeout = std::chrono::milliseconds(1000);
+                options.ioTimeout = std::chrono::milliseconds(1000);
+                options.startTimeout = std::chrono::milliseconds(1000);
+
+                app::WindowsOpenBrokerIdentity firstIdentity;
+                app::WindowsOpenBrokerIdentity secondIdentity;
+                std::string error;
+                DJV_BROKER_REQUIRE(app::WindowsOpenBroker::resolveIdentity(
+                    options, firstIdentity, error));
+                DJV_BROKER_REQUIRE(app::WindowsOpenBroker::resolveIdentity(
+                    options, secondIdentity, error));
+                DJV_BROKER_REQUIRE(firstIdentity.pipeName == secondIdentity.pipeName);
+                DJV_BROKER_REQUIRE(firstIdentity.mutexName == secondIdentity.mutexName);
+                DJV_BROKER_REQUIRE(firstIdentity.userSid == secondIdentity.userSid);
+                DJV_BROKER_REQUIRE(firstIdentity.logonSid == secondIdentity.logonSid);
+                DJV_BROKER_REQUIRE(!firstIdentity.logonSid.empty());
+                DJV_BROKER_REQUIRE(firstIdentity.userSid != firstIdentity.logonSid);
+                DJV_BROKER_REQUIRE(firstIdentity.rejectsRemoteClients);
+
+                app::WindowsOpenBrokerOptions otherOptions = options;
+                otherOptions.applicationId += ".other";
+                app::WindowsOpenBrokerIdentity otherIdentity;
+                DJV_BROKER_REQUIRE(app::WindowsOpenBroker::resolveIdentity(
+                    otherOptions, otherIdentity, error));
+                DJV_BROKER_REQUIRE(firstIdentity.pipeName != otherIdentity.pipeName);
+
+                std::mutex captureMutex;
+                std::vector<std::string> captured;
+                app::WindowsOpenBroker broker(options);
+                const auto startResult = broker.start(
+                    [&captureMutex, &captured](
+                        const std::vector<std::string>& paths,
+                        std::string& message)
+                    {
+                        if (std::string::npos != paths.front().find("throw"))
+                        {
+                            throw std::runtime_error("deliberate callback failure");
+                        }
+                        if (std::string::npos != paths.front().find("slow"))
+                        {
+                            std::this_thread::sleep_for(std::chrono::milliseconds(250));
+                        }
+                        if (std::string::npos != paths.front().find("reject"))
+                        {
+                            message = "deliberate rejection";
+                            return false;
+                        }
+                        std::lock_guard<std::mutex> lock(captureMutex);
+                        captured = paths;
+                        return true;
+                    });
+                DJV_BROKER_REQUIRE(startResult);
+                DJV_BROKER_REQUIRE(broker.isRunning());
+                verifyMutexDacl(broker.getIdentity());
+                {
+                    TestHandle pipe = connectRaw(broker.getIdentity().pipeName);
+                    DJV_BROKER_REQUIRE(pipe);
+                    verifyLogonDacl(pipe.get());
+                }
+
+                app::WindowsOpenBroker duplicate(options);
+                const auto duplicateResult = duplicate.start(
+                    [](const std::vector<std::string>&, std::string&)
+                    {
+                        return true;
+                    });
+                DJV_BROKER_REQUIRE(
+                    app::WindowsOpenBrokerStartStatus::AlreadyRunning ==
+                    duplicateResult.status);
+
+                const std::filesystem::path cwd =
+                    std::filesystem::path(getTempPath()) / L"DJV-\u00E9";
+                const std::string cwdUtf8 = wideToUtf8(cwd.native());
+                const auto forwarded = app::WindowsOpenBroker::forward(
+                    { std::string("clips\\s\xC3\xA9" "quence.mov") },
+                    cwdUtf8,
+                    options);
+                DJV_BROKER_REQUIRE(forwarded);
+                {
+                    std::lock_guard<std::mutex> lock(captureMutex);
+                    DJV_BROKER_REQUIRE(1 == captured.size());
+                    DJV_BROKER_REQUIRE(
+                        wideToUtf8((cwd / L"clips\\s\u00E9quence.mov").lexically_normal().native()) ==
+                        captured.front());
+                }
+
+                const auto rejected = app::WindowsOpenBroker::forward(
+                    { "reject.mov" }, cwdUtf8, options);
+                DJV_BROKER_REQUIRE(
+                    app::WindowsOpenForwardStatus::Rejected == rejected.status);
+                DJV_BROKER_REQUIRE("deliberate rejection" == rejected.error);
+
+                const auto threw = app::WindowsOpenBroker::forward(
+                    { "throw.mov" }, cwdUtf8, options);
+                DJV_BROKER_REQUIRE(
+                    app::WindowsOpenForwardStatus::DeliveryUnknown == threw.status);
+                DJV_BROKER_REQUIRE(std::string::npos !=
+                    broker.getLastError().find("deliberate callback failure"));
+
+                // The client deadline is independent from the server timeout.
+                app::WindowsOpenBrokerOptions shortClientOptions = options;
+                shortClientOptions.ioTimeout = std::chrono::milliseconds(50);
+                const auto timedOut = app::WindowsOpenBroker::forward(
+                    { "slow.mov" }, cwdUtf8, shortClientOptions);
+                DJV_BROKER_REQUIRE(
+                    app::WindowsOpenForwardStatus::DeliveryUnknown == timedOut.status);
+                std::this_thread::sleep_for(std::chrono::milliseconds(300));
+                {
+                    std::lock_guard<std::mutex> lock(captureMutex);
+                    DJV_BROKER_REQUIRE(1 == captured.size());
+                    DJV_BROKER_REQUIRE(std::string::npos !=
+                        captured.front().find("slow.mov"));
+                }
+                DJV_BROKER_REQUIRE(app::WindowsOpenBroker::forward(
+                    { "after-timeout.mov" }, cwdUtf8, options));
+
+                // Malformed magic receives an explicit protocol NACK.
+                std::vector<uint8_t> invalidMagic = makeHeader(0, 1);
+                invalidMagic[0] = 'X';
+                std::string responseMessage;
+                DJV_BROKER_REQUIRE(6 == rawExchange(
+                    broker.getIdentity().pipeName,
+                    invalidMagic,
+                    0,
+                    responseMessage));
+
+                // Oversized declared payload is rejected before allocation/read.
+                const auto oversizedPayload = makeHeader(
+                    static_cast<uint32_t>(app::WindowsOpenBroker::maxPayloadBytes + 1),
+                    2);
+                DJV_BROKER_REQUIRE(7 == rawExchange(
+                    broker.getIdentity().pipeName,
+                    oversizedPayload,
+                    2,
+                    responseMessage));
+
+                // An oversized path count is rejected from a bounded payload.
+                std::vector<uint8_t> countPayload;
+                appendU32(countPayload, 0);
+                appendU32(
+                    countPayload,
+                    static_cast<uint32_t>(app::WindowsOpenBroker::maxPathCount + 1));
+                auto oversizedCount = makeHeader(
+                    static_cast<uint32_t>(countPayload.size()),
+                    3);
+                oversizedCount.insert(
+                    oversizedCount.end(), countPayload.begin(), countPayload.end());
+                DJV_BROKER_REQUIRE(1 == rawExchange(
+                    broker.getIdentity().pipeName,
+                    oversizedCount,
+                    3,
+                    responseMessage));
+
+                // An oversized individual path is rejected before path storage.
+                std::vector<uint8_t> pathPayload;
+                appendU32(pathPayload, 0);
+                appendU32(pathPayload, 1);
+                appendU32(
+                    pathPayload,
+                    static_cast<uint32_t>(app::WindowsOpenBroker::maxPathBytes + 1));
+                auto oversizedPath = makeHeader(
+                    static_cast<uint32_t>(pathPayload.size()),
+                    4);
+                oversizedPath.insert(
+                    oversizedPath.end(), pathPayload.begin(), pathPayload.end());
+                DJV_BROKER_REQUIRE(1 == rawExchange(
+                    broker.getIdentity().pipeName,
+                    oversizedPath,
+                    4,
+                    responseMessage));
+
+                // Invalid UTF-8 reaches the same explicit invalid-request path.
+                std::vector<uint8_t> invalidUtf8Payload;
+                appendU32(invalidUtf8Payload, 0);
+                appendU32(invalidUtf8Payload, 1);
+                appendU32(invalidUtf8Payload, 2);
+                invalidUtf8Payload.push_back(0xC3);
+                invalidUtf8Payload.push_back(0x28);
+                auto invalidUtf8 = makeHeader(
+                    static_cast<uint32_t>(invalidUtf8Payload.size()),
+                    5);
+                invalidUtf8.insert(
+                    invalidUtf8.end(),
+                    invalidUtf8Payload.begin(),
+                    invalidUtf8Payload.end());
+                DJV_BROKER_REQUIRE(1 == rawExchange(
+                    broker.getIdentity().pipeName,
+                    invalidUtf8,
+                    5,
+                    responseMessage));
+
+                // A future protocol version receives a NACK, not a silent drop.
+                const auto futureVersion = makeHeader(0, 6, 99);
+                DJV_BROKER_REQUIRE(6 == rawExchange(
+                    broker.getIdentity().pipeName,
+                    futureVersion,
+                    6,
+                    responseMessage));
+
+                broker.stop();
+                broker.stop();
+                DJV_BROKER_REQUIRE(!broker.isRunning());
+
+                // A primary marker without a ready pipe is a bounded startup
+                // race/health timeout, not a false "no server" result.
+                TestHandle marker(::CreateMutexW(
+                    nullptr,
+                    FALSE,
+                    broker.getIdentity().mutexName.c_str()));
+                DJV_BROKER_REQUIRE(marker);
+                app::WindowsOpenBrokerOptions markerOptions = options;
+                markerOptions.connectTimeout = std::chrono::milliseconds(50);
+                const auto markerTimeout = app::WindowsOpenBroker::forward(
+                    { "marker-timeout.mov" }, cwdUtf8, markerOptions);
+                DJV_BROKER_REQUIRE(
+                    app::WindowsOpenForwardStatus::Timeout == markerTimeout.status);
+                marker = TestHandle();
+                const auto noServer = app::WindowsOpenBroker::forward(
+                    { "after-stop.mov" }, cwdUtf8, options);
+                DJV_BROKER_REQUIRE(
+                    app::WindowsOpenForwardStatus::NoServer == noServer.status);
+            }
+
+            void boundedStopTest()
+            {
+                app::WindowsOpenBrokerOptions options;
+                options.applicationId = uniqueApplicationId("stop");
+                options.ioTimeout = std::chrono::seconds(10);
+                options.startTimeout = std::chrono::seconds(1);
+                app::WindowsOpenBroker broker(options);
+                DJV_BROKER_REQUIRE(broker.start(
+                    [](const std::vector<std::string>&, std::string&)
+                    {
+                        return true;
+                    }));
+
+                // Connect and deliberately send no bytes. stop() must cancel
+                // the pending overlapped read instead of waiting for ioTimeout.
+                TestHandle idleClient = connectRaw(broker.getIdentity().pipeName);
+                DJV_BROKER_REQUIRE(idleClient);
+                const auto start = std::chrono::steady_clock::now();
+                std::thread stopper([&broker] { broker.stop(); });
+                stopper.join();
+                const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                    std::chrono::steady_clock::now() - start);
+                DJV_BROKER_REQUIRE(elapsed < std::chrono::seconds(2));
+                DJV_BROKER_REQUIRE(!broker.isRunning());
+            }
+
+            void concurrentStopTest()
+            {
+                for (int iteration = 0; iteration < 12; ++iteration)
+                {
+                    app::WindowsOpenBrokerOptions options;
+                    options.applicationId = uniqueApplicationId(
+                        ("concurrent-stop-" + std::to_string(iteration)).c_str());
+                    options.connectTimeout = std::chrono::seconds(1);
+                    options.ioTimeout = std::chrono::seconds(2);
+                    options.startTimeout = std::chrono::seconds(1);
+
+                    app::WindowsOpenBroker broker(options);
+                    std::atomic<bool> callbackEntered(false);
+                    std::atomic<bool> releaseCallback(false);
+                    std::atomic<bool> callbackStopReturned(false);
+                    DJV_BROKER_REQUIRE(broker.start(
+                        [&broker, &callbackEntered, &releaseCallback,
+                         &callbackStopReturned](
+                            const std::vector<std::string>&,
+                            std::string&)
+                        {
+                            callbackEntered = true;
+                            while (!releaseCallback.load())
+                            {
+                                std::this_thread::yield();
+                            }
+                            // An external caller owns the join by this point.
+                            // This self-stop must return rather than wait for
+                            // that caller, which is waiting for this callback.
+                            broker.stop();
+                            callbackStopReturned = true;
+                            return true;
+                        }));
+
+                    app::WindowsOpenForwardResult forwardResult;
+                    std::thread forwarder([&]
+                        {
+                            forwardResult = app::WindowsOpenBroker::forward(
+                                { "concurrent-stop.mov" },
+                                wideToUtf8(getTempPath()),
+                                options);
+                        });
+                    const auto callbackDeadline =
+                        std::chrono::steady_clock::now() + std::chrono::seconds(2);
+                    while (!callbackEntered.load() &&
+                           std::chrono::steady_clock::now() < callbackDeadline)
+                    {
+                        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+                    }
+                    DJV_BROKER_REQUIRE(callbackEntered.load());
+
+                    std::atomic<bool> externalStopStarted(false);
+                    std::atomic<bool> externalStopReturned(false);
+                    std::thread stopper([&]
+                        {
+                            externalStopStarted = true;
+                            broker.stop();
+                            externalStopReturned = true;
+                        });
+                    while (!externalStopStarted.load())
+                    {
+                        std::this_thread::yield();
+                    }
+                    // Give the external caller time to claim join ownership
+                    // while the callback is deliberately held at the gate.
+                    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+                    releaseCallback = true;
+
+                    stopper.join();
+                    forwarder.join();
+                    DJV_BROKER_REQUIRE(callbackStopReturned.load());
+                    DJV_BROKER_REQUIRE(externalStopReturned.load());
+                    DJV_BROKER_REQUIRE(!broker.isRunning());
+                    DJV_BROKER_REQUIRE(
+                        app::WindowsOpenForwardStatus::Forwarded ==
+                            forwardResult.status ||
+                        app::WindowsOpenForwardStatus::DeliveryUnknown ==
+                            forwardResult.status ||
+                        app::WindowsOpenForwardStatus::IOError ==
+                            forwardResult.status);
+
+                    // Idempotence remains true after the concurrent cleanup.
+                    broker.stop();
+                }
+            }
+
+            void callbackDestructionTest()
+            {
+                app::WindowsOpenBrokerOptions options;
+                options.applicationId = uniqueApplicationId("callback-destroy");
+                options.connectTimeout = std::chrono::seconds(1);
+                options.ioTimeout = std::chrono::seconds(1);
+                options.startTimeout = std::chrono::seconds(1);
+
+                std::atomic<app::WindowsOpenBroker*> broker(
+                    new app::WindowsOpenBroker(options));
+                std::atomic<bool> destroyed(false);
+                DJV_BROKER_REQUIRE(broker.load()->start(
+                    [&broker, &destroyed](
+                        const std::vector<std::string>&,
+                        std::string&)
+                    {
+                        app::WindowsOpenBroker* value = broker.exchange(nullptr);
+                        delete value;
+                        destroyed = true;
+                        return true;
+                    }));
+
+                const auto result = app::WindowsOpenBroker::forward(
+                    { "destroy-from-callback.mov" },
+                    wideToUtf8(getTempPath()),
+                    options);
+                const auto deadline =
+                    std::chrono::steady_clock::now() + std::chrono::seconds(2);
+                while (!destroyed.load() &&
+                       std::chrono::steady_clock::now() < deadline)
+                {
+                    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+                }
+                DJV_BROKER_REQUIRE(destroyed.load());
+                DJV_BROKER_REQUIRE(nullptr == broker.load());
+                DJV_BROKER_REQUIRE(
+                    app::WindowsOpenForwardStatus::Forwarded == result.status ||
+                    app::WindowsOpenForwardStatus::DeliveryUnknown == result.status);
+                // The detached worker owns its state until run() exits. Reaching
+                // this point proves no joinable-thread terminate/use-after-free.
+                std::this_thread::sleep_for(std::chrono::milliseconds(50));
+            }
+
+#if defined(DJV_WINDOWS_OPEN_BROKER_TESTING)
+            std::atomic<bool> failStopObserved(false);
+
+            bool failRevertToSelf()
+            {
+                ::SetLastError(ERROR_ACCESS_DENIED);
+                return false;
+            }
+
+            void throwFromFailStop(const std::string& message)
+            {
+                failStopObserved = true;
+                throw std::runtime_error(std::string("test fail-stop: ") + message);
+            }
+
+            void revertFailureFailStopTest()
+            {
+                app::WindowsOpenBrokerOptions options;
+                options.applicationId = uniqueApplicationId("revert-fail-stop");
+                options.connectTimeout = std::chrono::seconds(1);
+                options.ioTimeout = std::chrono::seconds(1);
+                options.startTimeout = std::chrono::seconds(1);
+
+                failStopObserved = false;
+                app::setWindowsOpenBrokerSecurityTestHooks(
+                    failRevertToSelf, throwFromFailStop);
+                app::WindowsOpenBroker broker(options);
+                DJV_BROKER_REQUIRE(broker.start(
+                    [](const std::vector<std::string>&, std::string&)
+                    {
+                        return true;
+                    }));
+                const auto result = app::WindowsOpenBroker::forward(
+                    { "must-not-reach-callback.mov" },
+                    wideToUtf8(getTempPath()),
+                    options);
+                const auto deadline =
+                    std::chrono::steady_clock::now() + std::chrono::seconds(2);
+                while (broker.isRunning() &&
+                       std::chrono::steady_clock::now() < deadline)
+                {
+                    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+                }
+                broker.stop();
+                app::setWindowsOpenBrokerSecurityTestHooks(nullptr, nullptr);
+
+                DJV_BROKER_REQUIRE(!result);
+                DJV_BROKER_REQUIRE(failStopObserved.load());
+                DJV_BROKER_REQUIRE(std::string::npos !=
+                    broker.getLastError().find("RevertToSelf"));
+            }
+#endif // DJV_WINDOWS_OPEN_BROKER_TESTING
+#endif // _WIN32
+        }
+
+        int runWindowsOpenBrokerTests()
+        {
+            try
+            {
+#if defined(_WIN32)
+                normalizationTest();
+                std::cout << "[PASS] UTF-8 and relative path normalization\n";
+                identityAndRoundTripTest();
+                std::cout << "[PASS] identity, DACL, ACK/NACK, malformed bounds\n";
+                boundedStopTest();
+                std::cout << "[PASS] bounded cancellation and clean stop\n";
+                concurrentStopTest();
+                std::cout << "[PASS] concurrent external/callback stop is race-safe\n";
+                callbackDestructionTest();
+                std::cout << "[PASS] callback-triggered destruction is lifetime-safe\n";
+#if defined(DJV_WINDOWS_OPEN_BROKER_TESTING)
+                revertFailureFailStopTest();
+                std::cout << "[PASS] RevertToSelf failure takes the fail-stop path\n";
+#endif // DJV_WINDOWS_OPEN_BROKER_TESTING
+#else // _WIN32
+                app::WindowsOpenBroker broker;
+                const auto result = broker.start(
+                    [](const std::vector<std::string>&, std::string&)
+                    {
+                        return true;
+                    });
+                DJV_BROKER_REQUIRE(
+                    app::WindowsOpenBrokerStartStatus::Unsupported == result.status);
+                std::cout << "[PASS] non-Windows unsupported stub\n";
+#endif // _WIN32
+                return 0;
+            }
+            catch (const std::exception& exception)
+            {
+                std::cerr << "[FAIL] " << exception.what() << '\n';
+                return 1;
+            }
+        }
+    }
+}
+
+#if defined(DJV_WINDOWS_OPEN_BROKER_TEST_MAIN)
+int main()
+{
+    return djv::app_tests::runWindowsOpenBrokerTests();
+}
+#endif

--- a/lib/djv/AppTest/WindowsOpenBrokerTest.h
+++ b/lib/djv/AppTest/WindowsOpenBrokerTest.h
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the DJV project.
+
+#pragma once
+
+namespace djv
+{
+    namespace app_tests
+    {
+        //! Run the dependency-free Windows open-broker regression suite.
+        //!
+        //! Returns zero on success and a non-zero value on failure. Defining
+        //! DJV_WINDOWS_OPEN_BROKER_TEST_MAIN builds this as a standalone test.
+        int runWindowsOpenBrokerTests();
+    }
+}

--- a/lib/djv/CMakeLists.txt
+++ b/lib/djv/CMakeLists.txt
@@ -4,5 +4,6 @@ add_subdirectory(Resource)
 add_subdirectory(UI)
 
 if(DJV_TESTS)
+    add_subdirectory(AppTest)
     add_subdirectory(ModelsTest)
 endif()


### PR DESCRIPTION
## Summary
- forward plain file-open requests from a second Windows process to the running DJV instance
- isolate the broker per user, logon session, and Windows session with a restricted named-pipe DACL
- bound request sizes, timeouts, queued UI work, and shutdown behavior
- keep command-line invocations with extra options as independent processes

## Verification
- `djvWindowsOpenBrokerTest` passes on Windows (ACK/NACK, malformed payload bounds, DACL identity, cancellation, concurrent stop, callback destruction, and fail-stop security path)
- the complete `djvApp` C++ source set compiles with MSVC using the generated project and `BuildProjectReferences=false`
- `git diff --check` passes

## Notes
This is intentionally a draft because the normal full build is currently blocked earlier in unmodified tlRender `Core/Time.cpp` by the local OpenTimelineIO/nlohmann dependency combination. The focused broker test and DJV application compilation both pass.