### PR TITLE
Add editable OTIO playlists with bounded folder import, CLI, and optional live watch

### DIFF
--- a/docs/otio-playlist.md
+++ b/docs/otio-playlist.md
@@ -12,10 +12,40 @@ editor.
 - In the **OTIO Playlist** tool, add files or a filtered folder, drag items to
   reorder them, remove items, and save or save as `.otio`.
 
-Folder filters are case-insensitive regular-expression terms. Prefix a term
-with `-` to exclude it and target `name:`, `dir:`, or `path:`. Folder imports
-are sorted deterministically, do not follow directory symlinks, and stop at
-hard depth, entry, and result limits.
+Folder filters are compiled case-insensitive regular-expression terms. Prefix
+a term with `-` to exclude it and target `name:`, `ext:`, `dir:`, or `path:`.
+Folder imports are sorted deterministically, stay confined to the selected
+root, skip directory links by default, and fail atomically at hard traversal
+or result limits rather than publishing a partial playlist. Scanning runs on
+an owned cancellable worker so a slow folder does not block the UI.
+
+## Command line and Windows batch
+
+Create the playlist on demand while DJV starts:
+
+```console
+djv -playlistFolder . -playlistFilter "ext:^(mov|mp4)$ -dir:(cache|proxy)"
+```
+
+The generated playlist opens in DJV immediately. Add
+`-playlistOutput review.otio` to save it, `-playlistTopLevel` to scan only the
+folder root, or `-playlistFrames` to keep numbered image frames separate.
+Normal playback options can be combined with the playlist options:
+
+```console
+djv -playlistFolder . -playlistFilter "ext:^mov$" -playback Forward -loop Loop
+```
+
+On Windows, `etc\Windows\djv-playlist-folder.bat` uses the current directory as
+the playlist root and forwards additional options:
+
+```bat
+set "DJV_EXE=C:\path\to\djv.exe"
+C:\path\to\DJV\etc\Windows\djv-playlist-folder.bat -playlistOutput review.otio
+```
+
+This is a fresh, dynamic construction at launch, not a persistent filesystem
+watcher: rerun the command to include later folder changes.
 
 ## Supported editable subset
 
@@ -24,8 +54,9 @@ hard depth, entry, and result limits.
   item.
 - Add, remove, and reorder media while preserving matching audio or silence.
 - Save to `.otio`; a scratch playlist requires Save As before its first save.
-- Numbered still-image paths are imported as separate one-frame clips rather
-  than automatically grouped into an image sequence.
+- Numbered still-image paths added directly remain separate one-frame clips.
+  Folder imports collapse eligible sequences by default; the
+  `-playlistFrames` command-line flag keeps every frame separate.
 
 ## Read-only timelines
 
@@ -37,5 +68,8 @@ The model exposes the reason so the UI can communicate the editing boundary.
 ## Verification
 
 `djvPlaylistModelTest` checks item order, aligned audio/gaps, round-trip OTIO
-serialization, image-sequence handling, read-only complex timelines, filtered
-folder selection, and folder scan limits.
+serialization, image-sequence handling, read-only complex timelines, and
+filtered folder selection. `djvFileFilterTest` and
+`djvFolderScanServiceTest` cover bounded parsing, root confinement,
+deterministic traversal, sequence collapsing, cancellation, queue saturation,
+and atomic limit failures.

--- a/docs/otio-playlist.md
+++ b/docs/otio-playlist.md
@@ -29,7 +29,27 @@ djv -playlistFolder . -playlistFilter "ext:^(mov|mp4)$ -dir:(cache|proxy)"
 
 The generated playlist opens in DJV immediately. Add
 `-playlistOutput review.otio` to save it, `-playlistTopLevel` to scan only the
-folder root, or `-playlistFrames` to keep numbered image frames separate.
+folder root, or `-playlistFrames` to keep numbered image frames separate. Add
+`-playlistWatch` to keep rescanning the folder while DJV is open:
+
+```console
+djv -playlistFolder . -playlistWatch -playlistOutput review.otio
+```
+
+Watch mode performs a bounded background rescan about every two seconds. It
+rebuilds the same playlist tab only when a matching file path, size, or
+modification time changes. Changes to individual frames are detected even when
+an image sequence is collapsed to one playlist item. A saved playlist,
+including one selected with `-playlistOutput`, is rewritten after each
+successful refresh.
+
+The watched playlist is not replaced while another playlist is active; the
+pending change is applied after the watched playlist becomes active again.
+Closing the watched playlist stops its watcher. If the folder temporarily has
+no matching media, DJV keeps the last playable playlist and continues watching
+for media to return. Watch mode owns playlist membership, so manual edits may
+be replaced after the next folder change.
+
 Normal playback options can be combined with the playlist options:
 
 ```console
@@ -41,11 +61,12 @@ the playlist root and forwards additional options:
 
 ```bat
 set "DJV_EXE=C:\path\to\djv.exe"
-C:\path\to\DJV\etc\Windows\djv-playlist-folder.bat -playlistOutput review.otio
+C:\path\to\DJV\etc\Windows\djv-playlist-folder.bat -playlistWatch -playlistOutput review.otio
 ```
 
-This is a fresh, dynamic construction at launch, not a persistent filesystem
-watcher: rerun the command to include later folder changes.
+Without `-playlistWatch`, the command performs one fresh scan at launch.
+The watcher lives inside DJV and stops when DJV exits; the batch file does not
+leave a separate background process running.
 
 ## Supported editable subset
 
@@ -71,5 +92,5 @@ The model exposes the reason so the UI can communicate the editing boundary.
 serialization, image-sequence handling, read-only complex timelines, and
 filtered folder selection. `djvFileFilterTest` and
 `djvFolderScanServiceTest` cover bounded parsing, root confinement,
-deterministic traversal, sequence collapsing, cancellation, queue saturation,
-and atomic limit failures.
+deterministic traversal, metadata change detection before sequence collapsing,
+cancellation, queue saturation, and atomic limit failures.

--- a/docs/otio-playlist.md
+++ b/docs/otio-playlist.md
@@ -1,0 +1,41 @@
+# Editable OTIO Playlist Model
+
+`PlaylistModel` provides the core editable OTIO playlist contract for DJV.
+It is designed for the existing player and timeline, not as a general OTIO
+editor.
+
+## User workflow
+
+- Use **File > New OTIO Playlist** to start from one image or video.
+- Use **File > New OTIO Playlist from Folder** to build a playlist from
+  recursively discovered media before it is loaded.
+- In the **OTIO Playlist** tool, add files or a filtered folder, drag items to
+  reorder them, remove items, and save or save as `.otio`.
+
+Folder filters are case-insensitive regular-expression terms. Prefix a term
+with `-` to exclude it and target `name:`, `dir:`, or `path:`. Folder imports
+are sorted deterministically, do not follow directory symlinks, and stop at
+hard depth, entry, and result limits.
+
+## Supported editable subset
+
+- One video track containing clips.
+- Optionally, one aligned audio track containing a clip or gap for every video
+  item.
+- Add, remove, and reorder media while preserving matching audio or silence.
+- Save to `.otio`; a scratch playlist requires Save As before its first save.
+- Numbered still-image paths are imported as separate one-frame clips rather
+  than automatically grouped into an image sequence.
+
+## Read-only timelines
+
+DJV retains complex OTIO timelines for playback and Save As, but never flattens
+them to make them editable. Multiple video tracks, nested compositions,
+transitions, unaligned audio, and packaged `.otioz` timelines are read-only.
+The model exposes the reason so the UI can communicate the editing boundary.
+
+## Verification
+
+`djvPlaylistModelTest` checks item order, aligned audio/gaps, round-trip OTIO
+serialization, image-sequence handling, read-only complex timelines, filtered
+folder selection, and folder scan limits.

--- a/etc/Windows/djv-playlist-folder.bat
+++ b/etc/Windows/djv-playlist-folder.bat
@@ -1,0 +1,7 @@
+@echo off
+setlocal
+
+if not defined DJV_EXE set "DJV_EXE=djv"
+
+"%DJV_EXE%" -playlistFolder "%CD%" %*
+exit /b %ERRORLEVEL%

--- a/lib/djv/App/App.cpp
+++ b/lib/djv/App/App.cpp
@@ -10,6 +10,7 @@
 #include <djv/App/DiagTool.h>
 #include <djv/App/ExportTool.h>
 #include <djv/App/FilesTool.h>
+#include <djv/App/FolderScanService.h>
 #include <djv/App/InfoTool.h>
 #include <djv/App/MagnifyTool.h>
 #include <djv/App/MainWindow.h>
@@ -60,6 +61,7 @@
 
 #include <chrono>
 #include <filesystem>
+#include <future>
 #include <optional>
 
 namespace djv
@@ -82,6 +84,11 @@ namespace djv
             std::shared_ptr<ftk::CmdLineOption<std::string> > seek;
             std::shared_ptr<ftk::CmdLineOption<std::string> > inPoint;
             std::shared_ptr<ftk::CmdLineOption<std::string> > outPoint;
+            std::shared_ptr<ftk::CmdLineOption<std::string> > playlistFolder;
+            std::shared_ptr<ftk::CmdLineOption<std::string> > playlistFilter;
+            std::shared_ptr<ftk::CmdLineFlag> playlistTopLevel;
+            std::shared_ptr<ftk::CmdLineFlag> playlistFrames;
+            std::shared_ptr<ftk::CmdLineOption<std::string> > playlistOutput;
             std::shared_ptr<ftk::CmdLineOption<std::string> > ocioFileName;
             std::shared_ptr<ftk::CmdLineOption<std::string> > ocioInput;
             std::shared_ptr<ftk::CmdLineOption<std::string> > ocioDisplay;
@@ -177,6 +184,12 @@ namespace djv
             std::shared_ptr<SecondaryWindow> secondaryWindow;
             std::shared_ptr<ui::SeparateAudioDialog> separateAudioDialog;
             std::shared_ptr<ui::OpenFolderFilterDialog> playlistFolderDialog;
+
+            std::unique_ptr<FolderScanService> folderScanService;
+            FolderScanServiceRequest folderScanRequest;
+            std::shared_ptr<ftk::Timer> folderScanTimer;
+            bool folderScanCreatePlaylist = true;
+            ftk::Path folderScanOutputPath;
 
             std::shared_ptr<ftk::Observer<tl::PlayerCacheOptions> > cacheObserver;
             std::shared_ptr<ftk::Observer<models::ImageSeqSettings> > imageSeqObserver;
@@ -287,6 +300,29 @@ namespace djv
                 { "-outPoint", "-out" },
                 "Set the out point.",
                 "Playback");
+            p.cmdLine.playlistFolder =
+                ftk::CmdLineOption<std::string>::create(
+                    { "-playlistFolder" },
+                    "Create an OTIO playlist from matching media below a folder.",
+                    "OTIO Playlist");
+            p.cmdLine.playlistFilter =
+                ftk::CmdLineOption<std::string>::create(
+                    { "-playlistFilter" },
+                    "Filter expression for -playlistFolder.",
+                    "OTIO Playlist");
+            p.cmdLine.playlistTopLevel = ftk::CmdLineFlag::create(
+                { "-playlistTopLevel" },
+                "Do not recurse into subfolders for -playlistFolder.",
+                "OTIO Playlist");
+            p.cmdLine.playlistFrames = ftk::CmdLineFlag::create(
+                { "-playlistFrames" },
+                "Keep numbered image frames separate instead of collapsing sequences.",
+                "OTIO Playlist");
+            p.cmdLine.playlistOutput =
+                ftk::CmdLineOption<std::string>::create(
+                    { "-playlistOutput" },
+                    "Save the generated playlist to an .otio file.",
+                    "OTIO Playlist");
             p.cmdLine.ocioFileName = ftk::CmdLineOption<std::string>::create(
                 { "-ocio" },
                 "OCIO configuration file name (e.g., config.ocio).",
@@ -426,6 +462,11 @@ namespace djv
                     p.cmdLine.frameRange,
                     p.cmdLine.inPoint,
                     p.cmdLine.outPoint,
+                    p.cmdLine.playlistFolder,
+                    p.cmdLine.playlistFilter,
+                    p.cmdLine.playlistTopLevel,
+                    p.cmdLine.playlistFrames,
+                    p.cmdLine.playlistOutput,
                     p.cmdLine.ocioFileName,
                     p.cmdLine.ocioInput,
                     p.cmdLine.ocioDisplay,
@@ -462,7 +503,21 @@ namespace djv
         {}
 
         App::~App()
-        {}
+        {
+            FTK_P();
+            if (p.folderScanTimer)
+            {
+                p.folderScanTimer->stop();
+            }
+            if (p.folderScanService)
+            {
+                if (p.folderScanRequest)
+                {
+                    p.folderScanService->cancel(p.folderScanRequest.id);
+                }
+                p.folderScanService->shutdown();
+            }
+        }
 
         std::shared_ptr<App> App::create(
             const std::shared_ptr<ftk::Context>& context,
@@ -607,6 +662,10 @@ namespace djv
         void App::openPlaylistFolderDialog(bool createPlaylist)
         {
             FTK_P();
+            if (p.folderScanRequest)
+            {
+                return;
+            }
             p.playlistFolderDialog =
                 ui::OpenFolderFilterDialog::create(_context);
             p.playlistFolderDialog->setFilterPresets(
@@ -616,70 +675,22 @@ namespace djv
                     const ftk::Path& folder,
                     const std::string& filter)
                 {
-                    FTK_P();
-                    models::FileScanOptions options;
-                    auto extensions = tl::getExts(_context);
-                    extensions.erase(
-                        std::remove_if(
-                            extensions.begin(),
-                            extensions.end(),
-                            [](const std::string& value)
-                            {
-                                const std::string extension =
-                                    ftk::toLower(value);
-                                return
-                                    ".otio" == extension ||
-                                    ".otioz" == extension;
-                            }),
-                        extensions.end());
-                    const auto result = models::scanFiles(
+                    _startPlaylistFolderScan(
                         folder,
                         filter,
-                        extensions,
-                        options);
-                    if (p.playlistFolderDialog)
-                    {
-                        p.playlistFolderDialog->close();
-                        p.playlistFolderDialog.reset();
-                    }
-                    if (!result.error.empty())
-                    {
-                        _context->log(
-                            "djv::app::App",
-                            result.error,
-                            ftk::LogType::Error);
-                        return;
-                    }
-                    if (result.paths.empty())
-                    {
-                        _context->log(
-                            "djv::app::App",
-                            "No matching media was found in the selected folder.",
-                            ftk::LogType::Warning);
-                        return;
-                    }
-                    if (result.truncated)
-                    {
-                        _context->log(
-                            "djv::app::App",
-                            "The playlist folder import reached its safety limit; only the bounded result set was imported.",
-                            ftk::LogType::Warning);
-                    }
-                    if (createPlaylist)
-                    {
-                        createPlaylistFromMedia(result.paths.front());
-                        addPlaylistMedia(std::vector<ftk::Path>(
-                            result.paths.begin() + 1,
-                            result.paths.end()));
-                    }
-                    else
-                    {
-                        addPlaylistMedia(result.paths);
-                    }
+                        createPlaylist,
+                        true,
+                        true);
                 });
             p.playlistFolderDialog->setCloseCallback(
                 [this]
                 {
+                    FTK_P();
+                    if (p.folderScanService && p.folderScanRequest)
+                    {
+                        p.folderScanService->cancel(
+                            p.folderScanRequest.id);
+                    }
                     _p->playlistFolderDialog.reset();
                 });
             p.playlistFolderDialog->open(p.mainWindow);
@@ -855,30 +866,7 @@ namespace djv
                 p.mainWindow,
                 [this](const ftk::Path& value)
                 {
-                    FTK_P();
-                    std::string error;
-                    if (p.playlistModel->save(value, &error))
-                    {
-                        if (auto item = p.filesModel->getA())
-                        {
-                            item->playlistDirty = false;
-                            item->playlistScratch = false;
-                            p.filesModel->setPath(
-                                item,
-                                p.playlistModel->getPath());
-                        }
-                        p.recentFilesModel->addRecent(
-                            std::filesystem::u8path(
-                                p.playlistModel->getPath().get()));
-                        _refreshPlaylistTimeline();
-                    }
-                    else if (!error.empty())
-                    {
-                        _context->log(
-                            "djv::app::App",
-                            error,
-                            ftk::LogType::Error);
-                    }
+                    _savePlaylistTo(value);
                 },
                 "Save OTIO Playlist As",
                 initialPath,
@@ -1713,6 +1701,24 @@ namespace djv
                     }
                 }
             }
+            if (p.cmdLine.playlistFolder->found())
+            {
+                const std::string filter =
+                    p.cmdLine.playlistFilter->found() ?
+                    p.cmdLine.playlistFilter->getValue() :
+                    std::string();
+                const ftk::Path outputPath =
+                    p.cmdLine.playlistOutput->found() ?
+                    ftk::Path(p.cmdLine.playlistOutput->getValue()) :
+                    ftk::Path();
+                _startPlaylistFolderScan(
+                    ftk::Path(p.cmdLine.playlistFolder->getValue()),
+                    filter,
+                    true,
+                    !p.cmdLine.playlistTopLevel->found(),
+                    !p.cmdLine.playlistFrames->found(),
+                    outputPath);
+            }
         }
 
         void App::_uiInit()
@@ -2077,6 +2083,289 @@ namespace djv
                 singleImages ? 0 : imageSeq.maxDigits;
             options.readThreadCount = imageSeq.readThreadCount;
             return options;
+        }
+
+        void App::_startPlaylistFolderScan(
+            const ftk::Path& folder,
+            const std::string& filterExpression,
+            bool createPlaylist,
+            bool recursive,
+            bool collapseSequences,
+            const ftk::Path& outputPath)
+        {
+            FTK_P();
+            if (p.folderScanRequest)
+            {
+                if (p.playlistFolderDialog)
+                {
+                    p.playlistFolderDialog->setStatus(
+                        "A folder scan is already running.");
+                }
+                return;
+            }
+
+            const auto filter =
+                models::compileFileFilter(filterExpression);
+            if (!filter)
+            {
+                const std::string message =
+                    filter.error.has_value() ?
+                    filter.error->message :
+                    "The folder filter is invalid.";
+                if (p.playlistFolderDialog)
+                {
+                    p.playlistFolderDialog->setStatus(message);
+                }
+                _context->log(
+                    "djv::app::FolderScan",
+                    message,
+                    ftk::LogType::Error);
+                return;
+            }
+
+            models::FolderScanOptions options;
+            options.recursive = recursive;
+            options.collapseSequences = collapseSequences;
+            options.sequenceMaxDigits =
+                p.settingsModel->getImageSeq().maxDigits;
+            options.sequenceExtensions = tl::getExts(
+                _context,
+                static_cast<int>(tl::FileType::Seq));
+            options.fileExtensions = tl::getExts(_context);
+            options.fileExtensions.erase(
+                std::remove_if(
+                    options.fileExtensions.begin(),
+                    options.fileExtensions.end(),
+                    [](const std::string& value)
+                    {
+                        const std::string extension =
+                            ftk::toLower(value);
+                        return
+                            ".otio" == extension ||
+                            ".otioz" == extension;
+                    }),
+                options.fileExtensions.end());
+            options.maxCandidates = 250000;
+            options.maxDirectoryEntries = 100000;
+            options.maxDirectories = 50000;
+            options.maxEntries = 250000;
+            options.maxResults = 500;
+            options.maxDepth = 64;
+            options.maxWarnings = 200;
+
+            if (!p.folderScanService)
+            {
+                p.folderScanService.reset(new FolderScanService);
+            }
+            p.folderScanCreatePlaylist = createPlaylist;
+            p.folderScanOutputPath = outputPath;
+            p.folderScanRequest = p.folderScanService->request(
+                std::filesystem::u8path(folder.get()),
+                filter.filter,
+                options);
+            if (!p.folderScanRequest)
+            {
+                const std::string message =
+                    "The folder scan could not be queued.";
+                if (p.playlistFolderDialog)
+                {
+                    p.playlistFolderDialog->setStatus(message);
+                }
+                _context->log(
+                    "djv::app::FolderScan",
+                    message,
+                    ftk::LogType::Error);
+                return;
+            }
+
+            if (p.playlistFolderDialog)
+            {
+                p.playlistFolderDialog->setBusy(
+                    true,
+                    "Scanning the folder. Cancel remains available.");
+            }
+            if (!p.folderScanTimer)
+            {
+                p.folderScanTimer = ftk::Timer::create(_context);
+                p.folderScanTimer->setRepeating(true);
+            }
+            p.folderScanTimer->start(
+                std::chrono::milliseconds(50),
+                [this] { _folderScanPoll(); });
+        }
+
+        void App::_folderScanPoll()
+        {
+            FTK_P();
+            if (!p.folderScanRequest ||
+                !p.folderScanRequest.future.valid() ||
+                std::future_status::ready !=
+                    p.folderScanRequest.future.wait_for(
+                        std::chrono::milliseconds(0)))
+            {
+                return;
+            }
+
+            FolderScanServiceResult result;
+            try
+            {
+                result = p.folderScanRequest.future.get();
+            }
+            catch (const std::exception& e)
+            {
+                result.status = FolderScanServiceStatus::Failed;
+                result.error = FolderScanServiceError::InternalError;
+                result.message =
+                    std::string("Folder scan failed: ") + e.what();
+            }
+            p.folderScanRequest = FolderScanServiceRequest();
+            if (p.folderScanTimer)
+            {
+                p.folderScanTimer->stop();
+            }
+            if (p.playlistFolderDialog)
+            {
+                p.playlistFolderDialog->setBusy(false);
+            }
+            _finishPlaylistFolderScan(result);
+        }
+
+        void App::_finishPlaylistFolderScan(
+            const FolderScanServiceResult& result)
+        {
+            FTK_P();
+            if (!result.isSuccess())
+            {
+                std::string message;
+                switch (result.error)
+                {
+                case FolderScanServiceError::Cancelled:
+                    message = "The folder scan was cancelled.";
+                    break;
+                case FolderScanServiceError::LimitReached:
+                    message =
+                        "A safety limit was reached. Narrow the filter or "
+                        "choose a smaller folder.";
+                    break;
+                case FolderScanServiceError::InvalidRoot:
+                    message = "The folder is not an accessible directory.";
+                    break;
+                case FolderScanServiceError::QueueFull:
+                    message = "The folder scan queue is full.";
+                    break;
+                default:
+                    message = "The folder scan failed.";
+                    break;
+                }
+                if (p.playlistFolderDialog)
+                {
+                    p.playlistFolderDialog->setStatus(message);
+                }
+                _context->log(
+                    "djv::app::FolderScan",
+                    result.message.empty() ? message : result.message,
+                    FolderScanServiceStatus::Cancelled == result.status ?
+                        ftk::LogType::Message :
+                        ftk::LogType::Error);
+                return;
+            }
+
+            for (const auto& warning : result.scanResult.warnings)
+            {
+                const std::string detail = warning.message.empty() ?
+                    warning.path.u8string() :
+                    ftk::Format("{0}: {1}").
+                        arg(warning.path.u8string()).
+                        arg(warning.message).
+                        str();
+                _context->log(
+                    "djv::app::FolderScan",
+                    detail,
+                    ftk::LogType::Warning);
+            }
+            if (result.scanResult.suppressedWarnings)
+            {
+                _context->log(
+                    "djv::app::FolderScan",
+                    ftk::Format("{0} additional folder scan warnings suppressed.").
+                        arg(result.scanResult.suppressedWarnings).
+                        str(),
+                    ftk::LogType::Warning);
+            }
+
+            if (result.scanResult.paths.empty())
+            {
+                const std::string message =
+                    "No matching media was found in the folder.";
+                if (p.playlistFolderDialog)
+                {
+                    p.playlistFolderDialog->setStatus(message);
+                }
+                _context->log(
+                    "djv::app::FolderScan",
+                    message,
+                    ftk::LogType::Warning);
+                return;
+            }
+
+            if (p.folderScanCreatePlaylist)
+            {
+                createPlaylistFromMedia(result.scanResult.paths.front());
+                if (!p.playlistModel->isAvailable())
+                {
+                    return;
+                }
+                if (result.scanResult.paths.size() > 1)
+                {
+                    addPlaylistMedia(std::vector<ftk::Path>(
+                        result.scanResult.paths.begin() + 1,
+                        result.scanResult.paths.end()));
+                }
+            }
+            else
+            {
+                addPlaylistMedia(result.scanResult.paths);
+            }
+
+            if (!p.folderScanOutputPath.isEmpty())
+            {
+                _savePlaylistTo(p.folderScanOutputPath);
+            }
+            if (p.playlistFolderDialog)
+            {
+                p.playlistFolderDialog->close();
+                p.playlistFolderDialog.reset();
+            }
+        }
+
+        bool App::_savePlaylistTo(const ftk::Path& value)
+        {
+            FTK_P();
+            std::string error;
+            if (p.playlistModel->save(value, &error))
+            {
+                if (auto item = p.filesModel->getA())
+                {
+                    item->playlistDirty = false;
+                    item->playlistScratch = false;
+                    p.filesModel->setPath(
+                        item,
+                        p.playlistModel->getPath());
+                }
+                p.recentFilesModel->addRecent(
+                    std::filesystem::u8path(
+                        p.playlistModel->getPath().get()));
+                _refreshPlaylistTimeline();
+                return true;
+            }
+            if (!error.empty())
+            {
+                _context->log(
+                    "djv::app::App",
+                    error,
+                    ftk::LogType::Error);
+            }
+            return false;
         }
 
         void App::_refreshPlaylistTimeline()

--- a/lib/djv/App/App.cpp
+++ b/lib/djv/App/App.cpp
@@ -60,6 +60,7 @@
 #include <ftk/Core/Timer.h>
 
 #include <chrono>
+#include <cstdint>
 #include <filesystem>
 #include <future>
 #include <optional>
@@ -88,6 +89,7 @@ namespace djv
             std::shared_ptr<ftk::CmdLineOption<std::string> > playlistFilter;
             std::shared_ptr<ftk::CmdLineFlag> playlistTopLevel;
             std::shared_ptr<ftk::CmdLineFlag> playlistFrames;
+            std::shared_ptr<ftk::CmdLineFlag> playlistWatch;
             std::shared_ptr<ftk::CmdLineOption<std::string> > playlistOutput;
             std::shared_ptr<ftk::CmdLineOption<std::string> > ocioFileName;
             std::shared_ptr<ftk::CmdLineOption<std::string> > ocioInput;
@@ -190,6 +192,15 @@ namespace djv
             std::shared_ptr<ftk::Timer> folderScanTimer;
             bool folderScanCreatePlaylist = true;
             ftk::Path folderScanOutputPath;
+            ftk::Path folderScanFolder;
+            std::shared_ptr<const models::CompiledFileFilter> folderScanFilter;
+            models::FolderScanOptions folderScanOptions;
+            bool folderScanWatch = false;
+            bool folderScanWatchHasSignature = false;
+            bool folderScanWatchPlaylistCreated = false;
+            uint64_t folderScanWatchSignature = 0;
+            std::chrono::steady_clock::time_point folderScanWatchNext;
+            std::weak_ptr<models::FilesModelItem> folderScanWatchItem;
 
             std::shared_ptr<ftk::Observer<tl::PlayerCacheOptions> > cacheObserver;
             std::shared_ptr<ftk::Observer<models::ImageSeqSettings> > imageSeqObserver;
@@ -317,6 +328,10 @@ namespace djv
             p.cmdLine.playlistFrames = ftk::CmdLineFlag::create(
                 { "-playlistFrames" },
                 "Keep numbered image frames separate instead of collapsing sequences.",
+                "OTIO Playlist");
+            p.cmdLine.playlistWatch = ftk::CmdLineFlag::create(
+                { "-playlistWatch" },
+                "Keep the folder playlist synchronized while DJV is running.",
                 "OTIO Playlist");
             p.cmdLine.playlistOutput =
                 ftk::CmdLineOption<std::string>::create(
@@ -466,6 +481,7 @@ namespace djv
                     p.cmdLine.playlistFilter,
                     p.cmdLine.playlistTopLevel,
                     p.cmdLine.playlistFrames,
+                    p.cmdLine.playlistWatch,
                     p.cmdLine.playlistOutput,
                     p.cmdLine.ocioFileName,
                     p.cmdLine.ocioInput,
@@ -1717,7 +1733,8 @@ namespace djv
                     true,
                     !p.cmdLine.playlistTopLevel->found(),
                     !p.cmdLine.playlistFrames->found(),
-                    outputPath);
+                    outputPath,
+                    p.cmdLine.playlistWatch->found());
             }
         }
 
@@ -2091,7 +2108,8 @@ namespace djv
             bool createPlaylist,
             bool recursive,
             bool collapseSequences,
-            const ftk::Path& outputPath)
+            const ftk::Path& outputPath,
+            bool watch)
         {
             FTK_P();
             if (p.folderScanRequest)
@@ -2159,22 +2177,17 @@ namespace djv
             }
             p.folderScanCreatePlaylist = createPlaylist;
             p.folderScanOutputPath = outputPath;
-            p.folderScanRequest = p.folderScanService->request(
-                std::filesystem::u8path(folder.get()),
-                filter.filter,
-                options);
-            if (!p.folderScanRequest)
+            p.folderScanFolder = folder;
+            p.folderScanFilter = filter.filter;
+            p.folderScanOptions = options;
+            p.folderScanWatch = watch && createPlaylist;
+            p.folderScanWatchHasSignature = false;
+            p.folderScanWatchPlaylistCreated = false;
+            p.folderScanWatchSignature = 0;
+            p.folderScanWatchItem.reset();
+            if (!_queuePlaylistFolderScan())
             {
-                const std::string message =
-                    "The folder scan could not be queued.";
-                if (p.playlistFolderDialog)
-                {
-                    p.playlistFolderDialog->setStatus(message);
-                }
-                _context->log(
-                    "djv::app::FolderScan",
-                    message,
-                    ftk::LogType::Error);
+                p.folderScanWatch = false;
                 return;
             }
 
@@ -2190,15 +2203,76 @@ namespace djv
                 p.folderScanTimer->setRepeating(true);
             }
             p.folderScanTimer->start(
-                std::chrono::milliseconds(50),
+                std::chrono::milliseconds(100),
                 [this] { _folderScanPoll(); });
+        }
+
+        bool App::_queuePlaylistFolderScan()
+        {
+            FTK_P();
+            if (!p.folderScanService ||
+                !p.folderScanFilter ||
+                p.folderScanRequest)
+            {
+                return false;
+            }
+            p.folderScanRequest = p.folderScanService->request(
+                std::filesystem::u8path(p.folderScanFolder.get()),
+                p.folderScanFilter,
+                p.folderScanOptions);
+            if (p.folderScanRequest)
+            {
+                return true;
+            }
+
+            const std::string message =
+                "The folder scan could not be queued.";
+            if (p.playlistFolderDialog)
+            {
+                p.playlistFolderDialog->setStatus(message);
+            }
+            _context->log(
+                "djv::app::FolderScan",
+                message,
+                ftk::LogType::Error);
+            return false;
         }
 
         void App::_folderScanPoll()
         {
             FTK_P();
-            if (!p.folderScanRequest ||
-                !p.folderScanRequest.future.valid() ||
+            if (!p.folderScanRequest)
+            {
+                if (!p.folderScanWatch)
+                {
+                    return;
+                }
+                if (p.folderScanWatchPlaylistCreated)
+                {
+                    const auto item = p.folderScanWatchItem.lock();
+                    if (!item ||
+                        p.files.end() ==
+                            std::find(p.files.begin(), p.files.end(), item))
+                    {
+                        _stopPlaylistFolderWatch(
+                            "Folder playlist watching stopped because its "
+                            "playlist was closed.");
+                        return;
+                    }
+                }
+                if (std::chrono::steady_clock::now() >=
+                    p.folderScanWatchNext)
+                {
+                    if (!_queuePlaylistFolderScan())
+                    {
+                        p.folderScanWatchNext =
+                            std::chrono::steady_clock::now() +
+                            std::chrono::seconds(2);
+                    }
+                }
+                return;
+            }
+            if (!p.folderScanRequest.future.valid() ||
                 std::future_status::ready !=
                     p.folderScanRequest.future.wait_for(
                         std::chrono::milliseconds(0)))
@@ -2219,15 +2293,21 @@ namespace djv
                     std::string("Folder scan failed: ") + e.what();
             }
             p.folderScanRequest = FolderScanServiceRequest();
-            if (p.folderScanTimer)
-            {
-                p.folderScanTimer->stop();
-            }
             if (p.playlistFolderDialog)
             {
                 p.playlistFolderDialog->setBusy(false);
             }
             _finishPlaylistFolderScan(result);
+            if (p.folderScanWatch)
+            {
+                p.folderScanWatchNext =
+                    std::chrono::steady_clock::now() +
+                    std::chrono::seconds(2);
+            }
+            else if (p.folderScanTimer)
+            {
+                p.folderScanTimer->stop();
+            }
         }
 
         void App::_finishPlaylistFolderScan(
@@ -2270,6 +2350,14 @@ namespace djv
                 return;
             }
 
+            if (p.folderScanWatch &&
+                p.folderScanWatchHasSignature &&
+                p.folderScanWatchSignature ==
+                    result.scanResult.contentSignature)
+            {
+                return;
+            }
+
             for (const auto& warning : result.scanResult.warnings)
             {
                 const std::string detail = warning.message.empty() ?
@@ -2295,7 +2383,9 @@ namespace djv
 
             if (result.scanResult.paths.empty())
             {
-                const std::string message =
+                const std::string message = p.folderScanWatch ?
+                    "No matching media was found. Folder watching remains "
+                    "active and the last playable playlist is kept." :
                     "No matching media was found in the folder.";
                 if (p.playlistFolderDialog)
                 {
@@ -2305,36 +2395,183 @@ namespace djv
                     "djv::app::FolderScan",
                     message,
                     ftk::LogType::Warning);
+                if (p.folderScanWatch)
+                {
+                    p.folderScanWatchSignature =
+                        result.scanResult.contentSignature;
+                    p.folderScanWatchHasSignature = true;
+                }
                 return;
             }
 
-            if (p.folderScanCreatePlaylist)
+            bool applied = true;
+            bool outputHandled = false;
+            if (p.folderScanWatch &&
+                p.folderScanWatchPlaylistCreated)
             {
-                createPlaylistFromMedia(result.scanResult.paths.front());
-                if (!p.playlistModel->isAvailable())
+                const auto item = p.folderScanWatchItem.lock();
+                if (!item ||
+                    p.files.end() ==
+                        std::find(p.files.begin(), p.files.end(), item))
                 {
+                    _stopPlaylistFolderWatch(
+                        "Folder playlist watching stopped because its "
+                        "playlist was closed.");
                     return;
                 }
-                if (result.scanResult.paths.size() > 1)
+                if (p.filesModel->getA() != item)
                 {
-                    addPlaylistMedia(std::vector<ftk::Path>(
-                        result.scanResult.paths.begin() + 1,
-                        result.scanResult.paths.end()));
+                    // Do not replace a different active playlist. The changed
+                    // signature is deliberately left unapplied so the watcher
+                    // retries when its own playlist becomes active again.
+                    return;
                 }
+                applied = _replaceWatchedPlaylist(
+                    result.scanResult.paths);
+                outputHandled = true;
             }
             else
             {
-                addPlaylistMedia(result.scanResult.paths);
+                const auto previousItem = p.filesModel->getA();
+                if (p.folderScanCreatePlaylist)
+                {
+                    createPlaylistFromMedia(
+                        result.scanResult.paths.front());
+                    const auto item = p.filesModel->getA();
+                    if (!p.playlistModel->isAvailable() ||
+                        !item ||
+                        item == previousItem)
+                    {
+                        return;
+                    }
+                    if (result.scanResult.paths.size() > 1)
+                    {
+                        addPlaylistMedia(std::vector<ftk::Path>(
+                            result.scanResult.paths.begin() + 1,
+                            result.scanResult.paths.end()));
+                    }
+                    applied =
+                        p.playlistModel->getItems().size() ==
+                        result.scanResult.paths.size();
+                    if (p.folderScanWatch)
+                    {
+                        p.folderScanWatchItem = item;
+                        p.folderScanWatchPlaylistCreated = true;
+                    }
+                }
+                else
+                {
+                    addPlaylistMedia(result.scanResult.paths);
+                }
             }
 
-            if (!p.folderScanOutputPath.isEmpty())
+            if (!outputHandled &&
+                !p.folderScanOutputPath.isEmpty())
             {
-                _savePlaylistTo(p.folderScanOutputPath);
+                applied = _savePlaylistTo(
+                    p.folderScanOutputPath) && applied;
+            }
+            if (p.folderScanWatch && applied)
+            {
+                p.folderScanWatchSignature =
+                    result.scanResult.contentSignature;
+                p.folderScanWatchHasSignature = true;
             }
             if (p.playlistFolderDialog)
             {
                 p.playlistFolderDialog->close();
                 p.playlistFolderDialog.reset();
+            }
+        }
+
+        bool App::_replaceWatchedPlaylist(
+            const std::vector<ftk::Path>& paths)
+        {
+            FTK_P();
+            const auto item = p.folderScanWatchItem.lock();
+            if (!item ||
+                paths.empty() ||
+                p.filesModel->getA() != item)
+            {
+                return false;
+            }
+
+            const ftk::Path playlistPath = item->path;
+            const bool savePlaylist =
+                !p.folderScanOutputPath.isEmpty() ||
+                !item->playlistScratch;
+            std::string error;
+            if (!p.playlistModel->createFromMedia(
+                _context,
+                paths.front(),
+                paths.front(),
+                playlistPath,
+                _getTimelineOptions(true),
+                &error))
+            {
+                if (!error.empty())
+                {
+                    _context->log(
+                        "djv::app::FolderScan",
+                        error,
+                        ftk::LogType::Error);
+                }
+                return false;
+            }
+            for (auto i = paths.begin() + 1;
+                i != paths.end(); ++i)
+            {
+                error.clear();
+                if (!p.playlistModel->addMedia(
+                    _context,
+                    *i,
+                    *i,
+                    _getTimelineOptions(true),
+                    &error))
+                {
+                    if (!error.empty())
+                    {
+                        _context->log(
+                            "djv::app::FolderScan",
+                            error,
+                            ftk::LogType::Error);
+                    }
+                    return false;
+                }
+            }
+
+            if (savePlaylist)
+            {
+                const ftk::Path path =
+                    !p.folderScanOutputPath.isEmpty() ?
+                    p.folderScanOutputPath :
+                    playlistPath;
+                return _savePlaylistTo(path);
+            }
+            item->playlistDirty = true;
+            item->playlistScratch = true;
+            _refreshPlaylistTimeline();
+            return true;
+        }
+
+        void App::_stopPlaylistFolderWatch(
+            const std::string& message)
+        {
+            FTK_P();
+            p.folderScanWatch = false;
+            p.folderScanWatchHasSignature = false;
+            p.folderScanWatchPlaylistCreated = false;
+            p.folderScanWatchItem.reset();
+            if (p.folderScanTimer)
+            {
+                p.folderScanTimer->stop();
+            }
+            if (!message.empty())
+            {
+                _context->log(
+                    "djv::app::FolderScan",
+                    message,
+                    ftk::LogType::Message);
             }
         }
 

--- a/lib/djv/App/App.cpp
+++ b/lib/djv/App/App.cpp
@@ -14,6 +14,7 @@
 #include <djv/App/MagnifyTool.h>
 #include <djv/App/MainWindow.h>
 #include <djv/App/MessagesTool.h>
+#include <djv/App/PlaylistTool.h>
 #include <djv/App/SecondaryWindow.h>
 #include <djv/App/SettingsTool.h>
 #include <djv/App/StatusBar.h>
@@ -21,10 +22,13 @@
 #include <djv/App/ViewTool.h>
 #include <djv/App/Viewport.h>
 #include <djv/UI/SeparateAudioDialog.h>
+#include <djv/UI/OpenFolderFilterDialog.h>
 #include <djv/Models/AppInfoModel.h>
 #include <djv/Models/AudioModel.h>
 #include <djv/Models/ColorModel.h>
+#include <djv/Models/FileFilter.h>
 #include <djv/Models/FilesModel.h>
+#include <djv/Models/PlaylistModel.h>
 #include <djv/Models/RecentFilesModel.h>
 #include <djv/Models/TimeUnitsModel.h>
 #include <djv/Models/CommandsModel.h>
@@ -54,6 +58,7 @@
 #include <ftk/Core/OS.h>
 #include <ftk/Core/Timer.h>
 
+#include <chrono>
 #include <filesystem>
 #include <optional>
 
@@ -153,6 +158,7 @@ namespace djv
             std::shared_ptr<ftk::SysLogModel> sysLogModel;
             std::shared_ptr<models::TimeUnitsModel> timeUnitsModel;
             std::shared_ptr<models::FilesModel> filesModel;
+            std::shared_ptr<models::PlaylistModel> playlistModel;
             std::vector<std::shared_ptr<models::FilesModelItem> > files;
             std::vector<std::shared_ptr<models::FilesModelItem> > activeFiles;
             std::shared_ptr<models::RecentFilesModel> recentFilesModel;
@@ -170,6 +176,7 @@ namespace djv
             std::shared_ptr<MainWindow> mainWindow;
             std::shared_ptr<SecondaryWindow> secondaryWindow;
             std::shared_ptr<ui::SeparateAudioDialog> separateAudioDialog;
+            std::shared_ptr<ui::OpenFolderFilterDialog> playlistFolderDialog;
 
             std::shared_ptr<ftk::Observer<tl::PlayerCacheOptions> > cacheObserver;
             std::shared_ptr<ftk::Observer<models::ImageSeqSettings> > imageSeqObserver;
@@ -497,6 +504,11 @@ namespace djv
             return _p->filesModel;
         }
 
+        const std::shared_ptr<models::PlaylistModel>& App::getPlaylistModel() const
+        {
+            return _p->playlistModel;
+        }
+
         const std::shared_ptr<models::RecentFilesModel>& App::getRecentFilesModel() const
         {
             return _p->recentFilesModel;
@@ -564,6 +576,313 @@ namespace djv
                 {
                     _p->separateAudioDialog.reset();
                 });
+        }
+
+        void App::openMediaAsPlaylistDialog()
+        {
+            FTK_P();
+            auto fileBrowserSystem = _context->getSystem<ftk::FileBrowserSystem>();
+            fileBrowserSystem->open(
+                p.mainWindow,
+                [this](const ftk::Path& value)
+                {
+                    createPlaylistFromMedia(value);
+                },
+                "Create OTIO Playlist");
+        }
+
+        void App::openPlaylistMediaDialog()
+        {
+            FTK_P();
+            auto fileBrowserSystem = _context->getSystem<ftk::FileBrowserSystem>();
+            fileBrowserSystem->open(
+                p.mainWindow,
+                [this](const ftk::Path& value)
+                {
+                    addPlaylistMedia({ value });
+                },
+                "Add Media to OTIO Playlist");
+        }
+
+        void App::openPlaylistFolderDialog(bool createPlaylist)
+        {
+            FTK_P();
+            p.playlistFolderDialog =
+                ui::OpenFolderFilterDialog::create(_context);
+            p.playlistFolderDialog->setFilterPresets(
+                models::getDefaultFileFilterPresets());
+            p.playlistFolderDialog->setCallback(
+                [this, createPlaylist](
+                    const ftk::Path& folder,
+                    const std::string& filter)
+                {
+                    FTK_P();
+                    models::FileScanOptions options;
+                    auto extensions = tl::getExts(_context);
+                    extensions.erase(
+                        std::remove_if(
+                            extensions.begin(),
+                            extensions.end(),
+                            [](const std::string& value)
+                            {
+                                const std::string extension =
+                                    ftk::toLower(value);
+                                return
+                                    ".otio" == extension ||
+                                    ".otioz" == extension;
+                            }),
+                        extensions.end());
+                    const auto result = models::scanFiles(
+                        folder,
+                        filter,
+                        extensions,
+                        options);
+                    if (p.playlistFolderDialog)
+                    {
+                        p.playlistFolderDialog->close();
+                        p.playlistFolderDialog.reset();
+                    }
+                    if (!result.error.empty())
+                    {
+                        _context->log(
+                            "djv::app::App",
+                            result.error,
+                            ftk::LogType::Error);
+                        return;
+                    }
+                    if (result.paths.empty())
+                    {
+                        _context->log(
+                            "djv::app::App",
+                            "No matching media was found in the selected folder.",
+                            ftk::LogType::Warning);
+                        return;
+                    }
+                    if (result.truncated)
+                    {
+                        _context->log(
+                            "djv::app::App",
+                            "The playlist folder import reached its safety limit; only the bounded result set was imported.",
+                            ftk::LogType::Warning);
+                    }
+                    if (createPlaylist)
+                    {
+                        createPlaylistFromMedia(result.paths.front());
+                        addPlaylistMedia(std::vector<ftk::Path>(
+                            result.paths.begin() + 1,
+                            result.paths.end()));
+                    }
+                    else
+                    {
+                        addPlaylistMedia(result.paths);
+                    }
+                });
+            p.playlistFolderDialog->setCloseCallback(
+                [this]
+                {
+                    _p->playlistFolderDialog.reset();
+                });
+            p.playlistFolderDialog->open(p.mainWindow);
+        }
+
+        void App::createPlaylistFromMedia(const ftk::Path& path)
+        {
+            FTK_P();
+            try
+            {
+                const std::filesystem::path scratchDirectory =
+                    std::filesystem::temp_directory_path() /
+                    "djv" /
+                    "playlists";
+                std::filesystem::create_directories(scratchDirectory);
+                const auto stamp = std::chrono::high_resolution_clock::now().
+                    time_since_epoch().count();
+                const ftk::Path scratchPath(
+                    (scratchDirectory /
+                        ftk::Format("Untitled-Playlist-{0}.otio").
+                        arg(stamp).
+                        str()).
+                    u8string());
+                std::string error;
+                if (!p.playlistModel->createFromMedia(
+                    _context,
+                    path,
+                    path,
+                    scratchPath,
+                    _getTimelineOptions(true),
+                    &error))
+                {
+                    throw std::runtime_error(error);
+                }
+                auto item = std::make_shared<models::FilesModelItem>();
+                item->path = scratchPath;
+                item->playlistDirty = true;
+                item->playlistScratch = true;
+                p.filesModel->add(item);
+                p.toolsModel->setActiveTool("OTIO Playlist");
+            }
+            catch (const std::exception& e)
+            {
+                _context->log(
+                    "djv::app::App",
+                    e.what(),
+                    ftk::LogType::Error);
+            }
+        }
+
+        void App::addPlaylistMedia(const std::vector<ftk::Path>& paths)
+        {
+            FTK_P();
+            bool changed = false;
+            for (const auto& path : paths)
+            {
+                std::string error;
+                if (p.playlistModel->addMedia(
+                    _context,
+                    path,
+                    path,
+                    _getTimelineOptions(true),
+                    &error))
+                {
+                    changed = true;
+                }
+                else if (!error.empty())
+                {
+                    _context->log(
+                        "djv::app::App",
+                        error,
+                        ftk::LogType::Error);
+                }
+            }
+            if (changed)
+            {
+                if (auto item = p.filesModel->getA())
+                {
+                    item->playlistDirty = true;
+                }
+                _refreshPlaylistTimeline();
+            }
+        }
+
+        void App::movePlaylistMedia(size_t from, size_t to)
+        {
+            FTK_P();
+            std::string error;
+            if (p.playlistModel->move(from, to, &error))
+            {
+                if (auto item = p.filesModel->getA())
+                {
+                    item->playlistDirty = true;
+                }
+                _refreshPlaylistTimeline();
+            }
+            else if (!error.empty())
+            {
+                _context->log(
+                    "djv::app::App",
+                    error,
+                    ftk::LogType::Error);
+            }
+        }
+
+        void App::removePlaylistMedia(size_t index)
+        {
+            FTK_P();
+            std::string error;
+            if (p.playlistModel->remove(index, &error))
+            {
+                if (auto item = p.filesModel->getA())
+                {
+                    item->playlistDirty = true;
+                }
+                _refreshPlaylistTimeline();
+            }
+            else if (!error.empty())
+            {
+                _context->log(
+                    "djv::app::App",
+                    error,
+                    ftk::LogType::Error);
+            }
+        }
+
+        void App::savePlaylist()
+        {
+            FTK_P();
+            if (!p.playlistModel->isAvailable())
+            {
+                return;
+            }
+            if (p.playlistModel->isScratch() ||
+                !p.playlistModel->isEditable())
+            {
+                savePlaylistAsDialog();
+                return;
+            }
+            std::string error;
+            if (p.playlistModel->save(p.playlistModel->getPath(), &error))
+            {
+                if (auto item = p.filesModel->getA())
+                {
+                    item->playlistDirty = false;
+                    item->playlistScratch = false;
+                }
+                _refreshPlaylistTimeline();
+            }
+            else if (!error.empty())
+            {
+                _context->log(
+                    "djv::app::App",
+                    error,
+                    ftk::LogType::Error);
+            }
+        }
+
+        void App::savePlaylistAsDialog()
+        {
+            FTK_P();
+            if (!p.playlistModel->isAvailable())
+            {
+                return;
+            }
+            const std::filesystem::path initialPath =
+                p.playlistModel->isScratch() ?
+                _appDocsPath() / "playlist.otio" :
+                std::filesystem::u8path(
+                    p.playlistModel->getPath().get());
+            auto fileBrowserSystem = _context->getSystem<ftk::FileBrowserSystem>();
+            fileBrowserSystem->open(
+                p.mainWindow,
+                [this](const ftk::Path& value)
+                {
+                    FTK_P();
+                    std::string error;
+                    if (p.playlistModel->save(value, &error))
+                    {
+                        if (auto item = p.filesModel->getA())
+                        {
+                            item->playlistDirty = false;
+                            item->playlistScratch = false;
+                            p.filesModel->setPath(
+                                item,
+                                p.playlistModel->getPath());
+                        }
+                        p.recentFilesModel->addRecent(
+                            std::filesystem::u8path(
+                                p.playlistModel->getPath().get()));
+                        _refreshPlaylistTimeline();
+                    }
+                    else if (!error.empty())
+                    {
+                        _context->log(
+                            "djv::app::App",
+                            error,
+                            ftk::LogType::Error);
+                    }
+                },
+                "Save OTIO Playlist As",
+                initialPath,
+                ftk::FileBrowserMode::Save);
         }
 
         void App::open(
@@ -1062,6 +1381,7 @@ namespace djv
             p.timeUnitsModel = models::TimeUnitsModel::create(_context, p.settings);
             
             p.filesModel = models::FilesModel::create(p.settings);
+            p.playlistModel = models::PlaylistModel::create();
 
             p.recentFilesModel = models::RecentFilesModel::create(_context, p.settings);
             auto fileBrowserSystem = _context->getSystem<ftk::FileBrowserSystem>();
@@ -1411,6 +1731,7 @@ namespace djv
             p.toolWidgetFactory->addTool("Information", &InfoTool::create);
             p.toolWidgetFactory->addTool("Magnify", &MagnifyTool::create);
             p.toolWidgetFactory->addTool("Messages", &MessagesTool::create);
+            p.toolWidgetFactory->addTool("OTIO Playlist", &PlaylistTool::create);
             p.toolWidgetFactory->addTool("Settings", &SettingsTool::create);
             p.toolWidgetFactory->addTool("System Log", &SysLogTool::create);
             p.toolWidgetFactory->addTool("View", &ViewTool::create);
@@ -1516,18 +1837,7 @@ namespace djv
                 {
                     try
                     {
-                        tl::Options options;
-                        const models::ImageSeqSettings imageSeq = p.settingsModel->getImageSeq();
-                        options.imageSeqAudio = imageSeq.audio;
-                        options.imageSeqAudioExts = imageSeq.audioExts;
-                        options.imageSeqAudioFileName = imageSeq.audioFileName;
-                        const models::OTIOSettings otio = p.settingsModel->getOTIO();
-                        options.spatial = otio.spatial;
-                        options.compat = otio.compat;
-                        options.ioOptions = p.settingsModel->getIOOptions();
-                        options.pathOptions.seqMaxDigits = imageSeq.maxDigits;
-                        options.readThreadCount = imageSeq.readThreadCount;
-
+                        tl::Options options = _getTimelineOptions();
                         // A range that was asked for is used as it is. One
                         // that was not is looked for on disk, so that
                         // reopening picks up frames rendered since.
@@ -1715,6 +2025,109 @@ namespace djv
 
             _layersUpdate(p.filesModel->observeLayers()->get());
             _audioUpdate();
+
+            bool playlistSet = false;
+            if (!activeFiles.empty())
+            {
+                const std::string extension =
+                    ftk::toLower(activeFiles.front()->path.getExt());
+                if (".otio" == extension || ".otioz" == extension)
+                {
+                    const auto i = std::find(
+                        p.files.begin(),
+                        p.files.end(),
+                        activeFiles.front());
+                    if (i != p.files.end())
+                    {
+                        const auto& timeline =
+                            p.timelines[i - p.files.begin()];
+                        if (timeline)
+                        {
+                            p.playlistModel->setTimeline(
+                                timeline->getTimeline(),
+                                activeFiles.front()->path,
+                                activeFiles.front()->playlistDirty,
+                                activeFiles.front()->playlistScratch);
+                            playlistSet = true;
+                        }
+                    }
+                }
+            }
+            if (!playlistSet)
+            {
+                p.playlistModel->clear();
+            }
+        }
+
+        tl::Options App::_getTimelineOptions(bool singleImages) const
+        {
+            FTK_P();
+            tl::Options options;
+            const models::ImageSeqSettings imageSeq =
+                p.settingsModel->getImageSeq();
+            options.imageSeqAudio =
+                singleImages ? tl::ImageSeqAudio::None : imageSeq.audio;
+            options.imageSeqAudioExts = imageSeq.audioExts;
+            options.imageSeqAudioFileName = imageSeq.audioFileName;
+            const models::OTIOSettings otio = p.settingsModel->getOTIO();
+            options.spatial = otio.spatial;
+            options.compat = otio.compat;
+            options.ioOptions = p.settingsModel->getIOOptions();
+            options.pathOptions.seqMaxDigits =
+                singleImages ? 0 : imageSeq.maxDigits;
+            options.readThreadCount = imageSeq.readThreadCount;
+            return options;
+        }
+
+        void App::_refreshPlaylistTimeline()
+        {
+            FTK_P();
+            if (!p.playlistModel->isAvailable() || p.activeFiles.empty())
+            {
+                return;
+            }
+            const auto item = p.activeFiles.front();
+            const auto i = std::find(p.files.begin(), p.files.end(), item);
+            if (i == p.files.end())
+            {
+                return;
+            }
+            try
+            {
+                const size_t index = i - p.files.begin();
+                p.timelines[index] = tl::Timeline::create(
+                    _context,
+                    p.playlistModel->getTimeline(),
+                    _getTimelineOptions(true));
+                item->videoLayers.clear();
+                for (const auto& video :
+                    p.timelines[index]->getIOInfo().video)
+                {
+                    item->videoLayers.push_back(video.name);
+                }
+                item->playlistDirty = p.playlistModel->isDirty();
+                item->playlistScratch = p.playlistModel->isScratch();
+
+                if (auto player = p.player->get())
+                {
+                    item->speed = player->getSpeed();
+                    item->currentTime = player->getCurrentTime();
+                    item->inOutRange = player->getInOutRange();
+                }
+                const auto activeFiles = p.activeFiles;
+                p.activeFiles.clear();
+                _activeUpdate(activeFiles);
+                auto thumbnailSystem =
+                    _context->getSystem<tl::ui::ThumbnailSystem>();
+                thumbnailSystem->clearCache();
+            }
+            catch (const std::exception& e)
+            {
+                _context->log(
+                    "djv::app::App",
+                    e.what(),
+                    ftk::LogType::Error);
+            }
         }
 
         void App::_layersUpdate(const std::vector<int>& value)

--- a/lib/djv/App/App.cpp
+++ b/lib/djv/App/App.cpp
@@ -59,6 +59,7 @@
 #include <ftk/Core/OS.h>
 #include <ftk/Core/Timer.h>
 
+#include <algorithm>
 #include <chrono>
 #include <cstdint>
 #include <filesystem>
@@ -152,6 +153,19 @@ namespace djv
                 }
                 return out;
             }
+
+            void deduplicateFolderScanExtensions(
+                std::vector<std::string>& values)
+            {
+                for (auto& value : values)
+                {
+                    value = ftk::toLower(value);
+                }
+                std::sort(values.begin(), values.end());
+                values.erase(
+                    std::unique(values.begin(), values.end()),
+                    values.end());
+            }
         }
 
         struct App::Private
@@ -201,6 +215,8 @@ namespace djv
             uint64_t folderScanWatchSignature = 0;
             std::chrono::steady_clock::time_point folderScanWatchNext;
             std::weak_ptr<models::FilesModelItem> folderScanWatchItem;
+            std::vector<ftk::Path> folderScanPendingPaths;
+            uint64_t folderScanPendingSignature = 0;
 
             std::shared_ptr<ftk::Observer<tl::PlayerCacheOptions> > cacheObserver;
             std::shared_ptr<ftk::Observer<models::ImageSeqSettings> > imageSeqObserver;
@@ -2163,6 +2179,10 @@ namespace djv
                             ".otioz" == extension;
                     }),
                 options.fileExtensions.end());
+            deduplicateFolderScanExtensions(
+                options.sequenceExtensions);
+            deduplicateFolderScanExtensions(
+                options.fileExtensions);
             options.maxCandidates = 250000;
             options.maxDirectoryEntries = 100000;
             options.maxDirectories = 50000;
@@ -2185,6 +2205,8 @@ namespace djv
             p.folderScanWatchPlaylistCreated = false;
             p.folderScanWatchSignature = 0;
             p.folderScanWatchItem.reset();
+            p.folderScanPendingPaths.clear();
+            p.folderScanPendingSignature = 0;
             if (!_queuePlaylistFolderScan())
             {
                 p.folderScanWatch = false;
@@ -2243,6 +2265,11 @@ namespace djv
             FTK_P();
             if (!p.folderScanRequest)
             {
+                if (!p.folderScanPendingPaths.empty())
+                {
+                    _applyPendingPlaylistFolderScan();
+                    return;
+                }
                 if (!p.folderScanWatch)
                 {
                     return;
@@ -2304,7 +2331,9 @@ namespace djv
                     std::chrono::steady_clock::now() +
                     std::chrono::seconds(2);
             }
-            else if (p.folderScanTimer)
+            else if (
+                p.folderScanPendingPaths.empty() &&
+                p.folderScanTimer)
             {
                 p.folderScanTimer->stop();
             }
@@ -2438,26 +2467,23 @@ namespace djv
                     createPlaylistFromMedia(
                         result.scanResult.paths.front());
                     const auto item = p.filesModel->getA();
-                    if (!p.playlistModel->isAvailable() ||
-                        !item ||
-                        item == previousItem)
+                    if (!item || item == previousItem)
                     {
                         return;
                     }
-                    if (result.scanResult.paths.size() > 1)
-                    {
-                        addPlaylistMedia(std::vector<ftk::Path>(
-                            result.scanResult.paths.begin() + 1,
-                            result.scanResult.paths.end()));
-                    }
-                    applied =
-                        p.playlistModel->getItems().size() ==
-                        result.scanResult.paths.size();
+                    p.folderScanWatchItem = item;
+                    p.folderScanPendingPaths =
+                        result.scanResult.paths;
+                    p.folderScanPendingSignature =
+                        result.scanResult.contentSignature;
                     if (p.folderScanWatch)
                     {
-                        p.folderScanWatchItem = item;
                         p.folderScanWatchPlaylistCreated = true;
                     }
+                    // FilesModel loads and activates the new scratch timeline
+                    // asynchronously. Finish population and saving only after
+                    // that exact item is the active PlaylistModel.
+                    return;
                 }
                 else
                 {
@@ -2482,6 +2508,73 @@ namespace djv
                 p.playlistFolderDialog->close();
                 p.playlistFolderDialog.reset();
             }
+        }
+
+        bool App::_applyPendingPlaylistFolderScan()
+        {
+            FTK_P();
+            if (p.folderScanPendingPaths.empty())
+            {
+                return true;
+            }
+            const auto item = p.folderScanWatchItem.lock();
+            if (!item ||
+                p.files.end() ==
+                    std::find(p.files.begin(), p.files.end(), item))
+            {
+                p.folderScanPendingPaths.clear();
+                p.folderScanPendingSignature = 0;
+                _stopPlaylistFolderWatch(
+                    "Folder playlist initialization stopped because its "
+                    "playlist was closed.");
+                return false;
+            }
+            if (p.filesModel->getA() != item ||
+                !p.playlistModel->isAvailable())
+            {
+                return false;
+            }
+
+            const bool applied = _replaceWatchedPlaylist(
+                p.folderScanPendingPaths);
+            if (!applied)
+            {
+                p.folderScanPendingPaths.clear();
+                p.folderScanPendingSignature = 0;
+                if (p.folderScanWatch)
+                {
+                    p.folderScanWatchNext =
+                        std::chrono::steady_clock::now() +
+                        std::chrono::seconds(2);
+                }
+                else if (p.folderScanTimer)
+                {
+                    p.folderScanTimer->stop();
+                }
+                return false;
+            }
+            p.folderScanPendingPaths.clear();
+            if (p.folderScanWatch)
+            {
+                p.folderScanWatchSignature =
+                    p.folderScanPendingSignature;
+                p.folderScanWatchHasSignature = true;
+                p.folderScanWatchNext =
+                    std::chrono::steady_clock::now() +
+                    std::chrono::seconds(2);
+            }
+            p.folderScanPendingSignature = 0;
+            if (p.playlistFolderDialog)
+            {
+                p.playlistFolderDialog->close();
+                p.playlistFolderDialog.reset();
+            }
+            if (!p.folderScanWatch &&
+                p.folderScanTimer)
+            {
+                p.folderScanTimer->stop();
+            }
+            return true;
         }
 
         bool App::_replaceWatchedPlaylist(
@@ -2562,6 +2655,8 @@ namespace djv
             p.folderScanWatchHasSignature = false;
             p.folderScanWatchPlaylistCreated = false;
             p.folderScanWatchItem.reset();
+            p.folderScanPendingPaths.clear();
+            p.folderScanPendingSignature = 0;
             if (p.folderScanTimer)
             {
                 p.folderScanTimer->stop();

--- a/lib/djv/App/App.h
+++ b/lib/djv/App/App.h
@@ -223,6 +223,7 @@ namespace djv
             void _folderScanPoll();
             void _finishPlaylistFolderScan(
                 const FolderScanServiceResult&);
+            bool _applyPendingPlaylistFolderScan();
             bool _replaceWatchedPlaylist(
                 const std::vector<ftk::Path>&);
             void _stopPlaylistFolderWatch(const std::string&);

--- a/lib/djv/App/App.h
+++ b/lib/djv/App/App.h
@@ -39,6 +39,8 @@ namespace djv
     //! DJV Application
     namespace app
     {
+        struct FolderScanServiceResult;
+
         class MainWindow;
         class StatusBar;
         class ToolWidgetFactory;
@@ -209,6 +211,17 @@ namespace djv
             void _audioUpdate();
             tl::Options _getTimelineOptions(bool singleImages = false) const;
             void _refreshPlaylistTimeline();
+            void _startPlaylistFolderScan(
+                const ftk::Path&,
+                const std::string& filter,
+                bool createPlaylist,
+                bool recursive,
+                bool collapseSequences,
+                const ftk::Path& outputPath = ftk::Path());
+            void _folderScanPoll();
+            void _finishPlaylistFolderScan(
+                const FolderScanServiceResult&);
+            bool _savePlaylistTo(const ftk::Path&);
 
             FTK_PRIVATE();
         };

--- a/lib/djv/App/App.h
+++ b/lib/djv/App/App.h
@@ -217,10 +217,15 @@ namespace djv
                 bool createPlaylist,
                 bool recursive,
                 bool collapseSequences,
-                const ftk::Path& outputPath = ftk::Path());
+                const ftk::Path& outputPath = ftk::Path(),
+                bool watch = false);
+            bool _queuePlaylistFolderScan();
             void _folderScanPoll();
             void _finishPlaylistFolderScan(
                 const FolderScanServiceResult&);
+            bool _replaceWatchedPlaylist(
+                const std::vector<ftk::Path>&);
+            void _stopPlaylistFolderWatch(const std::string&);
             bool _savePlaylistTo(const ftk::Path&);
 
             FTK_PRIVATE();

--- a/lib/djv/App/App.h
+++ b/lib/djv/App/App.h
@@ -29,6 +29,7 @@ namespace djv
         class ColorModel;
         class CommandsModel;
         class FilesModel;
+        class PlaylistModel;
         class RecentFilesModel;
         class TimeUnitsModel;
         class ToolsModel;
@@ -82,6 +83,9 @@ namespace djv
             //! Get the files model.
             const std::shared_ptr<models::FilesModel>& getFilesModel() const;
 
+            //! Get the OTIO playlist model.
+            const std::shared_ptr<models::PlaylistModel>& getPlaylistModel() const;
+
             //! Get the recent files model.
             const std::shared_ptr<models::RecentFilesModel>& getRecentFilesModel() const;
 
@@ -123,6 +127,34 @@ namespace djv
 
             //! Open a file and separate audio file dialog.
             void openSeparateAudioDialog();
+
+            //! Create an OTIO playlist from media selected in a dialog.
+            void openMediaAsPlaylistDialog();
+
+            //! Add media selected in a dialog to the active playlist.
+            void openPlaylistMediaDialog();
+
+            //! Import matching media from a folder into a new or active
+            //! playlist.
+            void openPlaylistFolderDialog(bool createPlaylist);
+
+            //! Create an OTIO playlist from one media path.
+            void createPlaylistFromMedia(const ftk::Path&);
+
+            //! Add media paths to the active playlist.
+            void addPlaylistMedia(const std::vector<ftk::Path>&);
+
+            //! Move an item in the active playlist.
+            void movePlaylistMedia(size_t from, size_t to);
+
+            //! Remove an item from the active playlist.
+            void removePlaylistMedia(size_t);
+
+            //! Save the active playlist.
+            void savePlaylist();
+
+            //! Save the active playlist to a selected path.
+            void savePlaylistAsDialog();
 
             //! Reload the active files.
             void reload();
@@ -175,6 +207,8 @@ namespace djv
             void _reloadUpdate(const std::shared_ptr<models::FilesModelItem>&);
             void _layersUpdate(const std::vector<int>&);
             void _audioUpdate();
+            tl::Options _getTimelineOptions(bool singleImages = false) const;
+            void _refreshPlaylistTimeline();
 
             FTK_PRIVATE();
         };

--- a/lib/djv/App/CMakeLists.txt
+++ b/lib/djv/App/CMakeLists.txt
@@ -19,6 +19,7 @@ set(HEADERS
     FileMenu.h
     FileToolBar.h
     FilesTool.h
+    FolderScanService.h
     FrameActions.h
     FrameMenu.h
     HelpActions.h
@@ -74,6 +75,7 @@ set(SOURCE
     FileMenu.cpp
     FileToolBar.cpp
     FilesTool.cpp
+    FolderScanService.cpp
     FrameActions.cpp
     FrameMenu.cpp
     HelpActions.cpp

--- a/lib/djv/App/CMakeLists.txt
+++ b/lib/djv/App/CMakeLists.txt
@@ -31,6 +31,7 @@ set(HEADERS
     MessagesTool.h
     PlaybackActions.h
     PlaybackMenu.h
+    PlaylistTool.h
     SecondaryWindow.h
     SettingsTool.h
     StatusBar.h
@@ -85,6 +86,7 @@ set(SOURCE
     MessagesTool.cpp
     PlaybackActions.cpp
     PlaybackMenu.cpp
+    PlaylistTool.cpp
     SecondaryWindow.cpp
     SettingsTool.cpp
     StatusBar.cpp

--- a/lib/djv/App/FileActions.cpp
+++ b/lib/djv/App/FileActions.cpp
@@ -42,6 +42,28 @@ namespace djv
                 });
 
             _addCommand(
+                "NewPlaylist",
+                "Create an editable OTIO playlist from a media file.",
+                [appWeak](const nlohmann::json&)
+                {
+                    if (auto app = appWeak.lock())
+                    {
+                        app->openMediaAsPlaylistDialog();
+                    }
+                });
+
+            _addCommand(
+                "NewPlaylistFolder",
+                "Create an editable OTIO playlist from matching media in a folder.",
+                [appWeak](const nlohmann::json&)
+                {
+                    if (auto app = appWeak.lock())
+                    {
+                        app->openPlaylistFolderDialog(true);
+                    }
+                });
+
+            _addCommand(
                 "OpenAudio",
                 "Open a file with a separate audio file.",
                 [appWeak](const nlohmann::json&)
@@ -174,6 +196,14 @@ namespace djv
                 "Open",
                 "FileOpen",
                 _command("Open"));
+            _actions["NewPlaylist"] = ftk::Action::create(
+                "New OTIO Playlist",
+                "FileOpen",
+                _command("NewPlaylist"));
+            _actions["NewPlaylistFolder"] = ftk::Action::create(
+                "New OTIO Playlist from Folder",
+                "Files",
+                _command("NewPlaylistFolder"));
             _actions["OpenAudio"] = ftk::Action::create(
                 "Open With Audio",
                 "FileOpenAudio",

--- a/lib/djv/App/FileMenu.cpp
+++ b/lib/djv/App/FileMenu.cpp
@@ -56,6 +56,8 @@ namespace djv
 
             auto actions = fileActions->getActions();
             addAction(actions["Open"]);
+            addAction(actions["NewPlaylist"]);
+            addAction(actions["NewPlaylistFolder"]);
             addAction(actions["OpenAudio"]);
             addAction(actions["Close"]);
             addAction(actions["CloseAll"]);

--- a/lib/djv/App/FolderScanService.cpp
+++ b/lib/djv/App/FolderScanService.cpp
@@ -1,0 +1,586 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the DJV project.
+
+#include <djv/App/FolderScanService.h>
+
+#include <algorithm>
+#include <condition_variable>
+#include <deque>
+#include <mutex>
+#include <stdexcept>
+#include <thread>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace djv
+{
+    namespace app
+    {
+        bool FolderScanServiceResult::isSuccess() const
+        {
+            return FolderScanServiceStatus::Accepted == status &&
+                FolderScanServiceError::None == error &&
+                models::FolderScanStatus::Completed == scanResult.status;
+        }
+
+        FolderScanServiceRequest::operator bool() const
+        {
+            return 0 != id && future.valid();
+        }
+
+        struct FolderScanServiceStartGate::Private
+        {
+            mutable std::mutex mutex;
+            mutable std::condition_variable cv;
+            bool blocked = true;
+            bool entered = false;
+        };
+
+        FolderScanServiceStartGate::FolderScanServiceStartGate(bool blocked) :
+            _p(new Private)
+        {
+            _p->blocked = blocked;
+        }
+
+        FolderScanServiceStartGate::~FolderScanServiceStartGate() = default;
+
+        void FolderScanServiceStartGate::block()
+        {
+            std::lock_guard<std::mutex> lock(_p->mutex);
+            _p->blocked = true;
+            _p->entered = false;
+        }
+
+        void FolderScanServiceStartGate::release()
+        {
+            {
+                std::lock_guard<std::mutex> lock(_p->mutex);
+                _p->blocked = false;
+            }
+            _p->cv.notify_all();
+        }
+
+        bool FolderScanServiceStartGate::isBlocked() const
+        {
+            std::lock_guard<std::mutex> lock(_p->mutex);
+            return _p->blocked;
+        }
+
+        bool FolderScanServiceStartGate::waitUntilEntered(
+            std::chrono::milliseconds timeout) const
+        {
+            std::unique_lock<std::mutex> lock(_p->mutex);
+            return _p->cv.wait_for(
+                lock,
+                timeout,
+                [this] { return _p->entered; });
+        }
+
+        bool FolderScanServiceStartGate::waitForRelease(
+            std::chrono::milliseconds timeout)
+        {
+            std::unique_lock<std::mutex> lock(_p->mutex);
+            _p->entered = true;
+            _p->cv.notify_all();
+            return _p->cv.wait_for(
+                lock,
+                timeout,
+                [this] { return !_p->blocked; });
+        }
+
+        namespace
+        {
+            FolderScanServiceResult makeImmediateResult(
+                uint64_t requestId,
+                const std::filesystem::path& root,
+                FolderScanServiceStatus status,
+                FolderScanServiceError error,
+                const std::string& message)
+            {
+                FolderScanServiceResult out;
+                out.requestId = requestId;
+                out.root = root;
+                out.status = status;
+                out.error = error;
+                out.message = message;
+                return out;
+            }
+
+            bool validateExtensionList(
+                const std::vector<std::string>& values,
+                const FolderScanServiceOptions& limits)
+            {
+                if (values.size() > limits.maxExtensionsPerRequest)
+                {
+                    return false;
+                }
+                return std::all_of(
+                    values.begin(),
+                    values.end(),
+                    [&limits](const std::string& value)
+                    {
+                        return value.size() <= limits.maxExtensionLength;
+                    });
+            }
+
+            bool validateRequest(
+                const std::filesystem::path& root,
+                const std::shared_ptr<const models::CompiledFileFilter>& filter,
+                const models::FolderScanOptions& options,
+                const FolderScanServiceOptions& limits,
+                std::string& message)
+            {
+                if (root.empty() || !root.is_absolute())
+                {
+                    message = "The folder scan root must be an absolute path.";
+                    return false;
+                }
+                if (!filter)
+                {
+                    message = "The folder scan requires a compiled immutable filter.";
+                    return false;
+                }
+                if (options.maxCandidates > limits.maxCandidatesPerRequest ||
+                    options.maxDirectoryEntries > limits.maxDirectoryEntriesPerRequest ||
+                    0 == options.maxDirectories ||
+                    options.maxDirectories > limits.maxDirectoriesPerRequest ||
+                    0 == options.maxEntries ||
+                    options.maxEntries > limits.maxEntriesPerRequest ||
+                    0 == options.maxResults ||
+                    options.maxResults > limits.maxResultsPerRequest ||
+                    options.maxDepth > limits.maxDepthPerRequest ||
+                    options.maxWarnings > limits.maxWarningsPerRequest ||
+                    0 == options.sequenceMaxDigits ||
+                    options.sequenceMaxDigits > limits.maxSequenceDigits ||
+                    !validateExtensionList(options.fileExtensions, limits) ||
+                    !validateExtensionList(options.sequenceExtensions, limits))
+                {
+                    message = "The folder scan options exceed the service's bounded limits.";
+                    return false;
+                }
+                return true;
+            }
+
+            FolderScanServiceResult classifyScanResult(
+                uint64_t requestId,
+                const std::filesystem::path& root,
+                models::FolderScanResult scanResult)
+            {
+                FolderScanServiceResult out;
+                out.requestId = requestId;
+                out.root = root;
+                out.scanResult = std::move(scanResult);
+                switch (out.scanResult.status)
+                {
+                case models::FolderScanStatus::Completed:
+                    out.status = FolderScanServiceStatus::Accepted;
+                    out.error = FolderScanServiceError::None;
+                    out.message = "Folder scan completed.";
+                    break;
+                case models::FolderScanStatus::Cancelled:
+                    out.scanResult.paths.clear();
+                    out.status = FolderScanServiceStatus::Cancelled;
+                    out.error = FolderScanServiceError::Cancelled;
+                    out.message = "Folder scan was cancelled.";
+                    break;
+                case models::FolderScanStatus::CandidateLimitReached:
+                case models::FolderScanStatus::TraversalLimitReached:
+                case models::FolderScanStatus::ResultLimitReached:
+                    out.scanResult.paths.clear();
+                    out.status = FolderScanServiceStatus::Failed;
+                    out.error = FolderScanServiceError::LimitReached;
+                    out.message = "Folder scan stopped at a configured limit; no partial paths were published.";
+                    break;
+                case models::FolderScanStatus::InvalidRoot:
+                    out.scanResult.paths.clear();
+                    out.status = FolderScanServiceStatus::Failed;
+                    out.error = FolderScanServiceError::InvalidRoot;
+                    out.message = "The folder scan root is not an accessible directory.";
+                    break;
+                default:
+                    out.scanResult.paths.clear();
+                    out.status = FolderScanServiceStatus::Failed;
+                    out.error = FolderScanServiceError::InternalError;
+                    out.message = "Folder scan returned an unknown status.";
+                    break;
+                }
+                return out;
+            }
+        }
+
+        struct FolderScanService::Private
+        {
+            struct RequestState
+            {
+                uint64_t id = 0;
+                std::filesystem::path root;
+                std::shared_ptr<const models::CompiledFileFilter> filter;
+                models::FolderScanOptions options;
+                models::FolderScanCancellationSource cancellation;
+                std::promise<FolderScanServiceResult> promise;
+                std::shared_future<FolderScanServiceResult> future;
+                bool running = false;
+                bool done = false;
+            };
+
+            explicit Private(const FolderScanServiceOptions& value) :
+                options(value)
+            {
+                if (0 == options.maxPendingRequests ||
+                    0 == options.maxCandidatesPerRequest ||
+                    0 == options.maxDirectoryEntriesPerRequest ||
+                    0 == options.maxDirectoriesPerRequest ||
+                    0 == options.maxEntriesPerRequest ||
+                    0 == options.maxResultsPerRequest ||
+                    0 == options.maxExtensionsPerRequest ||
+                    0 == options.maxExtensionLength ||
+                    0 == options.maxSequenceDigits)
+                {
+                    throw std::invalid_argument(
+                        "FolderScanService requires non-zero hard limits.");
+                }
+                worker = std::thread([this] { run(); });
+            }
+
+            FolderScanServiceResult cancelledResult(
+                const std::shared_ptr<RequestState>& request,
+                FolderScanServiceError error) const
+            {
+                FolderScanServiceResult out = makeImmediateResult(
+                    request->id,
+                    request->root,
+                    FolderScanServiceStatus::Cancelled,
+                    error,
+                    FolderScanServiceError::ShuttingDown == error ?
+                        "Folder scan stopped because the service is shutting down." :
+                        "Folder scan request was cancelled.");
+                out.scanResult.status = models::FolderScanStatus::Cancelled;
+                return out;
+            }
+
+            void accountResult(const FolderScanServiceResult& result)
+            {
+                ++stats.requestsCompleted;
+                switch (result.status)
+                {
+                case FolderScanServiceStatus::Cancelled:
+                    ++stats.requestsCancelled;
+                    break;
+                case FolderScanServiceStatus::Rejected:
+                    ++stats.requestsRejected;
+                    break;
+                case FolderScanServiceStatus::Failed:
+                    ++stats.requestsFailed;
+                    break;
+                default:
+                    break;
+                }
+            }
+
+            void complete(
+                const std::shared_ptr<RequestState>& request,
+                FolderScanServiceResult result)
+            {
+                bool publish = false;
+                {
+                    std::lock_guard<std::mutex> lock(mutex);
+                    if (!request->done)
+                    {
+                        request->done = true;
+                        requests.erase(request->id);
+                        accountResult(result);
+                        publish = true;
+                    }
+                }
+                if (publish)
+                {
+                    request->promise.set_value(std::move(result));
+                }
+            }
+
+            FolderScanServiceResult execute(
+                const std::shared_ptr<RequestState>& request)
+            {
+                const auto token = request->cancellation.getToken();
+                if (options.startGate)
+                {
+                    while (!options.startGate->waitForRelease(
+                        std::chrono::milliseconds(5)))
+                    {
+                        if (token.isCancellationRequested())
+                        {
+                            return cancelledResult(
+                                request,
+                                FolderScanServiceError::Cancelled);
+                        }
+                    }
+                }
+                if (token.isCancellationRequested())
+                {
+                    return cancelledResult(request, FolderScanServiceError::Cancelled);
+                }
+
+                try
+                {
+                    return classifyScanResult(
+                        request->id,
+                        request->root,
+                        models::scanFolder(
+                            request->root,
+                            *request->filter,
+                            request->options,
+                            token));
+                }
+                catch (const std::exception& e)
+                {
+                    return makeImmediateResult(
+                        request->id,
+                        request->root,
+                        FolderScanServiceStatus::Failed,
+                        FolderScanServiceError::InternalError,
+                        std::string("Unexpected folder scan failure: ") + e.what());
+                }
+                catch (...)
+                {
+                    return makeImmediateResult(
+                        request->id,
+                        request->root,
+                        FolderScanServiceStatus::Failed,
+                        FolderScanServiceError::InternalError,
+                        "Unexpected folder scan failure.");
+                }
+            }
+
+            void run()
+            {
+                while (true)
+                {
+                    std::shared_ptr<RequestState> request;
+                    {
+                        std::unique_lock<std::mutex> lock(mutex);
+                        cv.wait(lock, [this] { return stopping || !queue.empty(); });
+                        if (queue.empty())
+                        {
+                            if (stopping)
+                            {
+                                return;
+                            }
+                            continue;
+                        }
+                        request = queue.front();
+                        queue.pop_front();
+                        if (request->done)
+                        {
+                            continue;
+                        }
+                        request->running = true;
+                    }
+
+                    complete(request, execute(request));
+                }
+            }
+
+            FolderScanServiceOptions options;
+            mutable std::mutex mutex;
+            std::mutex shutdownMutex;
+            std::condition_variable cv;
+            std::deque<std::shared_ptr<RequestState> > queue;
+            std::unordered_map<uint64_t, std::shared_ptr<RequestState> > requests;
+            uint64_t nextRequestId = 1;
+            bool accepting = true;
+            bool stopping = false;
+            std::thread worker;
+            FolderScanServiceStats stats;
+        };
+
+        FolderScanService::FolderScanService(
+            const FolderScanServiceOptions& options) :
+            _p(new Private(options))
+        {}
+
+        FolderScanService::~FolderScanService()
+        {
+            shutdown();
+        }
+
+        FolderScanServiceRequest FolderScanService::request(
+            const std::filesystem::path& root,
+            const std::shared_ptr<const models::CompiledFileFilter>& filter,
+            const models::FolderScanOptions& options)
+        {
+            const auto request = std::make_shared<Private::RequestState>();
+            request->root = root;
+            request->filter = filter;
+            request->options = options;
+            request->future = request->promise.get_future().share();
+
+            FolderScanServiceResult immediate;
+            bool hasImmediate = false;
+            {
+                std::lock_guard<std::mutex> lock(_p->mutex);
+                request->id = _p->nextRequestId++;
+                ++_p->stats.requestsSubmitted;
+
+                if (!_p->accepting)
+                {
+                    immediate = makeImmediateResult(
+                        request->id,
+                        root,
+                        FolderScanServiceStatus::Rejected,
+                        FolderScanServiceError::ShuttingDown,
+                        "Folder scan service is not accepting requests.");
+                    hasImmediate = true;
+                }
+                else
+                {
+                    std::string validationMessage;
+                    if (!validateRequest(
+                        root, filter, options, _p->options, validationMessage))
+                    {
+                        immediate = makeImmediateResult(
+                            request->id,
+                            root,
+                            FolderScanServiceStatus::Rejected,
+                            FolderScanServiceError::InvalidRequest,
+                            validationMessage);
+                        hasImmediate = true;
+                    }
+                }
+                if (!hasImmediate &&
+                    _p->requests.size() >= _p->options.maxPendingRequests)
+                {
+                    immediate = makeImmediateResult(
+                        request->id,
+                        root,
+                        FolderScanServiceStatus::Rejected,
+                        FolderScanServiceError::QueueFull,
+                        "Folder scan request queue is full.");
+                    hasImmediate = true;
+                }
+
+                if (hasImmediate)
+                {
+                    request->done = true;
+                    _p->accountResult(immediate);
+                }
+                else
+                {
+                    _p->requests[request->id] = request;
+                    _p->queue.push_back(request);
+                }
+            }
+
+            if (hasImmediate)
+            {
+                request->promise.set_value(std::move(immediate));
+            }
+            else
+            {
+                _p->cv.notify_one();
+            }
+            return { request->id, request->future };
+        }
+
+        bool FolderScanService::cancel(uint64_t requestId)
+        {
+            std::shared_ptr<Private::RequestState> request;
+            FolderScanServiceResult result;
+            {
+                std::lock_guard<std::mutex> lock(_p->mutex);
+                const auto i = _p->requests.find(requestId);
+                if (i == _p->requests.end() || !i->second || i->second->done)
+                {
+                    return false;
+                }
+                request = i->second;
+                request->cancellation.cancel();
+                request->done = true;
+                _p->requests.erase(i);
+                if (!request->running)
+                {
+                    const auto queueIt = std::find(
+                        _p->queue.begin(), _p->queue.end(), request);
+                    if (queueIt != _p->queue.end())
+                    {
+                        _p->queue.erase(queueIt);
+                    }
+                }
+                result = _p->cancelledResult(
+                    request, FolderScanServiceError::Cancelled);
+                _p->accountResult(result);
+            }
+            request->promise.set_value(std::move(result));
+            _p->cv.notify_all();
+            return true;
+        }
+
+        std::optional<FolderScanServiceRequestState> FolderScanService::getState(
+            uint64_t requestId) const
+        {
+            std::lock_guard<std::mutex> lock(_p->mutex);
+            const auto i = _p->requests.find(requestId);
+            if (i == _p->requests.end() || !i->second || i->second->done)
+            {
+                return std::nullopt;
+            }
+            return i->second->running ?
+                FolderScanServiceRequestState::Running :
+                FolderScanServiceRequestState::Queued;
+        }
+
+        void FolderScanService::shutdown()
+        {
+            std::lock_guard<std::mutex> shutdownLock(_p->shutdownMutex);
+            std::vector<std::pair<
+                std::shared_ptr<Private::RequestState>,
+                FolderScanServiceResult> > completions;
+            {
+                std::lock_guard<std::mutex> lock(_p->mutex);
+                if (_p->accepting || !_p->stopping)
+                {
+                    _p->accepting = false;
+                    _p->stopping = true;
+                    completions.reserve(_p->requests.size());
+                    for (const auto& i : _p->requests)
+                    {
+                        const auto& request = i.second;
+                        if (!request || request->done)
+                        {
+                            continue;
+                        }
+                        request->cancellation.cancel();
+                        request->done = true;
+                        FolderScanServiceResult result = _p->cancelledResult(
+                            request, FolderScanServiceError::ShuttingDown);
+                        _p->accountResult(result);
+                        completions.emplace_back(request, std::move(result));
+                    }
+                    _p->requests.clear();
+                    _p->queue.clear();
+                }
+            }
+            for (auto& completion : completions)
+            {
+                completion.first->promise.set_value(std::move(completion.second));
+            }
+            _p->cv.notify_all();
+            if (_p->worker.joinable())
+            {
+                // The worker never invokes user code or any service method, so
+                // ownership cannot return to shutdown() on the worker thread.
+                if (_p->worker.get_id() == std::this_thread::get_id())
+                {
+                    std::terminate();
+                }
+                _p->worker.join();
+            }
+        }
+
+        FolderScanServiceStats FolderScanService::getStats() const
+        {
+            std::lock_guard<std::mutex> lock(_p->mutex);
+            return _p->stats;
+        }
+    }
+}

--- a/lib/djv/App/FolderScanService.h
+++ b/lib/djv/App/FolderScanService.h
@@ -114,7 +114,7 @@ namespace djv
             size_t maxResultsPerRequest = 5000;
             size_t maxDepthPerRequest = 128;
             size_t maxWarningsPerRequest = 1000;
-            size_t maxExtensionsPerRequest = 256;
+            size_t maxExtensionsPerRequest = 4096;
             size_t maxExtensionLength = 32;
             size_t maxSequenceDigits = 18;
 

--- a/lib/djv/App/FolderScanService.h
+++ b/lib/djv/App/FolderScanService.h
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the DJV project.
+
+#pragma once
+
+#include <djv/Models/FolderScanner.h>
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <future>
+#include <memory>
+#include <optional>
+#include <string>
+
+namespace djv
+{
+    namespace app
+    {
+        //! High-level outcome for an asynchronous folder scan request.
+        enum class FolderScanServiceStatus
+        {
+            Accepted,
+            Cancelled,
+            Rejected,
+            Failed
+        };
+
+        //! Typed service errors. The lower-level scan status and warnings are
+        //! retained in FolderScanServiceResult::scanResult.
+        enum class FolderScanServiceError
+        {
+            None,
+            Cancelled,
+            ShuttingDown,
+            QueueFull,
+            InvalidRequest,
+            InvalidRoot,
+            LimitReached,
+            InternalError
+        };
+
+        //! Result returned by a folder scan request.
+        //!
+        //! Paths are exposed only for a completed scan. Cancellation and
+        //! candidate/result limits are atomic and always return an empty path
+        //! list, while preserving counters and warnings for diagnostics.
+        struct FolderScanServiceResult
+        {
+            uint64_t requestId = 0;
+            std::filesystem::path root;
+            FolderScanServiceStatus status = FolderScanServiceStatus::Rejected;
+            FolderScanServiceError error = FolderScanServiceError::InvalidRequest;
+            std::string message;
+            models::FolderScanResult scanResult;
+
+            bool isSuccess() const;
+        };
+
+        //! Immediate handle for a folder scan request.
+        struct FolderScanServiceRequest
+        {
+            uint64_t id = 0;
+            std::shared_future<FolderScanServiceResult> future;
+
+            explicit operator bool() const;
+        };
+
+        //! Truthful state for an active request. Completed requests are not
+        //! retained by the service and therefore return std::nullopt.
+        enum class FolderScanServiceRequestState
+        {
+            Queued,
+            Running
+        };
+
+        //! Data-only worker gate used by deterministic stress tests. No user
+        //! callback is ever invoked from the service worker.
+        class FolderScanServiceStartGate
+        {
+        public:
+            explicit FolderScanServiceStartGate(bool blocked = true);
+            ~FolderScanServiceStartGate();
+
+            FolderScanServiceStartGate(const FolderScanServiceStartGate&) = delete;
+            FolderScanServiceStartGate& operator = (const FolderScanServiceStartGate&) = delete;
+
+            void block();
+            void release();
+            bool isBlocked() const;
+            bool waitUntilEntered(std::chrono::milliseconds) const;
+
+            //! Worker-side bounded wait step. Public solely to keep the gate a
+            //! passive synchronization primitive rather than a callback.
+            bool waitForRelease(std::chrono::milliseconds);
+
+        private:
+            struct Private;
+            std::unique_ptr<Private> _p;
+        };
+
+        //! Bounded configuration for FolderScanService.
+        struct FolderScanServiceOptions
+        {
+            //! Maximum active requests, including the running request.
+            size_t maxPendingRequests = 16;
+
+            //! Per-request hard limits accepted by this service.
+            size_t maxCandidatesPerRequest = 1000000;
+            size_t maxDirectoryEntriesPerRequest = 250000;
+            size_t maxDirectoriesPerRequest = 100000;
+            size_t maxEntriesPerRequest = 1000000;
+            size_t maxResultsPerRequest = 5000;
+            size_t maxDepthPerRequest = 128;
+            size_t maxWarningsPerRequest = 1000;
+            size_t maxExtensionsPerRequest = 256;
+            size_t maxExtensionLength = 32;
+            size_t maxSequenceDigits = 18;
+
+            //! Optional passive start gate for deterministic tests.
+            std::shared_ptr<FolderScanServiceStartGate> startGate;
+        };
+
+        //! Snapshot of service-level counters.
+        struct FolderScanServiceStats
+        {
+            uint64_t requestsSubmitted = 0;
+            uint64_t requestsCompleted = 0;
+            uint64_t requestsCancelled = 0;
+            uint64_t requestsRejected = 0;
+            uint64_t requestsFailed = 0;
+        };
+
+        //! One-worker, bounded asynchronous wrapper around models::scanFolder().
+        //!
+        //! Cancellation is observed at directory and entry checkpoints. On
+        //! Windows the scanner also cancels synchronous filesystem I/O on its
+        //! owned worker thread, so a blocked remote enumeration can unwind.
+        //! No partial paths are published and shutdown always joins the worker.
+        class FolderScanService
+        {
+        public:
+            explicit FolderScanService(
+                const FolderScanServiceOptions& = FolderScanServiceOptions());
+            ~FolderScanService();
+
+            FolderScanService(const FolderScanService&) = delete;
+            FolderScanService& operator = (const FolderScanService&) = delete;
+
+            //! Validate and queue a scan. The filter is shared immutably for
+            //! the duration of the request.
+            FolderScanServiceRequest request(
+                const std::filesystem::path& root,
+                const std::shared_ptr<const models::CompiledFileFilter>& filter,
+                const models::FolderScanOptions& = models::FolderScanOptions());
+
+            //! Cancel a queued or running request. Its future is completed
+            //! immediately and its queue capacity is released immediately.
+            bool cancel(uint64_t requestId);
+
+            //! Poll the state of an active request only.
+            std::optional<FolderScanServiceRequestState> getState(
+                uint64_t requestId) const;
+
+            //! Refuse new work, cancel all active requests, and join the owned
+            //! worker. Safe to call repeatedly.
+            void shutdown();
+
+            FolderScanServiceStats getStats() const;
+
+        private:
+            struct Private;
+            std::unique_ptr<Private> _p;
+        };
+    }
+}

--- a/lib/djv/App/PlaylistTool.cpp
+++ b/lib/djv/App/PlaylistTool.cpp
@@ -1,0 +1,512 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the DJV project.
+
+#include <djv/App/PlaylistTool.h>
+
+#include <djv/App/App.h>
+#include <djv/Models/PlaylistModel.h>
+
+#include <ftk/UI/Divider.h>
+#include <ftk/UI/Label.h>
+#include <ftk/UI/PushButton.h>
+#include <ftk/UI/RowLayout.h>
+#include <ftk/UI/ScrollWidget.h>
+#include <ftk/UI/Spacer.h>
+
+#include <ftk/Core/Format.h>
+#include <ftk/Core/String.h>
+
+#include <cmath>
+
+namespace djv
+{
+    namespace app
+    {
+        namespace
+        {
+            class PlaylistDragData : public ftk::IDragDropData
+            {
+            public:
+                explicit PlaylistDragData(size_t value) :
+                    index(value)
+                {}
+
+                ~PlaylistDragData() override = default;
+
+                size_t index = 0;
+            };
+
+            class PlaylistRow : public ftk::PushButton
+            {
+            protected:
+                void _init(
+                    const std::shared_ptr<ftk::Context>& context,
+                    size_t index,
+                    const std::string& text,
+                    const std::string& tooltip,
+                    bool editable,
+                    const std::function<void(size_t, size_t)>& moveCallback,
+                    const std::function<void(const std::vector<ftk::Path>&)>& addCallback,
+                    const std::shared_ptr<IWidget>& parent)
+                {
+                    PushButton::_init(context, parent);
+                    setText(text);
+                    setTooltip(tooltip);
+                    setCheckable(true);
+                    setHStretch(ftk::Stretch::Expanding);
+                    _index = index;
+                    _editable = editable;
+                    _moveCallback = moveCallback;
+                    _addCallback = addCallback;
+                }
+
+                PlaylistRow() = default;
+
+            public:
+                ~PlaylistRow() override = default;
+
+                static std::shared_ptr<PlaylistRow> create(
+                    const std::shared_ptr<ftk::Context>& context,
+                    size_t index,
+                    const std::string& text,
+                    const std::string& tooltip,
+                    bool editable,
+                    const std::function<void(size_t, size_t)>& moveCallback,
+                    const std::function<void(const std::vector<ftk::Path>&)>& addCallback,
+                    const std::shared_ptr<IWidget>& parent = nullptr)
+                {
+                    auto out = std::shared_ptr<PlaylistRow>(new PlaylistRow);
+                    out->_init(
+                        context,
+                        index,
+                        text,
+                        tooltip,
+                        editable,
+                        moveCallback,
+                        addCallback,
+                        parent);
+                    return out;
+                }
+
+                void sizeHintEvent(const ftk::SizeHintEvent& event) override
+                {
+                    PushButton::sizeHintEvent(event);
+                    _dragLength = event.style->getSizeRole(
+                        ftk::SizeRole::DragLength,
+                        event.displayScale);
+                }
+
+                void mouseMoveEvent(ftk::MouseMoveEvent& event) override
+                {
+                    PushButton::mouseMoveEvent(event);
+                    if (_editable && _isMousePressed())
+                    {
+                        const float length = ftk::length(event.pos - _getMousePressPos());
+                        if (length > _dragLength)
+                        {
+                            event.dragDropData =
+                                std::make_shared<PlaylistDragData>(_index);
+                        }
+                    }
+                }
+
+                void dragEnterEvent(ftk::DragDropEvent& event) override
+                {
+                    if (!_editable)
+                    {
+                        return;
+                    }
+                    event.accept =
+                        static_cast<bool>(
+                            std::dynamic_pointer_cast<PlaylistDragData>(event.data)) ||
+                        static_cast<bool>(
+                            std::dynamic_pointer_cast<ftk::DragDropTextData>(event.data));
+                }
+
+                void dropEvent(ftk::DragDropEvent& event) override
+                {
+                    if (!_editable)
+                    {
+                        return;
+                    }
+                    if (auto data =
+                        std::dynamic_pointer_cast<PlaylistDragData>(event.data))
+                    {
+                        event.accept = true;
+                        if (_moveCallback)
+                        {
+                            _moveCallback(data->index, _index);
+                        }
+                    }
+                    else if (auto data =
+                        std::dynamic_pointer_cast<ftk::DragDropTextData>(event.data))
+                    {
+                        event.accept = true;
+                        std::vector<ftk::Path> paths;
+                        for (const auto& value : data->getText())
+                        {
+                            paths.push_back(ftk::Path(value));
+                        }
+                        if (_addCallback)
+                        {
+                            _addCallback(paths);
+                        }
+                    }
+                }
+
+            private:
+                size_t _index = 0;
+                bool _editable = false;
+                int _dragLength = 0;
+                std::function<void(size_t, size_t)> _moveCallback;
+                std::function<void(const std::vector<ftk::Path>&)> _addCallback;
+            };
+
+            std::string getDurationText(const OTIO_NS::RationalTime& value)
+            {
+                const int64_t frames = static_cast<int64_t>(std::llround(value.value()));
+                return ftk::Format("{0}f").arg(frames).str();
+            }
+        }
+
+        struct PlaylistTool::Private
+        {
+            std::weak_ptr<App> app;
+            int selected = -1;
+            std::shared_ptr<ftk::Label> pathLabel;
+            std::shared_ptr<ftk::Label> statusLabel;
+            std::shared_ptr<ftk::VerticalLayout> listLayout;
+            std::vector<std::shared_ptr<PlaylistRow> > rows;
+            std::shared_ptr<ftk::PushButton> addButton;
+            std::shared_ptr<ftk::PushButton> addFolderButton;
+            std::shared_ptr<ftk::PushButton> removeButton;
+            std::shared_ptr<ftk::PushButton> saveButton;
+            std::shared_ptr<ftk::PushButton> saveAsButton;
+            std::shared_ptr<ftk::Observer<int> > revisionObserver;
+        };
+
+        void PlaylistTool::_init(
+            const std::shared_ptr<ftk::Context>& context,
+            const std::shared_ptr<App>& app,
+            const std::shared_ptr<MainWindow>& mainWindow,
+            const std::shared_ptr<IWidget>& parent)
+        {
+            IToolWidget::_init(
+                context,
+                app,
+                mainWindow,
+                "OTIO Playlist",
+                "Files",
+                "djv::app::PlaylistTool",
+                parent);
+            FTK_P();
+            p.app = app;
+
+            auto layout = ftk::VerticalLayout::create(context);
+            layout->setSpacingRole(ftk::SizeRole::None);
+
+            auto headerLayout = ftk::HorizontalLayout::create(context, layout);
+            headerLayout->setMarginRole(ftk::SizeRole::Margin);
+            headerLayout->setSpacingRole(ftk::SizeRole::SpacingSmall);
+            auto titleLabel = ftk::Label::create(context, "OTIO Playlist", headerLayout);
+            titleLabel->setFont(ftk::FontType::Bold);
+            titleLabel->setHStretch(ftk::Stretch::Expanding);
+
+            p.pathLabel = ftk::Label::create(context, layout);
+            p.pathLabel->setMarginRole(ftk::SizeRole::MarginSmall);
+            p.pathLabel->setTextRole(ftk::ColorRole::TextDisabled);
+
+            p.statusLabel = ftk::Label::create(context, layout);
+            p.statusLabel->setMarginRole(ftk::SizeRole::MarginSmall);
+
+            ftk::Divider::create(context, ftk::Orientation::Vertical, layout);
+
+            p.listLayout = ftk::VerticalLayout::create(context);
+            p.listLayout->setSpacingRole(ftk::SizeRole::SpacingSmall);
+            p.listLayout->setMarginRole(ftk::SizeRole::MarginSmall);
+            auto scrollWidget = ftk::ScrollWidget::create(
+                context,
+                ftk::ScrollType::Vertical,
+                layout);
+            scrollWidget->setBorder(false);
+            scrollWidget->setVStretch(ftk::Stretch::Expanding);
+            scrollWidget->setWidget(p.listLayout);
+
+            ftk::Divider::create(context, ftk::Orientation::Vertical, layout);
+
+            auto actionsLayout = ftk::HorizontalLayout::create(context, layout);
+            actionsLayout->setMarginRole(ftk::SizeRole::MarginSmall);
+            actionsLayout->setSpacingRole(ftk::SizeRole::SpacingSmall);
+            p.addButton = ftk::PushButton::create(context, "Add", actionsLayout);
+            p.addButton->setTooltip("Add an image or video to the end of the playlist.");
+            p.addFolderButton = ftk::PushButton::create(
+                context,
+                "Add Folder",
+                actionsLayout);
+            p.addFolderButton->setTooltip(
+                "Add matching media from a folder and its subfolders.");
+            p.removeButton = ftk::PushButton::create(context, "Remove", actionsLayout);
+            p.removeButton->setTooltip("Remove the selected playlist item.");
+            p.saveButton = ftk::PushButton::create(context, "Save", actionsLayout);
+            p.saveButton->setTooltip("Save the active OTIO playlist.");
+            p.saveAsButton = ftk::PushButton::create(context, "Save As", actionsLayout);
+            p.saveAsButton->setTooltip("Save the active timeline as an .otio file.");
+
+            _setWidget(layout);
+
+            std::weak_ptr<App> appWeak(app);
+            p.addButton->setClickedCallback(
+                [appWeak]
+                {
+                    if (auto app = appWeak.lock())
+                    {
+                        app->openPlaylistMediaDialog();
+                    }
+                });
+            p.addFolderButton->setClickedCallback(
+                [appWeak]
+                {
+                    if (auto app = appWeak.lock())
+                    {
+                        app->openPlaylistFolderDialog(false);
+                    }
+                });
+            p.removeButton->setClickedCallback(
+                [this, appWeak]
+                {
+                    if (_p->selected >= 0)
+                    {
+                        if (auto app = appWeak.lock())
+                        {
+                            app->removePlaylistMedia(
+                                static_cast<size_t>(_p->selected));
+                        }
+                    }
+                });
+            p.saveButton->setClickedCallback(
+                [appWeak]
+                {
+                    if (auto app = appWeak.lock())
+                    {
+                        app->savePlaylist();
+                    }
+                });
+            p.saveAsButton->setClickedCallback(
+                [appWeak]
+                {
+                    if (auto app = appWeak.lock())
+                    {
+                        app->savePlaylistAsDialog();
+                    }
+                });
+
+            p.revisionObserver = ftk::Observer<int>::create(
+                app->getPlaylistModel()->observeRevision(),
+                [this](int)
+                {
+                    _update();
+                });
+        }
+
+        PlaylistTool::PlaylistTool() :
+            _p(new Private)
+        {}
+
+        PlaylistTool::~PlaylistTool()
+        {}
+
+        std::shared_ptr<PlaylistTool> PlaylistTool::create(
+            const std::shared_ptr<ftk::Context>& context,
+            const std::shared_ptr<App>& app,
+            const std::shared_ptr<MainWindow>& mainWindow,
+            const std::shared_ptr<IWidget>& parent)
+        {
+            auto out = std::shared_ptr<PlaylistTool>(new PlaylistTool);
+            out->_init(context, app, mainWindow, parent);
+            return out;
+        }
+
+        void PlaylistTool::dragEnterEvent(ftk::DragDropEvent& event)
+        {
+            FTK_P();
+            if (auto app = p.app.lock())
+            {
+                if (app->getPlaylistModel()->isEditable())
+                {
+                    event.accept =
+                        static_cast<bool>(
+                            std::dynamic_pointer_cast<PlaylistDragData>(event.data)) ||
+                        static_cast<bool>(
+                            std::dynamic_pointer_cast<ftk::DragDropTextData>(event.data));
+                }
+            }
+        }
+
+        void PlaylistTool::dropEvent(ftk::DragDropEvent& event)
+        {
+            FTK_P();
+            auto app = p.app.lock();
+            if (!app || !app->getPlaylistModel()->isEditable())
+            {
+                return;
+            }
+            if (auto data = std::dynamic_pointer_cast<PlaylistDragData>(event.data))
+            {
+                event.accept = true;
+                const auto& items = app->getPlaylistModel()->getItems();
+                if (!items.empty())
+                {
+                    app->movePlaylistMedia(data->index, items.size() - 1);
+                }
+            }
+            else if (auto data =
+                std::dynamic_pointer_cast<ftk::DragDropTextData>(event.data))
+            {
+                event.accept = true;
+                std::vector<ftk::Path> paths;
+                for (const auto& value : data->getText())
+                {
+                    paths.push_back(ftk::Path(value));
+                }
+                app->addPlaylistMedia(paths);
+            }
+        }
+
+        void PlaylistTool::_update()
+        {
+            FTK_P();
+            auto app = p.app.lock();
+            if (!app)
+            {
+                return;
+            }
+            auto model = app->getPlaylistModel();
+            const auto& items = model->getItems();
+            if (p.selected >= static_cast<int>(items.size()))
+            {
+                p.selected = items.empty() ? -1 : static_cast<int>(items.size()) - 1;
+            }
+
+            p.pathLabel->setText(
+                model->isScratch() ?
+                "Untitled playlist" :
+                ftk::elide(model->getPath().getFileName()));
+            p.pathLabel->setTooltip(model->getPath().get());
+
+            if (!model->getLastError().empty())
+            {
+                p.statusLabel->setText(model->getLastError());
+                p.statusLabel->setTextRole(ftk::ColorRole::Red);
+            }
+            else if (model->isEditable())
+            {
+                p.statusLabel->setText(
+                    model->isDirty() ?
+                    "Editable - unsaved changes" :
+                    "Editable - saved");
+                p.statusLabel->setTextRole(
+                    model->isDirty() ?
+                    ftk::ColorRole::Yellow :
+                    ftk::ColorRole::Green);
+            }
+            else
+            {
+                p.statusLabel->setText(
+                    model->getReadOnlyReason().empty() ?
+                    "Read only" :
+                    model->getReadOnlyReason());
+                p.statusLabel->setTextRole(ftk::ColorRole::Yellow);
+            }
+
+            p.listLayout->clear();
+            p.rows.clear();
+            std::weak_ptr<App> appWeak(app);
+            for (size_t i = 0; i < items.size(); ++i)
+            {
+                const auto& item = items[i];
+                const std::string text = ftk::Format(
+                    "{0}.  {1}  [{2}{3}]").
+                    arg(i + 1).
+                    arg(item.name).
+                    arg(getDurationText(item.duration)).
+                    arg(item.hasAudio ? ", audio" : "").
+                    str();
+                std::string tooltip = item.path.get();
+                if (item.missing)
+                {
+                    tooltip += "\nMissing media";
+                }
+                auto row = PlaylistRow::create(
+                    getContext(),
+                    i,
+                    text,
+                    tooltip,
+                    model->isEditable(),
+                    [appWeak](size_t from, size_t to)
+                    {
+                        if (auto app = appWeak.lock())
+                        {
+                            app->movePlaylistMedia(from, to);
+                        }
+                    },
+                    [appWeak](const std::vector<ftk::Path>& paths)
+                    {
+                        if (auto app = appWeak.lock())
+                        {
+                            app->addPlaylistMedia(paths);
+                        }
+                    },
+                    p.listLayout);
+                row->setChecked(static_cast<int>(i) == p.selected);
+                row->setClickedCallback(
+                    [this, i]
+                    {
+                        _setSelected(static_cast<int>(i));
+                    });
+                p.rows.push_back(row);
+            }
+            if (items.empty())
+            {
+                auto label = ftk::Label::create(
+                    getContext(),
+                    "Drop images or videos here",
+                    p.listLayout);
+                label->setMarginRole(ftk::SizeRole::Margin);
+                label->setHAlign(ftk::HAlign::Center);
+            }
+            auto spacer = ftk::Spacer::create(
+                getContext(),
+                ftk::Orientation::Vertical,
+                p.listLayout);
+            spacer->setVStretch(ftk::Stretch::Expanding);
+
+            p.addButton->setEnabled(model->isEditable());
+            p.addFolderButton->setEnabled(model->isEditable());
+            p.removeButton->setEnabled(
+                model->isEditable() &&
+                p.selected >= 0 &&
+                items.size() > 1);
+            p.saveButton->setEnabled(
+                model->isEditable() &&
+                model->isDirty());
+            p.saveAsButton->setEnabled(model->isAvailable());
+        }
+
+        void PlaylistTool::_setSelected(int value)
+        {
+            FTK_P();
+            p.selected = value;
+            for (size_t i = 0; i < p.rows.size(); ++i)
+            {
+                p.rows[i]->setChecked(static_cast<int>(i) == value);
+            }
+            if (auto app = p.app.lock())
+            {
+                p.removeButton->setEnabled(
+                    app->getPlaylistModel()->isEditable() &&
+                    value >= 0 &&
+                    app->getPlaylistModel()->getItems().size() > 1);
+            }
+        }
+    }
+}

--- a/lib/djv/App/PlaylistTool.h
+++ b/lib/djv/App/PlaylistTool.h
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the DJV project.
+
+#pragma once
+
+#include <djv/App/IToolWidget.h>
+
+namespace djv
+{
+    namespace app
+    {
+        class App;
+
+        //! OTIO media playlist tool.
+        class PlaylistTool : public IToolWidget
+        {
+            FTK_NON_COPYABLE(PlaylistTool);
+
+        protected:
+            void _init(
+                const std::shared_ptr<ftk::Context>&,
+                const std::shared_ptr<App>&,
+                const std::shared_ptr<MainWindow>&,
+                const std::shared_ptr<IWidget>& parent);
+
+            PlaylistTool();
+
+        public:
+            ~PlaylistTool();
+
+            static std::shared_ptr<PlaylistTool> create(
+                const std::shared_ptr<ftk::Context>&,
+                const std::shared_ptr<App>&,
+                const std::shared_ptr<MainWindow>&,
+                const std::shared_ptr<IWidget>& parent = nullptr);
+
+            void dragEnterEvent(ftk::DragDropEvent&) override;
+            void dropEvent(ftk::DragDropEvent&) override;
+
+        private:
+            void _update();
+            void _setSelected(int);
+
+            FTK_PRIVATE();
+        };
+    }
+}

--- a/lib/djv/App/ToolsActions.cpp
+++ b/lib/djv/App/ToolsActions.cpp
@@ -4,6 +4,7 @@
 #include <djv/App/ToolsActions.h>
 
 #include <djv/App/App.h>
+#include <djv/Models/PlaylistModel.h>
 #include <djv/Models/ToolsModel.h>
 
 #include <ftk/Core/Format.h>
@@ -15,6 +16,7 @@ namespace djv
         struct ToolsActions::Private
         {
             std::shared_ptr<ftk::Observer<std::string> > activeObserver;
+            std::shared_ptr<ftk::Observer<int> > playlistObserver;
         };
 
         void ToolsActions::_init(
@@ -67,6 +69,25 @@ namespace djv
                     for (auto i : _actions)
                     {
                         i.second->setChecked(i.first == value);
+                    }
+                });
+
+            p.playlistObserver = ftk::Observer<int>::create(
+                app->getPlaylistModel()->observeRevision(),
+                [this, appWeak](int)
+                {
+                    if (auto app = appWeak.lock())
+                    {
+                        const bool available =
+                            app->getPlaylistModel()->isAvailable();
+                        _actions["OTIO Playlist"]->setEnabled(available);
+                        if (!available &&
+                            app->getToolsModel()->getActiveTool() ==
+                                "OTIO Playlist")
+                        {
+                            app->getToolsModel()->setActiveTool(
+                                std::string());
+                        }
                     }
                 });
         }

--- a/lib/djv/AppTest/FolderScanServiceTest.cpp
+++ b/lib/djv/AppTest/FolderScanServiceTest.cpp
@@ -135,6 +135,10 @@ namespace djv
                 DJV_FOLDER_SCAN_REQUIRE(secondResult.isSuccess());
                 DJV_FOLDER_SCAN_REQUIRE(1 == firstResult.scanResult.paths.size());
                 DJV_FOLDER_SCAN_REQUIRE(1 == secondResult.scanResult.paths.size());
+                DJV_FOLDER_SCAN_REQUIRE(
+                    0 != firstResult.scanResult.contentSignature);
+                DJV_FOLDER_SCAN_REQUIRE(
+                    0 != secondResult.scanResult.contentSignature);
                 DJV_FOLDER_SCAN_REQUIRE(!service.getState(first.id));
                 DJV_FOLDER_SCAN_REQUIRE(!service.getState(second.id));
             }

--- a/lib/djv/AppTest/FolderScanServiceTest.cpp
+++ b/lib/djv/AppTest/FolderScanServiceTest.cpp
@@ -299,6 +299,23 @@ namespace djv
                 DJV_FOLDER_SCAN_REQUIRE(
                     app::FolderScanServiceError::InvalidRequest == unboundedResult.error);
 
+                models::FolderScanOptions runtimeExtensions;
+                for (size_t i = 0; i < 512; ++i)
+                {
+                    runtimeExtensions.fileExtensions.push_back(
+                        ".runtime" + std::to_string(i));
+                }
+                const auto runtimeExtensionsResult = waitFor(
+                    service.request(root.path(), filter, runtimeExtensions));
+                DJV_FOLDER_SCAN_REQUIRE(runtimeExtensionsResult.isSuccess());
+
+                runtimeExtensions.fileExtensions.resize(4097, ".overflow");
+                const auto excessiveExtensionsResult = waitFor(
+                    service.request(root.path(), filter, runtimeExtensions));
+                DJV_FOLDER_SCAN_REQUIRE(
+                    app::FolderScanServiceError::InvalidRequest ==
+                        excessiveExtensionsResult.error);
+
                 models::FolderScanOptions resultLimit;
                 resultLimit.maxResults = 2;
                 const auto limited = waitFor(

--- a/lib/djv/AppTest/FolderScanServiceTest.cpp
+++ b/lib/djv/AppTest/FolderScanServiceTest.cpp
@@ -1,0 +1,558 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the DJV project.
+
+#include <djv/AppTest/FolderScanServiceTest.h>
+
+#include <djv/App/FolderScanService.h>
+#include <djv/Models/FileFilter.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <future>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+#if defined(_WIN32)
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <Windows.h>
+#endif
+namespace djv
+{
+    namespace app_tests
+    {
+        namespace
+        {
+            void require(bool value, const char* expression, int line)
+            {
+                if (!value)
+                {
+                    std::ostringstream stream;
+                    stream << "Requirement failed at line " << line << ": " << expression;
+                    throw std::runtime_error(stream.str());
+                }
+            }
+
+#define DJV_FOLDER_SCAN_REQUIRE(EXPRESSION) \
+            require(!!(EXPRESSION), #EXPRESSION, __LINE__)
+
+            class TempDirectory
+            {
+            public:
+                explicit TempDirectory(const std::string& suffix)
+                {
+                    static std::atomic<uint64_t> nextId(1);
+                    const auto clock = std::chrono::steady_clock::now().time_since_epoch().count();
+                    _path = std::filesystem::temp_directory_path() /
+                        ("djv-folder-scan-service-" + suffix + "-" +
+                            std::to_string(clock) + "-" +
+                            std::to_string(nextId.fetch_add(1)));
+                    std::filesystem::create_directories(_path);
+                    _path = std::filesystem::absolute(_path);
+                }
+
+                ~TempDirectory()
+                {
+                    std::error_code error;
+                    std::filesystem::remove_all(_path, error);
+                }
+
+                const std::filesystem::path& path() const
+                {
+                    return _path;
+                }
+
+                void touch(const std::filesystem::path& relative) const
+                {
+                    const auto path = _path / relative;
+                    std::filesystem::create_directories(path.parent_path());
+                    std::ofstream stream(path, std::ios::binary | std::ios::trunc);
+                    stream << "x";
+                    DJV_FOLDER_SCAN_REQUIRE(stream.good());
+                }
+
+            private:
+                std::filesystem::path _path;
+            };
+
+            std::shared_ptr<const models::CompiledFileFilter> emptyFilter()
+            {
+                const auto result = models::compileFileFilter("");
+                DJV_FOLDER_SCAN_REQUIRE(result);
+                DJV_FOLDER_SCAN_REQUIRE(result.filter);
+                return result.filter;
+            }
+
+            app::FolderScanServiceResult waitFor(
+                const app::FolderScanServiceRequest& request,
+                std::chrono::milliseconds timeout = std::chrono::seconds(5))
+            {
+                DJV_FOLDER_SCAN_REQUIRE(request);
+                DJV_FOLDER_SCAN_REQUIRE(
+                    std::future_status::ready == request.future.wait_for(timeout));
+                return request.future.get();
+            }
+
+            void orderAndState()
+            {
+                TempDirectory firstRoot("order-a");
+                TempDirectory secondRoot("order-b");
+                firstRoot.touch("a.exr");
+                secondRoot.touch("b.exr");
+                const auto filter = emptyFilter();
+                const auto gate = std::make_shared<app::FolderScanServiceStartGate>();
+                app::FolderScanServiceOptions serviceOptions;
+                serviceOptions.maxPendingRequests = 2;
+                serviceOptions.startGate = gate;
+                app::FolderScanService service(serviceOptions);
+
+                const auto first = service.request(firstRoot.path(), filter);
+                DJV_FOLDER_SCAN_REQUIRE(
+                    gate->waitUntilEntered(std::chrono::seconds(2)));
+                const auto second = service.request(secondRoot.path(), filter);
+                DJV_FOLDER_SCAN_REQUIRE(
+                    app::FolderScanServiceRequestState::Running ==
+                        service.getState(first.id).value());
+                DJV_FOLDER_SCAN_REQUIRE(
+                    app::FolderScanServiceRequestState::Queued ==
+                        service.getState(second.id).value());
+                DJV_FOLDER_SCAN_REQUIRE(
+                    std::future_status::timeout ==
+                        second.future.wait_for(std::chrono::milliseconds(20)));
+
+                gate->release();
+                const auto firstResult = waitFor(first);
+                const auto secondResult = waitFor(second);
+                DJV_FOLDER_SCAN_REQUIRE(firstResult.isSuccess());
+                DJV_FOLDER_SCAN_REQUIRE(secondResult.isSuccess());
+                DJV_FOLDER_SCAN_REQUIRE(1 == firstResult.scanResult.paths.size());
+                DJV_FOLDER_SCAN_REQUIRE(1 == secondResult.scanResult.paths.size());
+                DJV_FOLDER_SCAN_REQUIRE(!service.getState(first.id));
+                DJV_FOLDER_SCAN_REQUIRE(!service.getState(second.id));
+            }
+
+            void cancellationAndImmediateRerequest()
+            {
+                TempDirectory root("cancel");
+                root.touch("a.exr");
+                const auto filter = emptyFilter();
+                const auto gate = std::make_shared<app::FolderScanServiceStartGate>();
+                app::FolderScanServiceOptions options;
+                options.maxPendingRequests = 1;
+                options.startGate = gate;
+                app::FolderScanService service(options);
+
+                const auto first = service.request(root.path(), filter);
+                DJV_FOLDER_SCAN_REQUIRE(
+                    gate->waitUntilEntered(std::chrono::seconds(2)));
+                DJV_FOLDER_SCAN_REQUIRE(service.cancel(first.id));
+                DJV_FOLDER_SCAN_REQUIRE(!service.cancel(first.id));
+                const auto cancelled = waitFor(first);
+                DJV_FOLDER_SCAN_REQUIRE(
+                    app::FolderScanServiceStatus::Cancelled == cancelled.status);
+                DJV_FOLDER_SCAN_REQUIRE(
+                    app::FolderScanServiceError::Cancelled == cancelled.error);
+                DJV_FOLDER_SCAN_REQUIRE(cancelled.scanResult.paths.empty());
+
+                // The cancelled running request no longer occupies bounded
+                // queue capacity, even though its scanner checkpoint may still
+                // be unwinding on the single worker.
+                const auto second = service.request(root.path(), filter);
+                DJV_FOLDER_SCAN_REQUIRE(second);
+                DJV_FOLDER_SCAN_REQUIRE(
+                    std::future_status::timeout ==
+                        second.future.wait_for(std::chrono::milliseconds(20)));
+                gate->release();
+                DJV_FOLDER_SCAN_REQUIRE(waitFor(second).isSuccess());
+            }
+
+            void queueSaturation()
+            {
+                TempDirectory root("queue");
+                root.touch("a.exr");
+                const auto filter = emptyFilter();
+                const auto gate = std::make_shared<app::FolderScanServiceStartGate>();
+                app::FolderScanServiceOptions options;
+                options.maxPendingRequests = 2;
+                options.startGate = gate;
+                app::FolderScanService service(options);
+
+                const auto first = service.request(root.path(), filter);
+                DJV_FOLDER_SCAN_REQUIRE(
+                    gate->waitUntilEntered(std::chrono::seconds(2)));
+                const auto second = service.request(root.path(), filter);
+                const auto third = service.request(root.path(), filter);
+                const auto rejected = waitFor(third);
+                DJV_FOLDER_SCAN_REQUIRE(
+                    app::FolderScanServiceStatus::Rejected == rejected.status);
+                DJV_FOLDER_SCAN_REQUIRE(
+                    app::FolderScanServiceError::QueueFull == rejected.error);
+                gate->release();
+                DJV_FOLDER_SCAN_REQUIRE(waitFor(first).isSuccess());
+                DJV_FOLDER_SCAN_REQUIRE(waitFor(second).isSuccess());
+
+                const auto stats = service.getStats();
+                DJV_FOLDER_SCAN_REQUIRE(3 == stats.requestsSubmitted);
+                DJV_FOLDER_SCAN_REQUIRE(3 == stats.requestsCompleted);
+                DJV_FOLDER_SCAN_REQUIRE(1 == stats.requestsRejected);
+            }
+
+            void queuedCancellation()
+            {
+                TempDirectory root("queued-cancel");
+                root.touch("a.exr");
+                const auto filter = emptyFilter();
+                const auto gate = std::make_shared<app::FolderScanServiceStartGate>();
+                app::FolderScanServiceOptions options;
+                options.maxPendingRequests = 2;
+                options.startGate = gate;
+                app::FolderScanService service(options);
+
+                const auto running = service.request(root.path(), filter);
+                DJV_FOLDER_SCAN_REQUIRE(
+                    gate->waitUntilEntered(std::chrono::seconds(2)));
+                const auto queued = service.request(root.path(), filter);
+                DJV_FOLDER_SCAN_REQUIRE(
+                    app::FolderScanServiceRequestState::Queued ==
+                        service.getState(queued.id).value());
+                DJV_FOLDER_SCAN_REQUIRE(service.cancel(queued.id));
+                const auto cancelled = waitFor(queued);
+                DJV_FOLDER_SCAN_REQUIRE(
+                    app::FolderScanServiceStatus::Cancelled == cancelled.status);
+                DJV_FOLDER_SCAN_REQUIRE(cancelled.scanResult.paths.empty());
+                DJV_FOLDER_SCAN_REQUIRE(!service.getState(queued.id));
+
+                gate->release();
+                DJV_FOLDER_SCAN_REQUIRE(waitFor(running).isSuccess());
+            }
+
+            void shutdownAndDestruction()
+            {
+                TempDirectory root("shutdown");
+                root.touch("a.exr");
+                const auto filter = emptyFilter();
+                const auto gate = std::make_shared<app::FolderScanServiceStartGate>();
+                app::FolderScanServiceOptions options;
+                options.startGate = gate;
+
+                std::shared_future<app::FolderScanServiceResult> destroyedFuture;
+                const auto start = std::chrono::steady_clock::now();
+                {
+                    app::FolderScanService service(options);
+                    const auto request = service.request(root.path(), filter);
+                    destroyedFuture = request.future;
+                    DJV_FOLDER_SCAN_REQUIRE(
+                        gate->waitUntilEntered(std::chrono::seconds(2)));
+                }
+                const auto elapsed = std::chrono::steady_clock::now() - start;
+                DJV_FOLDER_SCAN_REQUIRE(elapsed < std::chrono::seconds(2));
+                DJV_FOLDER_SCAN_REQUIRE(
+                    std::future_status::ready ==
+                        destroyedFuture.wait_for(std::chrono::seconds(1)));
+                DJV_FOLDER_SCAN_REQUIRE(
+                    app::FolderScanServiceError::ShuttingDown ==
+                        destroyedFuture.get().error);
+
+                gate->release();
+                app::FolderScanService service;
+                service.shutdown();
+                service.shutdown();
+                const auto rejected = waitFor(service.request(root.path(), filter));
+                DJV_FOLDER_SCAN_REQUIRE(
+                    app::FolderScanServiceStatus::Rejected == rejected.status);
+                DJV_FOLDER_SCAN_REQUIRE(
+                    app::FolderScanServiceError::ShuttingDown == rejected.error);
+            }
+
+            void validationAndAtomicLimits()
+            {
+                TempDirectory root("limits");
+                root.touch("a.exr");
+                root.touch("b.exr");
+                root.touch("c.exr");
+                const auto filter = emptyFilter();
+                app::FolderScanService service;
+
+                const auto relative = waitFor(service.request("relative", filter));
+                DJV_FOLDER_SCAN_REQUIRE(
+                    app::FolderScanServiceError::InvalidRequest == relative.error);
+                const auto noFilter = waitFor(service.request(root.path(), nullptr));
+                DJV_FOLDER_SCAN_REQUIRE(
+                    app::FolderScanServiceError::InvalidRequest == noFilter.error);
+
+                models::FolderScanOptions unbounded;
+                unbounded.maxResults = 0;
+                const auto unboundedResult = waitFor(
+                    service.request(root.path(), filter, unbounded));
+                DJV_FOLDER_SCAN_REQUIRE(
+                    app::FolderScanServiceError::InvalidRequest == unboundedResult.error);
+
+                models::FolderScanOptions resultLimit;
+                resultLimit.maxResults = 2;
+                const auto limited = waitFor(
+                    service.request(root.path(), filter, resultLimit));
+                DJV_FOLDER_SCAN_REQUIRE(
+                    app::FolderScanServiceStatus::Failed == limited.status);
+                DJV_FOLDER_SCAN_REQUIRE(
+                    app::FolderScanServiceError::LimitReached == limited.error);
+                DJV_FOLDER_SCAN_REQUIRE(
+                    models::FolderScanStatus::ResultLimitReached ==
+                        limited.scanResult.status);
+                DJV_FOLDER_SCAN_REQUIRE(limited.scanResult.paths.empty());
+
+                models::FolderScanOptions candidateLimit;
+                candidateLimit.maxCandidates = 1;
+                const auto candidateLimited = waitFor(
+                    service.request(root.path(), filter, candidateLimit));
+                DJV_FOLDER_SCAN_REQUIRE(
+                    app::FolderScanServiceError::LimitReached == candidateLimited.error);
+                DJV_FOLDER_SCAN_REQUIRE(candidateLimited.scanResult.paths.empty());
+
+                std::filesystem::create_directories(root.path() / "empty-a");
+                std::filesystem::create_directories(root.path() / "empty-b");
+                models::FolderScanOptions traversalLimit;
+                traversalLimit.maxDirectories = 2;
+                const auto traversalLimited = waitFor(
+                    service.request(root.path(), filter, traversalLimit));
+                DJV_FOLDER_SCAN_REQUIRE(
+                    app::FolderScanServiceError::LimitReached ==
+                        traversalLimited.error);
+                DJV_FOLDER_SCAN_REQUIRE(
+                    models::FolderScanStatus::TraversalLimitReached ==
+                        traversalLimited.scanResult.status);
+                DJV_FOLDER_SCAN_REQUIRE(traversalLimited.scanResult.paths.empty());
+
+                models::FolderScanOptions entryLimit;
+                entryLimit.maxEntries = 2;
+                const auto entryLimited = waitFor(
+                    service.request(root.path(), filter, entryLimit));
+                DJV_FOLDER_SCAN_REQUIRE(
+                    app::FolderScanServiceError::LimitReached ==
+                        entryLimited.error);
+                DJV_FOLDER_SCAN_REQUIRE(2 == entryLimited.scanResult.visitedEntries);
+                DJV_FOLDER_SCAN_REQUIRE(entryLimited.scanResult.paths.empty());
+
+                models::FolderScanOptions complete;
+                complete.maxResults = 3;
+                const auto accepted = waitFor(
+                    service.request(root.path(), filter, complete));
+                DJV_FOLDER_SCAN_REQUIRE(accepted.isSuccess());
+                DJV_FOLDER_SCAN_REQUIRE(3 == accepted.scanResult.paths.size());
+
+                const auto missing = waitFor(service.request(
+                    root.path() / "missing", filter));
+                DJV_FOLDER_SCAN_REQUIRE(
+                    app::FolderScanServiceStatus::Failed == missing.status);
+                DJV_FOLDER_SCAN_REQUIRE(
+                    app::FolderScanServiceError::InvalidRoot == missing.error);
+            }
+
+            void repeatedRuns()
+            {
+                const auto filter = emptyFilter();
+                for (size_t iteration = 0; iteration < 20; ++iteration)
+                {
+                    TempDirectory root("repeat-" + std::to_string(iteration));
+                    for (size_t i = 0; i < 32; ++i)
+                    {
+                        root.touch(
+                            std::filesystem::path("shot") /
+                            ("frame-" + std::to_string(i) + ".exr"));
+                    }
+                    app::FolderScanServiceOptions options;
+                    options.maxPendingRequests = 4;
+                    app::FolderScanService service(options);
+                    std::vector<app::FolderScanServiceRequest> requests;
+                    for (size_t i = 0; i < 4; ++i)
+                    {
+                        requests.push_back(service.request(root.path(), filter));
+                    }
+                    for (const auto& request : requests)
+                    {
+                        const auto result = waitFor(request);
+                        DJV_FOLDER_SCAN_REQUIRE(result.isSuccess());
+                        DJV_FOLDER_SCAN_REQUIRE(32 == result.scanResult.paths.size());
+                    }
+                }
+            }
+
+            void concurrentSubmissionStress()
+            {
+                const auto filter = emptyFilter();
+                for (size_t iteration = 0; iteration < 10; ++iteration)
+                {
+                    TempDirectory root("concurrent-" + std::to_string(iteration));
+                    for (size_t i = 0; i < 16; ++i)
+                    {
+                        root.touch("frame-" + std::to_string(i) + ".exr");
+                    }
+
+                    app::FolderScanServiceOptions options;
+                    options.maxPendingRequests = 8;
+                    app::FolderScanService service(options);
+                    std::vector<app::FolderScanServiceRequest> requests(8);
+                    std::vector<std::thread> submitters;
+                    for (size_t i = 0; i < requests.size(); ++i)
+                    {
+                        submitters.emplace_back(
+                            [&service, &requests, &root, &filter, i]
+                            {
+                                requests[i] = service.request(root.path(), filter);
+                            });
+                    }
+                    for (auto& submitter : submitters)
+                    {
+                        submitter.join();
+                    }
+
+                    std::vector<uint64_t> ids;
+                    for (const auto& request : requests)
+                    {
+                        const auto result = waitFor(request);
+                        DJV_FOLDER_SCAN_REQUIRE(result.isSuccess());
+                        DJV_FOLDER_SCAN_REQUIRE(16 == result.scanResult.paths.size());
+                        ids.push_back(result.requestId);
+                    }
+                    std::sort(ids.begin(), ids.end());
+                    DJV_FOLDER_SCAN_REQUIRE(
+                        ids.end() == std::unique(ids.begin(), ids.end()));
+                }
+            }
+
+            void largeDirectoryBenchmark()
+            {
+                TempDirectory root("benchmark-10k");
+                for (size_t i = 0; i < 10000; ++i)
+                {
+                    std::ostringstream name;
+                    name << "frame-" << std::setfill('0') << std::setw(5)
+                         << i << ".exr";
+                    root.touch(std::filesystem::path("shots") / name.str());
+                }
+
+                const auto compiled = models::compileFileFilter("ext:^exr$");
+                DJV_FOLDER_SCAN_REQUIRE(compiled);
+                app::FolderScanServiceOptions serviceOptions;
+                serviceOptions.maxResultsPerRequest = 10000;
+                app::FolderScanService service(serviceOptions);
+                models::FolderScanOptions scanOptions;
+                scanOptions.maxCandidates = 10001;
+                scanOptions.maxResults = 10000;
+                scanOptions.fileExtensions = { ".exr" };
+
+                const auto submitStart = std::chrono::steady_clock::now();
+                const auto request = service.request(
+                    root.path(),
+                    compiled.filter,
+                    scanOptions);
+                const auto submitElapsed =
+                    std::chrono::steady_clock::now() - submitStart;
+                DJV_FOLDER_SCAN_REQUIRE(
+                    submitElapsed < std::chrono::milliseconds(50));
+
+                const auto scanStart = std::chrono::steady_clock::now();
+                const auto result = waitFor(request, std::chrono::seconds(30));
+                const auto scanElapsed = std::chrono::duration_cast<
+                    std::chrono::milliseconds>(
+                        std::chrono::steady_clock::now() - scanStart);
+                DJV_FOLDER_SCAN_REQUIRE(result.isSuccess());
+                DJV_FOLDER_SCAN_REQUIRE(10000 == result.scanResult.paths.size());
+                DJV_FOLDER_SCAN_REQUIRE(std::is_sorted(
+                    result.scanResult.paths.begin(),
+                    result.scanResult.paths.end(),
+                    [](const ftk::Path& a, const ftk::Path& b)
+                    {
+                        return a.get() < b.get();
+                    }));
+                DJV_FOLDER_SCAN_REQUIRE(scanElapsed < std::chrono::seconds(10));
+                std::cout << "FolderScanService 10k benchmark: "
+                          << scanElapsed.count() << " ms\n";
+            }
+
+#if defined(_WIN32)
+            void synchronousIoCancellation()
+            {
+                HANDLE readPipe = nullptr;
+                HANDLE writePipe = nullptr;
+                SECURITY_ATTRIBUTES attributes = {};
+                attributes.nLength = sizeof(attributes);
+                attributes.bInheritHandle = FALSE;
+                DJV_FOLDER_SCAN_REQUIRE(CreatePipe(
+                    &readPipe, &writePipe, &attributes, 0));
+
+                models::FolderScanCancellationSource cancellation;
+                const auto token = cancellation.getToken();
+                std::atomic_bool entered(false);
+                std::atomic<DWORD> error(ERROR_SUCCESS);
+                std::thread reader([&]
+                {
+                    token.bindToCurrentThread();
+                    entered.store(true, std::memory_order_release);
+                    char byte = 0;
+                    DWORD read = 0;
+                    const BOOL ok = ReadFile(readPipe, &byte, 1, &read, nullptr);
+                    if (!ok)
+                    {
+                        error.store(GetLastError(), std::memory_order_release);
+                    }
+                    token.unbindFromCurrentThread();
+                });
+                const auto deadline = std::chrono::steady_clock::now() +
+                    std::chrono::seconds(2);
+                while (!entered.load(std::memory_order_acquire) &&
+                    std::chrono::steady_clock::now() < deadline)
+                {
+                    std::this_thread::yield();
+                }
+                DJV_FOLDER_SCAN_REQUIRE(entered.load(std::memory_order_acquire));
+                cancellation.cancel();
+                reader.join();
+                CloseHandle(readPipe);
+                CloseHandle(writePipe);
+                DJV_FOLDER_SCAN_REQUIRE(
+                    ERROR_OPERATION_ABORTED == error.load(std::memory_order_acquire));
+            }
+#endif
+        }
+
+        int runFolderScanServiceTests()
+        {
+            try
+            {
+                orderAndState();
+                cancellationAndImmediateRerequest();
+                queueSaturation();
+                queuedCancellation();
+                shutdownAndDestruction();
+                validationAndAtomicLimits();
+                repeatedRuns();
+                concurrentSubmissionStress();
+                largeDirectoryBenchmark();
+#if defined(_WIN32)
+                synchronousIoCancellation();
+#endif
+                std::cout << "FolderScanServiceTest: PASS\n";
+                return 0;
+            }
+            catch (const std::exception& e)
+            {
+                std::cerr << "FolderScanServiceTest: FAIL: " << e.what() << '\n';
+                return 1;
+            }
+        }
+    }
+}
+#if defined(DJV_FOLDER_SCAN_SERVICE_TEST_MAIN)
+int main()
+{
+    return djv::app_tests::runFolderScanServiceTests();
+}
+#endif

--- a/lib/djv/AppTest/FolderScanServiceTest.h
+++ b/lib/djv/AppTest/FolderScanServiceTest.h
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the DJV project.
+
+#pragma once
+
+namespace djv
+{
+    namespace app_tests
+    {
+        //! Run the standalone FolderScanService stress suite.
+        int runFolderScanServiceTests();
+    }
+}

--- a/lib/djv/Models/CMakeLists.txt
+++ b/lib/djv/Models/CMakeLists.txt
@@ -5,6 +5,7 @@ set(HEADERS
     CommandsModel.h
     FileFilter.h
     FilesModel.h
+    FolderScanner.h
     OCIOModel.h
     PlaylistModel.h
     RecentFilesModel.h
@@ -23,6 +24,7 @@ set(SOURCE
     CommandsModel.cpp
     FileFilter.cpp
     FilesModel.cpp
+    FolderScanner.cpp
     OCIOModel.cpp
     PlaylistModel.cpp
     RecentFilesModel.cpp

--- a/lib/djv/Models/CMakeLists.txt
+++ b/lib/djv/Models/CMakeLists.txt
@@ -3,8 +3,10 @@ set(HEADERS
     AudioModel.h
     ColorModel.h
     CommandsModel.h
+    FileFilter.h
     FilesModel.h
     OCIOModel.h
+    PlaylistModel.h
     RecentFilesModel.h
     SettingsModel.h
     Shortcuts.h
@@ -19,8 +21,10 @@ set(SOURCE
     AudioModel.cpp
     ColorModel.cpp
     CommandsModel.cpp
+    FileFilter.cpp
     FilesModel.cpp
     OCIOModel.cpp
+    PlaylistModel.cpp
     RecentFilesModel.cpp
     SettingsModel.cpp
     Shortcuts.cpp

--- a/lib/djv/Models/FileFilter.cpp
+++ b/lib/djv/Models/FileFilter.cpp
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the DJV project.
+
+#include <djv/Models/FileFilter.h>
+
+#include <ftk/Core/String.h>
+
+#include <algorithm>
+#include <filesystem>
+#include <regex>
+#include <set>
+
+namespace djv
+{
+    namespace models
+    {
+        namespace
+        {
+            bool regexSearch(const std::string& text, const std::string& pattern)
+            {
+                try
+                {
+                    return std::regex_search(
+                        text,
+                        std::regex(pattern, std::regex_constants::icase));
+                }
+                catch (const std::regex_error&)
+                {
+                    return ftk::contains(text, pattern, ftk::CaseCompare::Insensitive);
+                }
+            }
+
+            std::string getFilterText(const ftk::Path& path, FileFilterTarget target)
+            {
+                switch (target)
+                {
+                case FileFilterTarget::Name:
+                    return path.getFileName();
+                case FileFilterTarget::Directory:
+                    return path.getDir();
+                case FileFilterTarget::Path:
+                default:
+                    return path.get();
+                }
+            }
+        }
+
+        std::vector<std::string> getDefaultFileFilterPresets()
+        {
+            return
+            {
+                "name:(exr|dpx|mov|mp4)$",
+                "-dir:(cache|tmp|temp)",
+                "-name:(proxy|thumb|thumbnail)",
+                "dir:(shot010|shot020)",
+                "name:beauty -name:proxy"
+            };
+        }
+
+        std::vector<FileFilterTerm> parseFileFilter(const std::string& text)
+        {
+            std::vector<FileFilterTerm> out;
+            for (auto token : ftk::split(text, { ' ', '\t' }))
+            {
+                if (token.empty())
+                    continue;
+
+                FileFilterTerm term;
+                if ('-' == token.front() || '!' == token.front())
+                {
+                    term.include = false;
+                    token.erase(token.begin());
+                }
+                else if ('+' == token.front())
+                {
+                    token.erase(token.begin());
+                }
+                if (token.empty())
+                    continue;
+
+                const size_t colon = token.find(':');
+                if (colon != std::string::npos)
+                {
+                    const std::string key = ftk::toLower(token.substr(0, colon));
+                    if ("name" == key || "file" == key)
+                    {
+                        term.target = FileFilterTarget::Name;
+                        token = token.substr(colon + 1);
+                    }
+                    else if ("dir" == key || "folder" == key)
+                    {
+                        term.target = FileFilterTarget::Directory;
+                        token = token.substr(colon + 1);
+                    }
+                    else if ("path" == key)
+                    {
+                        term.target = FileFilterTarget::Path;
+                        token = token.substr(colon + 1);
+                    }
+                }
+                if (!token.empty())
+                {
+                    term.pattern = token;
+                    out.push_back(term);
+                }
+            }
+            return out;
+        }
+
+        bool matchFileFilter(const ftk::Path& path, const std::string& text)
+        {
+            const auto terms = parseFileFilter(text);
+            if (terms.empty())
+                return true;
+
+            for (const auto& term : terms)
+            {
+                const bool match = regexSearch(
+                    getFilterText(path, term.target),
+                    term.pattern);
+                if (term.include && !match)
+                {
+                    return false;
+                }
+                if (!term.include && match)
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        bool pruneDirectoryByFileFilter(const ftk::Path& path, const std::string& text)
+        {
+            const auto terms = parseFileFilter(text);
+            for (const auto& term : terms)
+            {
+                if (!term.include &&
+                    (FileFilterTarget::Directory == term.target ||
+                     FileFilterTarget::Path == term.target) &&
+                    regexSearch(path.get(), term.pattern))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        FileScanResult scanFiles(
+            const ftk::Path& folder,
+            const std::string& filter,
+            const std::vector<std::string>& extensions,
+            const FileScanOptions& options)
+        {
+            FileScanResult out;
+            const std::filesystem::path root =
+                std::filesystem::u8path(folder.get());
+            std::error_code errorCode;
+            if (!std::filesystem::is_directory(root, errorCode))
+            {
+                out.error = "The selected playlist import folder is not available.";
+                return out;
+            }
+
+            std::set<std::string> normalizedExtensions;
+            for (auto extension : extensions)
+            {
+                extension = ftk::toLower(extension);
+                if (!extension.empty() && extension.front() != '.')
+                {
+                    extension.insert(extension.begin(), '.');
+                }
+                normalizedExtensions.insert(extension);
+            }
+
+            const auto directoryOptions =
+                std::filesystem::directory_options::skip_permission_denied;
+            std::filesystem::recursive_directory_iterator i(
+                root,
+                directoryOptions,
+                errorCode);
+            const std::filesystem::recursive_directory_iterator end;
+            while (i != end)
+            {
+                if (errorCode)
+                {
+                    errorCode.clear();
+                    i.increment(errorCode);
+                    continue;
+                }
+                if (out.entriesVisited >= options.maxEntries ||
+                    out.paths.size() >= options.maxResults)
+                {
+                    out.truncated = true;
+                    break;
+                }
+                ++out.entriesVisited;
+
+                const auto& entry = *i;
+                const ftk::Path path(entry.path().u8string());
+                if (entry.is_directory(errorCode))
+                {
+                    const bool isSymlink = entry.is_symlink(errorCode);
+                    if (isSymlink ||
+                        i.depth() >= static_cast<int>(options.maxDepth) ||
+                        pruneDirectoryByFileFilter(path, filter))
+                    {
+                        i.disable_recursion_pending();
+                    }
+                }
+                else if (entry.is_regular_file(errorCode))
+                {
+                    const std::string extension =
+                        ftk::toLower(entry.path().extension().u8string());
+                    if ((normalizedExtensions.empty() ||
+                         normalizedExtensions.count(extension)) &&
+                        matchFileFilter(path, filter))
+                    {
+                        out.paths.push_back(path);
+                    }
+                }
+                errorCode.clear();
+                i.increment(errorCode);
+            }
+            std::sort(
+                out.paths.begin(),
+                out.paths.end(),
+                [](const ftk::Path& a, const ftk::Path& b)
+                {
+                    return a.get() < b.get();
+                });
+            return out;
+        }
+    }
+}

--- a/lib/djv/Models/FileFilter.cpp
+++ b/lib/djv/Models/FileFilter.cpp
@@ -3,12 +3,12 @@
 
 #include <djv/Models/FileFilter.h>
 
-#include <ftk/Core/String.h>
-
 #include <algorithm>
-#include <filesystem>
+#include <cctype>
+#include <locale>
 #include <regex>
-#include <set>
+#include <stdexcept>
+#include <utility>
 
 namespace djv
 {
@@ -16,26 +16,186 @@ namespace djv
     {
         namespace
         {
-            bool regexSearch(const std::string& text, const std::string& pattern)
+            std::string toLowerASCII(const std::string& value)
             {
-                try
-                {
-                    return std::regex_search(
-                        text,
-                        std::regex(pattern, std::regex_constants::icase));
-                }
-                catch (const std::regex_error&)
-                {
-                    return ftk::contains(text, pattern, ftk::CaseCompare::Insensitive);
-                }
+                std::string out = value;
+                std::transform(
+                    out.begin(),
+                    out.end(),
+                    out.begin(),
+                    [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+                return out;
             }
 
-            std::string getFilterText(const ftk::Path& path, FileFilterTarget target)
+            bool isSpace(char value)
+            {
+                return 0 != std::isspace(static_cast<unsigned char>(value));
+            }
+
+            std::optional<FileFilterTarget> parseTarget(const std::string& value)
+            {
+                const std::string target = toLowerASCII(value);
+                if ("path" == target)
+                {
+                    return FileFilterTarget::Path;
+                }
+                if ("name" == target || "file" == target)
+                {
+                    return FileFilterTarget::Name;
+                }
+                if ("ext" == target || "extension" == target)
+                {
+                    return FileFilterTarget::Extension;
+                }
+                if ("dir" == target || "folder" == target)
+                {
+                    return FileFilterTarget::Directory;
+                }
+                return std::nullopt;
+            }
+
+            std::optional<std::string> validateRegexSafety(const std::string& pattern)
+            {
+                bool escaped = false;
+                bool characterClass = false;
+                size_t unboundedQuantifiers = 0;
+                size_t quantifiers = 0;
+                size_t alternations = 0;
+                for (size_t i = 0; i < pattern.size(); ++i)
+                {
+                    const char value = pattern[i];
+                    if (escaped)
+                    {
+                        if (value >= '1' && value <= '9')
+                        {
+                            return "Backreferences are not supported";
+                        }
+                        escaped = false;
+                        continue;
+                    }
+                    if ('\\' == value)
+                    {
+                        escaped = true;
+                        continue;
+                    }
+                    if (characterClass)
+                    {
+                        characterClass = ']' != value;
+                        continue;
+                    }
+                    if ('[' == value)
+                    {
+                        characterClass = true;
+                        continue;
+                    }
+                    if ('(' == value && i + 1 < pattern.size() && '?' == pattern[i + 1])
+                    {
+                        return "Lookaround and special groups are not supported";
+                    }
+                    if ('|' == value && ++alternations > 16)
+                    {
+                        return "Too many alternatives";
+                    }
+                    if (')' == value && i + 1 < pattern.size())
+                    {
+                        const char next = pattern[i + 1];
+                        if ('*' == next || '+' == next || '?' == next || '{' == next)
+                        {
+                            return "Quantified groups are not supported";
+                        }
+                    }
+                    if ('*' == value || '+' == value)
+                    {
+                        if (++quantifiers > 16)
+                        {
+                            return "Too many quantifiers";
+                        }
+                        ++unboundedQuantifiers;
+                        if (unboundedQuantifiers > 2)
+                        {
+                            return "Too many unbounded quantifiers";
+                        }
+                        if (i > 0 &&
+                            ('*' == pattern[i - 1] || '+' == pattern[i - 1] ||
+                                '?' == pattern[i - 1] || '}' == pattern[i - 1]))
+                        {
+                            return "Nested quantifiers are not supported";
+                        }
+                    }
+                    if ('?' == value)
+                    {
+                        if (++quantifiers > 16)
+                        {
+                            return "Too many quantifiers";
+                        }
+                        if (i > 0 &&
+                            ('*' == pattern[i - 1] || '+' == pattern[i - 1] ||
+                                '?' == pattern[i - 1] || '}' == pattern[i - 1]))
+                        {
+                            return "Nested quantifiers are not supported";
+                        }
+                    }
+                    if ('{' == value)
+                    {
+                        if (++quantifiers > 16)
+                        {
+                            return "Too many quantifiers";
+                        }
+                        const size_t close = pattern.find('}', i + 1);
+                        if (std::string::npos == close)
+                        {
+                            continue;
+                        }
+                        const std::string repetition = pattern.substr(i + 1, close - i - 1);
+                        const size_t comma = repetition.find(',');
+                        const std::string maximum = std::string::npos == comma ?
+                            repetition : repetition.substr(comma + 1);
+                        if (std::string::npos != comma && maximum.empty())
+                        {
+                            ++unboundedQuantifiers;
+                            if (unboundedQuantifiers > 2)
+                            {
+                                return "Too many unbounded quantifiers";
+                            }
+                        }
+                        else if (!maximum.empty())
+                        {
+                            try
+                            {
+                                if (std::stoull(maximum) > CompiledFileFilter::maxCandidateLength)
+                                {
+                                    return "Repetition exceeds the candidate length limit";
+                                }
+                            }
+                            catch (const std::out_of_range&)
+                            {
+                                return "Repetition exceeds the candidate length limit";
+                            }
+                            catch (const std::invalid_argument&)
+                            {
+                                // std::regex reports malformed repetitions precisely.
+                            }
+                        }
+                    }
+                }
+                return std::nullopt;
+            }
+
+            std::string getText(const ftk::Path& path, FileFilterTarget target)
             {
                 switch (target)
                 {
                 case FileFilterTarget::Name:
                     return path.getFileName();
+                case FileFilterTarget::Extension:
+                {
+                    std::string out = path.getExt();
+                    if (!out.empty() && '.' == out.front())
+                    {
+                        out.erase(out.begin());
+                    }
+                    return out;
+                }
                 case FileFilterTarget::Directory:
                     return path.getDir();
                 case FileFilterTarget::Path:
@@ -43,86 +203,94 @@ namespace djv
                     return path.get();
                 }
             }
-        }
 
-        std::vector<std::string> getDefaultFileFilterPresets()
-        {
-            return
+            bool matchDirectoryComponents(
+                const std::string& value,
+                const std::regex& regex)
             {
-                "name:(exr|dpx|mov|mp4)$",
-                "-dir:(cache|tmp|temp)",
-                "-name:(proxy|thumb|thumbnail)",
-                "dir:(shot010|shot020)",
-                "name:beauty -name:proxy"
-            };
-        }
-
-        std::vector<FileFilterTerm> parseFileFilter(const std::string& text)
-        {
-            std::vector<FileFilterTerm> out;
-            for (auto token : ftk::split(text, { ' ', '\t' }))
-            {
-                if (token.empty())
-                    continue;
-
-                FileFilterTerm term;
-                if ('-' == token.front() || '!' == token.front())
+                size_t begin = 0;
+                while (begin < value.size())
                 {
-                    term.include = false;
-                    token.erase(token.begin());
-                }
-                else if ('+' == token.front())
-                {
-                    token.erase(token.begin());
-                }
-                if (token.empty())
-                    continue;
-
-                const size_t colon = token.find(':');
-                if (colon != std::string::npos)
-                {
-                    const std::string key = ftk::toLower(token.substr(0, colon));
-                    if ("name" == key || "file" == key)
+                    while (begin < value.size() &&
+                        ('/' == value[begin] || '\\' == value[begin]))
                     {
-                        term.target = FileFilterTarget::Name;
-                        token = token.substr(colon + 1);
+                        ++begin;
                     }
-                    else if ("dir" == key || "folder" == key)
+                    size_t end = begin;
+                    while (end < value.size() &&
+                        '/' != value[end] && '\\' != value[end])
                     {
-                        term.target = FileFilterTarget::Directory;
-                        token = token.substr(colon + 1);
+                        ++end;
                     }
-                    else if ("path" == key)
+                    if (end > begin && std::regex_search(
+                        value.begin() + begin,
+                        value.begin() + end,
+                        regex))
                     {
-                        term.target = FileFilterTarget::Path;
-                        token = token.substr(colon + 1);
+                        return true;
                     }
+                    begin = end;
                 }
-                if (!token.empty())
-                {
-                    term.pattern = token;
-                    out.push_back(term);
-                }
+                return false;
             }
-            return out;
+
+            bool matchesTerm(
+                const ftk::Path& path,
+                FileFilterTarget target,
+                const std::regex& regex)
+            {
+                return FileFilterTarget::Directory == target ?
+                    matchDirectoryComponents(path.getDir(), regex) :
+                    std::regex_search(getText(path, target), regex);
+            }
+
+            FileFilterCompileResult makeError(
+                FileFilterErrorCode code,
+                size_t offset,
+                const std::string& token,
+                const std::string& message)
+            {
+                FileFilterCompileResult out;
+                out.error = FileFilterError{ code, offset, token, message };
+                return out;
+            }
         }
 
-        bool matchFileFilter(const ftk::Path& path, const std::string& text)
+        struct CompiledFileFilter::Private
         {
-            const auto terms = parseFileFilter(text);
-            if (terms.empty())
-                return true;
-
-            for (const auto& term : terms)
+            struct Term
             {
-                const bool match = regexSearch(
-                    getFilterText(path, term.target),
-                    term.pattern);
-                if (term.include && !match)
-                {
-                    return false;
-                }
-                if (!term.include && match)
+                FileFilterTerm info;
+                std::regex regex;
+            };
+
+            std::string expression;
+            std::vector<FileFilterTerm> termInfo;
+            std::vector<Term> terms;
+        };
+
+        FileFilterCompileResult::operator bool() const
+        {
+            return static_cast<bool>(filter) && !error.has_value();
+        }
+
+        CompiledFileFilter::CompiledFileFilter() :
+            _p(new Private)
+        {}
+
+        CompiledFileFilter::~CompiledFileFilter()
+        {}
+
+        bool CompiledFileFilter::matches(const ftk::Path& path) const
+        {
+            if (path.get().size() > maxCandidateLength)
+            {
+                return false;
+            }
+            for (const auto& term : _p->terms)
+            {
+                const bool match = matchesTerm(path, term.info.target, term.regex);
+                if ((term.info.include && !match) || (!term.info.include && match))
                 {
                     return false;
                 }
@@ -130,15 +298,17 @@ namespace djv
             return true;
         }
 
-        bool pruneDirectoryByFileFilter(const ftk::Path& path, const std::string& text)
+        bool CompiledFileFilter::excludesDirectory(const ftk::Path& path) const
         {
-            const auto terms = parseFileFilter(text);
-            for (const auto& term : terms)
+            if (path.get().size() > maxCandidateLength)
             {
-                if (!term.include &&
-                    (FileFilterTarget::Directory == term.target ||
-                     FileFilterTarget::Path == term.target) &&
-                    regexSearch(path.get(), term.pattern))
+                return false;
+            }
+            for (const auto& term : _p->terms)
+            {
+                if (!term.info.include &&
+                    FileFilterTarget::Directory == term.info.target &&
+                    matchDirectoryComponents(path.get(), term.regex))
                 {
                     return true;
                 }
@@ -146,90 +316,158 @@ namespace djv
             return false;
         }
 
-        FileScanResult scanFiles(
-            const ftk::Path& folder,
-            const std::string& filter,
-            const std::vector<std::string>& extensions,
-            const FileScanOptions& options)
+        bool CompiledFileFilter::isEmpty() const
         {
-            FileScanResult out;
-            const std::filesystem::path root =
-                std::filesystem::u8path(folder.get());
-            std::error_code errorCode;
-            if (!std::filesystem::is_directory(root, errorCode))
+            return _p->terms.empty();
+        }
+
+        const std::string& CompiledFileFilter::getExpression() const
+        {
+            return _p->expression;
+        }
+
+        const std::vector<FileFilterTerm>& CompiledFileFilter::getTerms() const
+        {
+            return _p->termInfo;
+        }
+
+        FileFilterCompileResult compileFileFilter(const std::string& expression)
+        {
+            if (expression.size() > CompiledFileFilter::maxExpressionLength)
             {
-                out.error = "The selected playlist import folder is not available.";
-                return out;
+                return makeError(
+                    FileFilterErrorCode::ExpressionTooLong,
+                    CompiledFileFilter::maxExpressionLength,
+                    std::string(),
+                    "File filter expression is too long");
             }
 
-            std::set<std::string> normalizedExtensions;
-            for (auto extension : extensions)
+            auto filter = std::shared_ptr<CompiledFileFilter>(new CompiledFileFilter);
+            filter->_p->expression = expression;
+            size_t position = 0;
+            while (position < expression.size())
             {
-                extension = ftk::toLower(extension);
-                if (!extension.empty() && extension.front() != '.')
+                while (position < expression.size() && isSpace(expression[position]))
                 {
-                    extension.insert(extension.begin(), '.');
+                    ++position;
                 }
-                normalizedExtensions.insert(extension);
-            }
-
-            const auto directoryOptions =
-                std::filesystem::directory_options::skip_permission_denied;
-            std::filesystem::recursive_directory_iterator i(
-                root,
-                directoryOptions,
-                errorCode);
-            const std::filesystem::recursive_directory_iterator end;
-            while (i != end)
-            {
-                if (errorCode)
+                if (position >= expression.size())
                 {
-                    errorCode.clear();
-                    i.increment(errorCode);
-                    continue;
-                }
-                if (out.entriesVisited >= options.maxEntries ||
-                    out.paths.size() >= options.maxResults)
-                {
-                    out.truncated = true;
                     break;
                 }
-                ++out.entriesVisited;
 
-                const auto& entry = *i;
-                const ftk::Path path(entry.path().u8string());
-                if (entry.is_directory(errorCode))
+                const size_t tokenOffset = position;
+                while (position < expression.size() && !isSpace(expression[position]))
                 {
-                    const bool isSymlink = entry.is_symlink(errorCode);
-                    if (isSymlink ||
-                        i.depth() >= static_cast<int>(options.maxDepth) ||
-                        pruneDirectoryByFileFilter(path, filter))
-                    {
-                        i.disable_recursion_pending();
-                    }
+                    ++position;
                 }
-                else if (entry.is_regular_file(errorCode))
+                const std::string token = expression.substr(tokenOffset, position - tokenOffset);
+                if (filter->_p->terms.size() >= CompiledFileFilter::maxTermCount)
                 {
-                    const std::string extension =
-                        ftk::toLower(entry.path().extension().u8string());
-                    if ((normalizedExtensions.empty() ||
-                         normalizedExtensions.count(extension)) &&
-                        matchFileFilter(path, filter))
-                    {
-                        out.paths.push_back(path);
-                    }
+                    return makeError(
+                        FileFilterErrorCode::TooManyTerms,
+                        tokenOffset,
+                        token,
+                        "File filter contains too many terms");
                 }
-                errorCode.clear();
-                i.increment(errorCode);
+
+                FileFilterTerm info;
+                size_t patternOffset = 0;
+                if ('+' == token.front() || '-' == token.front() || '!' == token.front())
+                {
+                    info.include = '+' == token.front();
+                    patternOffset = 1;
+                }
+                if (patternOffset >= token.size())
+                {
+                    return makeError(
+                        FileFilterErrorCode::EmptyPattern,
+                        tokenOffset + patternOffset,
+                        token,
+                        "File filter term has no pattern");
+                }
+
+                const size_t colon = token.find(':', patternOffset);
+                if (std::string::npos != colon)
+                {
+                    const auto target = parseTarget(
+                        token.substr(patternOffset, colon - patternOffset));
+                    if (!target.has_value())
+                    {
+                        return makeError(
+                            FileFilterErrorCode::UnknownTarget,
+                            tokenOffset + patternOffset,
+                            token,
+                            "Unknown file filter target");
+                    }
+                    info.target = target.value();
+                    patternOffset = colon + 1;
+                }
+
+                if (patternOffset >= token.size())
+                {
+                    return makeError(
+                        FileFilterErrorCode::EmptyPattern,
+                        tokenOffset + patternOffset,
+                        token,
+                        "File filter term has no pattern");
+                }
+                info.pattern = token.substr(patternOffset);
+                if (info.pattern.size() > CompiledFileFilter::maxPatternLength)
+                {
+                    return makeError(
+                        FileFilterErrorCode::PatternTooLong,
+                        tokenOffset + patternOffset,
+                        token,
+                        "File filter pattern is too long");
+                }
+                if (const auto unsafe = validateRegexSafety(info.pattern))
+                {
+                    return makeError(
+                        FileFilterErrorCode::UnsafeRegularExpression,
+                        tokenOffset + patternOffset,
+                        token,
+                        unsafe.value());
+                }
+
+                try
+                {
+                    CompiledFileFilter::Private::Term term;
+                    term.info = info;
+                    term.regex.imbue(std::locale::classic());
+                    term.regex.assign(
+                        info.pattern,
+                        std::regex_constants::ECMAScript |
+                            std::regex_constants::icase |
+                            std::regex_constants::optimize);
+                    filter->_p->termInfo.push_back(info);
+                    filter->_p->terms.push_back(std::move(term));
+                }
+                catch (const std::regex_error& e)
+                {
+                    return makeError(
+                        FileFilterErrorCode::InvalidRegularExpression,
+                        tokenOffset + patternOffset,
+                        token,
+                        std::string("Invalid regular expression: ") + e.what());
+                }
             }
-            std::sort(
-                out.paths.begin(),
-                out.paths.end(),
-                [](const ftk::Path& a, const ftk::Path& b)
-                {
-                    return a.get() < b.get();
-                });
+
+            FileFilterCompileResult out;
+            out.filter = std::move(filter);
             return out;
+        }
+
+        std::vector<std::string> getDefaultFileFilterPresets()
+        {
+            return
+            {
+                "ext:^(mov|mp4|m4v|mxf|avi|mkv|webm)$",
+                "ext:^(exr|dpx|tif|tiff|png|jpg|jpeg)$",
+                "-dir:^(cache|tmp|temp|proxy)$",
+                "-name:(proxy|thumb|thumbnail)",
+                "name:beauty -name:proxy"
+            };
         }
     }
 }

--- a/lib/djv/Models/FileFilter.h
+++ b/lib/djv/Models/FileFilter.h
@@ -5,6 +5,9 @@
 
 #include <ftk/Core/Path.h>
 
+#include <cstddef>
+#include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -17,10 +20,31 @@ namespace djv
         {
             Path,
             Name,
+            Extension,
             Directory
         };
 
-        //! File filter term.
+        //! File filter compilation error.
+        enum class FileFilterErrorCode
+        {
+            ExpressionTooLong,
+            TooManyTerms,
+            EmptyPattern,
+            UnknownTarget,
+            PatternTooLong,
+            UnsafeRegularExpression,
+            InvalidRegularExpression
+        };
+
+        struct FileFilterError
+        {
+            FileFilterErrorCode code = FileFilterErrorCode::InvalidRegularExpression;
+            size_t offset = 0;
+            std::string token;
+            std::string message;
+        };
+
+        //! Public description of a compiled term.
         struct FileFilterTerm
         {
             bool include = true;
@@ -28,41 +52,73 @@ namespace djv
             std::string pattern;
         };
 
-        //! Limits for a recursive folder scan.
-        struct FileScanOptions
+        class CompiledFileFilter;
+
+        //! Result of compiling a file filter expression.
+        struct FileFilterCompileResult
         {
-            size_t maxDepth = 32;
-            size_t maxEntries = 10000;
-            size_t maxResults = 1000;
+            std::shared_ptr<const CompiledFileFilter> filter;
+            std::optional<FileFilterError> error;
+
+            explicit operator bool() const;
         };
 
-        //! Result of a recursive folder scan.
-        struct FileScanResult
+        //! Immutable, compiled file filter.
+        //!
+        //! Grammar:
+        //! \code
+        //! expression := term *(ASCII-whitespace term)
+        //! term       := [ '+' | '-' | '!' ] [ target ':' ] regex
+        //! target     := path | name | file | ext | extension | dir | folder
+        //! \endcode
+        //!
+        //! Terms without a target match the full path. All include terms must
+        //! match and no exclude term may match. Regular expressions use the
+        //! C++ ECMAScript grammar with case-insensitive ASCII matching. Patterns
+        //! cannot contain literal whitespace; use a regular-expression class
+        //! such as `\\s`.
+        //! The extension target does not include the leading dot. The directory
+        //! target matches individual directory components, which makes explicit
+        //! directory exclusions safe to prune during recursive scans.
+        //!
+        //! To keep interactive filtering bounded, backreferences, lookaround,
+        //! quantified groups, repetitions above the candidate limit, and more
+        //! than two unbounded quantifiers in one term are rejected.
+        class CompiledFileFilter
         {
-            std::vector<ftk::Path> paths;
-            size_t entriesVisited = 0;
-            bool truncated = false;
-            std::string error;
+        public:
+            static constexpr size_t maxExpressionLength = 4096;
+            static constexpr size_t maxTermCount = 64;
+            static constexpr size_t maxPatternLength = 256;
+            static constexpr size_t maxCandidateLength = 4096;
+
+            ~CompiledFileFilter();
+
+            //! Match a file path. Overlong candidates do not match.
+            bool matches(const ftk::Path&) const;
+
+            //! Whether an excluded directory/path term permits pruning a
+            //! directory before visiting its children.
+            bool excludesDirectory(const ftk::Path&) const;
+
+            bool isEmpty() const;
+            const std::string& getExpression() const;
+            const std::vector<FileFilterTerm>& getTerms() const;
+
+        private:
+            CompiledFileFilter();
+
+            struct Private;
+            std::unique_ptr<Private> _p;
+
+            friend FileFilterCompileResult compileFileFilter(const std::string&);
         };
 
-        //! Get default file filter presets.
+        //! Compile a filter. Failure is explicit and never falls back to a
+        //! different matching language.
+        FileFilterCompileResult compileFileFilter(const std::string&);
+
+        //! Curated expressions suitable for a UI preset list.
         std::vector<std::string> getDefaultFileFilterPresets();
-
-        //! Parse a file filter expression into terms.
-        std::vector<FileFilterTerm> parseFileFilter(const std::string&);
-
-        //! Match a file path against a filter expression.
-        bool matchFileFilter(const ftk::Path&, const std::string&);
-
-        //! Check whether a folder can be skipped by exclude terms.
-        bool pruneDirectoryByFileFilter(const ftk::Path&, const std::string&);
-
-        //! Scan a folder recursively with deterministic ordering and hard
-        //! limits. Directory symlinks are not followed.
-        FileScanResult scanFiles(
-            const ftk::Path& folder,
-            const std::string& filter,
-            const std::vector<std::string>& extensions,
-            const FileScanOptions& = FileScanOptions());
     }
 }

--- a/lib/djv/Models/FileFilter.h
+++ b/lib/djv/Models/FileFilter.h
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the DJV project.
+
+#pragma once
+
+#include <ftk/Core/Path.h>
+
+#include <string>
+#include <vector>
+
+namespace djv
+{
+    namespace models
+    {
+        //! File filter target.
+        enum class FileFilterTarget
+        {
+            Path,
+            Name,
+            Directory
+        };
+
+        //! File filter term.
+        struct FileFilterTerm
+        {
+            bool include = true;
+            FileFilterTarget target = FileFilterTarget::Path;
+            std::string pattern;
+        };
+
+        //! Limits for a recursive folder scan.
+        struct FileScanOptions
+        {
+            size_t maxDepth = 32;
+            size_t maxEntries = 10000;
+            size_t maxResults = 1000;
+        };
+
+        //! Result of a recursive folder scan.
+        struct FileScanResult
+        {
+            std::vector<ftk::Path> paths;
+            size_t entriesVisited = 0;
+            bool truncated = false;
+            std::string error;
+        };
+
+        //! Get default file filter presets.
+        std::vector<std::string> getDefaultFileFilterPresets();
+
+        //! Parse a file filter expression into terms.
+        std::vector<FileFilterTerm> parseFileFilter(const std::string&);
+
+        //! Match a file path against a filter expression.
+        bool matchFileFilter(const ftk::Path&, const std::string&);
+
+        //! Check whether a folder can be skipped by exclude terms.
+        bool pruneDirectoryByFileFilter(const ftk::Path&, const std::string&);
+
+        //! Scan a folder recursively with deterministic ordering and hard
+        //! limits. Directory symlinks are not followed.
+        FileScanResult scanFiles(
+            const ftk::Path& folder,
+            const std::string& filter,
+            const std::vector<std::string>& extensions,
+            const FileScanOptions& = FileScanOptions());
+    }
+}

--- a/lib/djv/Models/FilesModel.cpp
+++ b/lib/djv/Models/FilesModel.cpp
@@ -148,6 +148,22 @@ namespace djv
             p.layers->setIfChanged(_getLayers());
         }
 
+        void FilesModel::setPath(
+            const std::shared_ptr<FilesModelItem>& item,
+            const ftk::Path& path)
+        {
+            FTK_P();
+            const auto i = std::find(
+                p.files->get().begin(),
+                p.files->get().end(),
+                item);
+            if (i != p.files->get().end() && item->path.get() != path.get())
+            {
+                item->path = path;
+                p.files->setAlways(p.files->get());
+            }
+        }
+
         void FilesModel::close()
         {
             FTK_P();

--- a/lib/djv/Models/FilesModel.h
+++ b/lib/djv/Models/FilesModel.h
@@ -43,6 +43,8 @@ namespace djv
             bool                     framesStated = false;
 
             bool                     newFile = true;
+            bool                     playlistDirty = false;
+            bool                     playlistScratch = false;
         };
 
         //! Files model.
@@ -102,6 +104,11 @@ namespace djv
 
             //! Add a file.
             void add(const std::shared_ptr<FilesModelItem>&);
+
+            //! Update a file path and notify observers.
+            void setPath(
+                const std::shared_ptr<FilesModelItem>&,
+                const ftk::Path&);
 
             //! Close the current "A" file.
             void close();

--- a/lib/djv/Models/FolderScanner.cpp
+++ b/lib/djv/Models/FolderScanner.cpp
@@ -7,6 +7,7 @@
 #include <atomic>
 #include <cctype>
 #include <climits>
+#include <cstdint>
 #include <cstring>
 #include <cwctype>
 #include <mutex>
@@ -27,6 +28,45 @@ namespace djv
     {
         namespace
         {
+            constexpr uint64_t contentSignatureOffset = 14695981039346656037ULL;
+            constexpr uint64_t contentSignaturePrime = 1099511628211ULL;
+
+            void appendSignatureBytes(
+                uint64_t& signature,
+                const void* data,
+                size_t size)
+            {
+                const auto* bytes = static_cast<const unsigned char*>(data);
+                for (size_t i = 0; i < size; ++i)
+                {
+                    signature ^= bytes[i];
+                    signature *= contentSignaturePrime;
+                }
+            }
+
+            void appendSignatureString(
+                uint64_t& signature,
+                const std::string& value)
+            {
+                const uint64_t size = static_cast<uint64_t>(value.size());
+                appendSignatureBytes(signature, &size, sizeof(size));
+                appendSignatureBytes(signature, value.data(), value.size());
+            }
+
+            void appendFileSignature(
+                uint64_t& signature,
+                const std::string& path,
+                uint64_t size,
+                int64_t lastWriteTime)
+            {
+                appendSignatureString(signature, path);
+                appendSignatureBytes(signature, &size, sizeof(size));
+                appendSignatureBytes(
+                    signature,
+                    &lastWriteTime,
+                    sizeof(lastWriteTime));
+            }
+
 #if defined(_WIN32)
             class WinHandle
             {
@@ -509,6 +549,7 @@ namespace djv
                 const FolderScanCancellationToken& cancellation)
             {
                 FolderScanResult out;
+                uint64_t contentSignature = contentSignatureOffset;
                 CancellationBinding cancellationBinding(cancellation);
                 if (cancellation.isCancellationRequested())
                 {
@@ -623,6 +664,8 @@ namespace djv
                     {
                         std::wstring name;
                         DWORD attributes = 0;
+                        uint64_t size = 0;
+                        int64_t lastWriteTime = 0;
                     };
                     std::vector<Entry> entries;
                     std::vector<unsigned char> buffer(64 * 1024);
@@ -680,7 +723,15 @@ namespace djv
                                     stop = true;
                                     break;
                                 }
-                                entries.push_back({ name, info->FileAttributes });
+                                entries.push_back(
+                                    {
+                                        name,
+                                        info->FileAttributes,
+                                        static_cast<uint64_t>(
+                                            info->EndOfFile.QuadPart),
+                                        static_cast<int64_t>(
+                                            info->LastWriteTime.QuadPart)
+                                    });
                                 ++out.visitedEntries;
                             }
                             if (!info->NextEntryOffset || stop)
@@ -834,6 +885,11 @@ namespace djv
                             {
                                 continue;
                             }
+                            appendFileSignature(
+                                contentSignature,
+                                value,
+                                entry.size,
+                                entry.lastWriteTime);
                             out.paths.push_back(path);
                         }
                     }
@@ -864,6 +920,10 @@ namespace djv
                         options.maxWarnings);
                     out.paths.clear();
                 }
+                if (FolderScanStatus::Completed == out.status)
+                {
+                    out.contentSignature = contentSignature;
+                }
                 return out;
             }
         }
@@ -879,6 +939,7 @@ namespace djv
             return scanFolderWindows(root, filter, options, cancellation);
 #else
             FolderScanResult out;
+            uint64_t contentSignature = contentSignatureOffset;
             if (cancellation.isCancellationRequested())
             {
                 out.status = FolderScanStatus::Cancelled;
@@ -1121,6 +1182,45 @@ namespace djv
                         {
                             continue;
                         }
+                        error.clear();
+                        uint64_t fileSize = static_cast<uint64_t>(
+                            std::filesystem::file_size(entry, error));
+                        if (error)
+                        {
+                            addWarning(
+                                out,
+                                warningCode(error),
+                                entry,
+                                error,
+                                "Cannot read file size",
+                                options.maxWarnings);
+                            fileSize = 0;
+                            error.clear();
+                        }
+                        const auto lastWriteTimeValue =
+                            std::filesystem::last_write_time(entry, error);
+                        int64_t lastWriteTime = 0;
+                        if (error)
+                        {
+                            addWarning(
+                                out,
+                                warningCode(error),
+                                entry,
+                                error,
+                                "Cannot read file modification time",
+                                options.maxWarnings);
+                            error.clear();
+                        }
+                        else
+                        {
+                            lastWriteTime = static_cast<int64_t>(
+                                lastWriteTimeValue.time_since_epoch().count());
+                        }
+                        appendFileSignature(
+                            contentSignature,
+                            value,
+                            fileSize,
+                            lastWriteTime);
                         out.paths.push_back(path);
                     }
                 }
@@ -1161,6 +1261,10 @@ namespace djv
                     "Folder scan result limit reached; use a narrower filter",
                     options.maxWarnings);
                 out.paths.clear();
+            }
+            if (FolderScanStatus::Completed == out.status)
+            {
+                out.contentSignature = contentSignature;
             }
             return out;
 #endif

--- a/lib/djv/Models/FolderScanner.cpp
+++ b/lib/djv/Models/FolderScanner.cpp
@@ -1,0 +1,1169 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the DJV project.
+
+#include <djv/Models/FolderScanner.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cctype>
+#include <climits>
+#include <cstring>
+#include <cwctype>
+#include <mutex>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+
+#if defined(_WIN32)
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <Windows.h>
+#include <winternl.h>
+#endif
+
+namespace djv
+{
+    namespace models
+    {
+        namespace
+        {
+#if defined(_WIN32)
+            class WinHandle
+            {
+            public:
+                WinHandle() = default;
+                explicit WinHandle(HANDLE value) : value(value) {}
+                ~WinHandle() { reset(); }
+                WinHandle(WinHandle&& other) noexcept : value(other.value)
+                { other.value = INVALID_HANDLE_VALUE; }
+                WinHandle& operator=(WinHandle&& other) noexcept
+                {
+                    if (this != &other)
+                    {
+                        reset();
+                        value = other.value;
+                        other.value = INVALID_HANDLE_VALUE;
+                    }
+                    return *this;
+                }
+                WinHandle(const WinHandle&) = delete;
+                WinHandle& operator=(const WinHandle&) = delete;
+                explicit operator bool() const
+                { return value && INVALID_HANDLE_VALUE != value; }
+                HANDLE get() const { return value; }
+                void reset(HANDLE next = INVALID_HANDLE_VALUE)
+                {
+                    if (*this)
+                    {
+                        CloseHandle(value);
+                    }
+                    value = next;
+                }
+            private:
+                HANDLE value = INVALID_HANDLE_VALUE;
+            };
+
+            struct DirectoryIdentity
+            {
+                ULONGLONG volume = 0;
+                FILE_ID_128 id = {};
+
+                bool operator==(const DirectoryIdentity& other) const
+                {
+                    return volume == other.volume &&
+                        0 == std::memcmp(id.Identifier, other.id.Identifier, sizeof(id.Identifier));
+                }
+            };
+
+            struct WinPendingDirectory
+            {
+                std::filesystem::path path;
+                size_t depth = 0;
+                WinHandle handle;
+                DirectoryIdentity identity;
+            };
+
+            using NtCreateFileFn = NTSTATUS (NTAPI *)(
+                PHANDLE, ACCESS_MASK, POBJECT_ATTRIBUTES, PIO_STATUS_BLOCK,
+                PLARGE_INTEGER, ULONG, ULONG, ULONG, ULONG, PVOID, ULONG);
+            using RtlNtStatusToDosErrorFn = ULONG (WINAPI *)(NTSTATUS);
+
+            std::error_code winError(DWORD value = GetLastError())
+            {
+                return std::error_code(static_cast<int>(value), std::system_category());
+            }
+
+            bool getIdentity(HANDLE handle, DirectoryIdentity& out)
+            {
+                FILE_ID_INFO info = {};
+                if (!GetFileInformationByHandleEx(
+                    handle, FileIdInfo, &info, sizeof(info)))
+                {
+                    return false;
+                }
+                out.volume = info.VolumeSerialNumber;
+                out.id = info.FileId;
+                return true;
+            }
+
+            std::wstring finalPath(HANDLE handle)
+            {
+                const DWORD size = GetFinalPathNameByHandleW(
+                    handle, nullptr, 0, FILE_NAME_NORMALIZED | VOLUME_NAME_DOS);
+                if (!size)
+                {
+                    return {};
+                }
+                std::wstring out(size, L'\0');
+                const DWORD written = GetFinalPathNameByHandleW(
+                    handle, out.data(), size, FILE_NAME_NORMALIZED | VOLUME_NAME_DOS);
+                if (!written || written >= size)
+                {
+                    return {};
+                }
+                out.resize(written);
+                std::transform(out.begin(), out.end(), out.begin(), towlower);
+                while (out.size() > 4 && (L'\\' == out.back() || L'/' == out.back()))
+                {
+                    out.pop_back();
+                }
+                return out;
+            }
+
+            bool isWithinRoot(const std::wstring& root, const std::wstring& candidate)
+            {
+                return candidate == root ||
+                    (candidate.size() > root.size() &&
+                     0 == candidate.compare(0, root.size(), root) &&
+                     (L'\\' == candidate[root.size()] || L'/' == candidate[root.size()]));
+            }
+
+            WinHandle openRootDirectory(
+                const std::filesystem::path& path,
+                bool openReparsePoint,
+                std::error_code& error)
+            {
+                const DWORD flags = FILE_FLAG_BACKUP_SEMANTICS |
+                    (openReparsePoint ? FILE_FLAG_OPEN_REPARSE_POINT : 0);
+                HANDLE handle = CreateFileW(
+                    path.c_str(),
+                    FILE_LIST_DIRECTORY | FILE_READ_ATTRIBUTES | SYNCHRONIZE,
+                    FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                    nullptr,
+                    OPEN_EXISTING,
+                    flags,
+                    nullptr);
+                if (INVALID_HANDLE_VALUE == handle)
+                {
+                    error = winError();
+                    return {};
+                }
+                error.clear();
+                return WinHandle(handle);
+            }
+
+            WinHandle openRelativeDirectory(
+                HANDLE parent,
+                const std::wstring& name,
+                bool openReparsePoint,
+                std::error_code& error)
+            {
+                if (name.size() > USHRT_MAX / sizeof(wchar_t))
+                {
+                    error = std::make_error_code(std::errc::filename_too_long);
+                    return {};
+                }
+                static const HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
+                static const auto ntCreateFile = reinterpret_cast<NtCreateFileFn>(
+                    GetProcAddress(ntdll, "NtCreateFile"));
+                static const auto rtlStatusToError = reinterpret_cast<RtlNtStatusToDosErrorFn>(
+                    GetProcAddress(ntdll, "RtlNtStatusToDosError"));
+                if (!ntCreateFile || !rtlStatusToError)
+                {
+                    error = std::make_error_code(std::errc::function_not_supported);
+                    return {};
+                }
+                UNICODE_STRING string = {};
+                string.Buffer = const_cast<PWSTR>(name.data());
+                string.Length = static_cast<USHORT>(name.size() * sizeof(wchar_t));
+                string.MaximumLength = string.Length;
+                OBJECT_ATTRIBUTES attributes;
+                InitializeObjectAttributes(
+                    &attributes, &string, OBJ_CASE_INSENSITIVE, parent, nullptr);
+                IO_STATUS_BLOCK statusBlock = {};
+                HANDLE raw = INVALID_HANDLE_VALUE;
+                ULONG createOptions = FILE_DIRECTORY_FILE | FILE_SYNCHRONOUS_IO_NONALERT;
+                if (openReparsePoint)
+                {
+                    createOptions |= FILE_OPEN_REPARSE_POINT;
+                }
+                const NTSTATUS status = ntCreateFile(
+                    &raw,
+                    FILE_LIST_DIRECTORY | FILE_READ_ATTRIBUTES | SYNCHRONIZE,
+                    &attributes,
+                    &statusBlock,
+                    nullptr,
+                    FILE_ATTRIBUTE_NORMAL,
+                    FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                    FILE_OPEN,
+                    createOptions,
+                    nullptr,
+                    0);
+                if (status < 0)
+                {
+                    error = winError(rtlStatusToError(status));
+                    return {};
+                }
+                error.clear();
+                return WinHandle(raw);
+            }
+
+            bool directoryAttributes(HANDLE handle, FILE_ATTRIBUTE_TAG_INFO& out)
+            {
+                return !!GetFileInformationByHandleEx(
+                    handle, FileAttributeTagInfo, &out, sizeof(out));
+            }
+#endif
+
+            struct PendingDirectory
+            {
+                std::filesystem::path path;
+                size_t depth = 0;
+            };
+
+            std::string pathString(const std::filesystem::path& path)
+            {
+                return path.generic_u8string();
+            }
+
+            std::string toLowerASCII(const std::string& value)
+            {
+                std::string out = value;
+                std::transform(
+                    out.begin(),
+                    out.end(),
+                    out.begin(),
+                    [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+                return out;
+            }
+
+            std::string normalizeExtension(const std::string& value)
+            {
+                std::string out = value;
+                if (!out.empty() && '.' == out.front())
+                {
+                    out.erase(out.begin());
+                }
+                return toLowerASCII(out);
+            }
+
+            std::unordered_set<std::string> normalizeExtensions(
+                const std::vector<std::string>& values)
+            {
+                std::unordered_set<std::string> out;
+                for (const auto& value : values)
+                {
+                    const std::string extension = normalizeExtension(value);
+                    if (!extension.empty())
+                    {
+                        out.insert(extension);
+                    }
+                }
+                return out;
+            }
+
+            FolderScanWarningCode warningCode(const std::error_code& error)
+            {
+                return error == std::errc::permission_denied ?
+                    FolderScanWarningCode::PermissionDenied :
+                    FolderScanWarningCode::IOError;
+            }
+
+            void addWarning(
+                FolderScanResult& result,
+                FolderScanWarningCode code,
+                const std::filesystem::path& path,
+                const std::error_code& error,
+                const std::string& message,
+                size_t maxWarnings)
+            {
+                if (result.warnings.size() < maxWarnings)
+                {
+                    result.warnings.push_back({ code, path, error, message });
+                }
+                else
+                {
+                    ++result.suppressedWarnings;
+                }
+            }
+
+            bool isLink(
+                const std::filesystem::path& path,
+                const std::filesystem::file_status& status)
+            {
+                if (std::filesystem::is_symlink(status))
+                {
+                    return true;
+                }
+#if defined(_WIN32)
+                if (!std::filesystem::is_directory(status))
+                {
+                    return false;
+                }
+                const DWORD attributes = GetFileAttributesW(path.c_str());
+                return INVALID_FILE_ATTRIBUTES != attributes &&
+                    0 != (attributes & FILE_ATTRIBUTE_REPARSE_POINT);
+#else
+                return false;
+#endif
+            }
+
+            std::string canonicalKey(const std::filesystem::path& path)
+            {
+                std::error_code error;
+                std::filesystem::path canonical = std::filesystem::weakly_canonical(path, error);
+                if (error)
+                {
+                    error.clear();
+                    canonical = std::filesystem::absolute(path, error);
+                }
+                if (error)
+                {
+                    canonical = path.lexically_normal();
+                }
+                std::string out = pathString(canonical);
+#if defined(_WIN32)
+                out = toLowerASCII(out);
+#endif
+                return out;
+            }
+
+            bool lessPath(
+                const std::filesystem::path& a,
+                const std::filesystem::path& b)
+            {
+                return pathString(a) < pathString(b);
+            }
+
+            bool lessPath(const ftk::Path& a, const ftk::Path& b)
+            {
+                return a.get() < b.get();
+            }
+
+            std::vector<ftk::Path> collapseSequences(
+                const std::vector<ftk::Path>& paths,
+                const std::unordered_set<std::string>& sequenceExtensions)
+            {
+                std::vector<ftk::Path> out;
+                std::unordered_map<std::string, size_t> groups;
+                for (const auto& path : paths)
+                {
+                    const std::string extension = normalizeExtension(path.getExt());
+                    if (path.hasNum() && sequenceExtensions.count(extension))
+                    {
+                        const std::string key =
+                            path.getDir() + '\0' +
+                            path.getBase() + '\0' +
+                            extension + '\0' +
+                            std::to_string(path.getPad());
+                        const auto i = groups.find(key);
+                        if (i != groups.end() && out[i->second].addSeq(path))
+                        {
+                            continue;
+                        }
+                        groups[key] = out.size();
+                    }
+                    out.push_back(path);
+                }
+                std::sort(
+                    out.begin(),
+                    out.end(),
+                    [](const ftk::Path& a, const ftk::Path& b)
+                    {
+                        return lessPath(a, b);
+                    });
+                return out;
+            }
+        }
+
+        struct FolderScanCancellationToken::State
+        {
+            std::atomic_bool cancelled{ false };
+#if defined(_WIN32)
+            std::mutex mutex;
+            HANDLE ioThread = nullptr;
+#endif
+        };
+
+        FolderScanCancellationToken::FolderScanCancellationToken(
+            const std::shared_ptr<State>& state) :
+            _state(state)
+        {}
+
+        bool FolderScanCancellationToken::isCancellationRequested() const
+        {
+            return _state && _state->cancelled.load(std::memory_order_acquire);
+        }
+
+        void FolderScanCancellationToken::bindToCurrentThread() const
+        {
+#if defined(_WIN32)
+            if (!_state)
+            {
+                return;
+            }
+            HANDLE duplicate = nullptr;
+            if (!DuplicateHandle(
+                GetCurrentProcess(),
+                GetCurrentThread(),
+                GetCurrentProcess(),
+                &duplicate,
+                0,
+                FALSE,
+                DUPLICATE_SAME_ACCESS))
+            {
+                return;
+            }
+            std::lock_guard<std::mutex> lock(_state->mutex);
+            if (_state->ioThread)
+            {
+                CloseHandle(_state->ioThread);
+            }
+            _state->ioThread = duplicate;
+            if (_state->cancelled.load(std::memory_order_acquire))
+            {
+                CancelSynchronousIo(_state->ioThread);
+            }
+#endif
+        }
+
+        void FolderScanCancellationToken::unbindFromCurrentThread() const
+        {
+#if defined(_WIN32)
+            if (!_state)
+            {
+                return;
+            }
+            std::lock_guard<std::mutex> lock(_state->mutex);
+            if (_state->ioThread)
+            {
+                CloseHandle(_state->ioThread);
+                _state->ioThread = nullptr;
+            }
+#endif
+        }
+
+        FolderScanCancellationSource::FolderScanCancellationSource() :
+            _state(std::make_shared<FolderScanCancellationToken::State>())
+        {}
+
+        FolderScanCancellationToken FolderScanCancellationSource::getToken() const
+        {
+            return FolderScanCancellationToken(_state);
+        }
+
+        void FolderScanCancellationSource::cancel() const
+        {
+            _state->cancelled.store(true, std::memory_order_release);
+#if defined(_WIN32)
+            std::lock_guard<std::mutex> lock(_state->mutex);
+            if (_state->ioThread)
+            {
+                // Directory enumeration on remote filesystems is synchronous;
+                // cancel the exact worker thread instead of abandoning it.
+                CancelSynchronousIo(_state->ioThread);
+            }
+#endif
+        }
+
+#if defined(_WIN32)
+        namespace
+        {
+            class CancellationBinding
+            {
+            public:
+                explicit CancellationBinding(const FolderScanCancellationToken& value) :
+                    token(value)
+                {
+                    token.bindToCurrentThread();
+                }
+                ~CancellationBinding()
+                {
+                    token.unbindFromCurrentThread();
+                }
+            private:
+                const FolderScanCancellationToken& token;
+            };
+
+            FolderScanResult cancelledResult(FolderScanResult out)
+            {
+                out.status = FolderScanStatus::Cancelled;
+                out.paths.clear();
+                return out;
+            }
+
+            FolderScanResult scanFolderWindows(
+                const std::filesystem::path& root,
+                const CompiledFileFilter& filter,
+                const FolderScanOptions& options,
+                const FolderScanCancellationToken& cancellation)
+            {
+                FolderScanResult out;
+                CancellationBinding cancellationBinding(cancellation);
+                if (cancellation.isCancellationRequested())
+                {
+                    return cancelledResult(std::move(out));
+                }
+
+                std::error_code error;
+                WinHandle rootHandle = openRootDirectory(root, true, error);
+                if (!rootHandle)
+                {
+                    if (cancellation.isCancellationRequested() ||
+                        ERROR_OPERATION_ABORTED == error.value())
+                    {
+                        return cancelledResult(std::move(out));
+                    }
+                    out.status = FolderScanStatus::InvalidRoot;
+                    addWarning(out, warningCode(error), root, error,
+                        "Cannot open scan root", options.maxWarnings);
+                    return out;
+                }
+                FILE_ATTRIBUTE_TAG_INFO rootAttributes = {};
+                if (!directoryAttributes(rootHandle.get(), rootAttributes) ||
+                    0 == (rootAttributes.FileAttributes & FILE_ATTRIBUTE_DIRECTORY))
+                {
+                    error = winError();
+                    if (!error)
+                    {
+                        error = std::make_error_code(std::errc::not_a_directory);
+                    }
+                    out.status = FolderScanStatus::InvalidRoot;
+                    addWarning(out, warningCode(error), root, error,
+                        "Scan root is not a directory", options.maxWarnings);
+                    return out;
+                }
+                const bool rootIsReparse =
+                    0 != (rootAttributes.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT);
+                if (rootIsReparse && !options.followDirectoryLinks)
+                {
+                    out.status = FolderScanStatus::InvalidRoot;
+                    addWarning(out, FolderScanWarningCode::LinkSkipped, root, {},
+                        "Scan root is a link and link traversal is disabled",
+                        options.maxWarnings);
+                    return out;
+                }
+                if (rootIsReparse)
+                {
+                    rootHandle = openRootDirectory(root, false, error);
+                    if (!rootHandle)
+                    {
+                        out.status = FolderScanStatus::InvalidRoot;
+                        addWarning(out, warningCode(error), root, error,
+                            "Cannot resolve scan root", options.maxWarnings);
+                        return out;
+                    }
+                }
+
+                DirectoryIdentity rootIdentity;
+                if (!getIdentity(rootHandle.get(), rootIdentity))
+                {
+                    error = winError();
+                    out.status = FolderScanStatus::InvalidRoot;
+                    addWarning(out, warningCode(error), root, error,
+                        "Cannot identify scan root", options.maxWarnings);
+                    return out;
+                }
+                const std::wstring rootFinalPath = finalPath(rootHandle.get());
+                if (rootFinalPath.empty())
+                {
+                    error = winError();
+                    out.status = FolderScanStatus::InvalidRoot;
+                    addWarning(out, warningCode(error), root, error,
+                        "Cannot resolve final scan root", options.maxWarnings);
+                    return out;
+                }
+
+                const auto fileExtensions = normalizeExtensions(options.fileExtensions);
+                const auto sequenceExtensions = normalizeExtensions(options.sequenceExtensions);
+                ftk::PathOptions pathOptions;
+                pathOptions.seqMaxDigits = options.sequenceMaxDigits;
+
+                std::vector<WinPendingDirectory> pending;
+                pending.push_back({ root, 0, std::move(rootHandle), rootIdentity });
+                std::vector<DirectoryIdentity> visitedDirectories;
+                bool stop = false;
+                while (!pending.empty() && !stop)
+                {
+                    if (cancellation.isCancellationRequested())
+                    {
+                        return cancelledResult(std::move(out));
+                    }
+                    WinPendingDirectory current = std::move(pending.back());
+                    pending.pop_back();
+                    if (std::find(
+                        visitedDirectories.begin(),
+                        visitedDirectories.end(),
+                        current.identity) != visitedDirectories.end())
+                    {
+                        continue;
+                    }
+                    visitedDirectories.push_back(current.identity);
+                    if (out.visitedDirectories >= options.maxDirectories)
+                    {
+                        out.status = FolderScanStatus::TraversalLimitReached;
+                        addWarning(out, FolderScanWarningCode::TraversalLimitReached,
+                            current.path, {}, "Folder scan directory limit reached",
+                            options.maxWarnings);
+                        break;
+                    }
+                    ++out.visitedDirectories;
+
+                    struct Entry
+                    {
+                        std::wstring name;
+                        DWORD attributes = 0;
+                    };
+                    std::vector<Entry> entries;
+                    std::vector<unsigned char> buffer(64 * 1024);
+                    while (true)
+                    {
+                        if (cancellation.isCancellationRequested())
+                        {
+                            return cancelledResult(std::move(out));
+                        }
+                        if (!GetFileInformationByHandleEx(
+                            current.handle.get(),
+                            FileIdBothDirectoryInfo,
+                            buffer.data(),
+                            static_cast<DWORD>(buffer.size())))
+                        {
+                            const DWORD value = GetLastError();
+                            if (ERROR_NO_MORE_FILES == value)
+                            {
+                                break;
+                            }
+                            if (ERROR_OPERATION_ABORTED == value ||
+                                cancellation.isCancellationRequested())
+                            {
+                                return cancelledResult(std::move(out));
+                            }
+                            error = winError(value);
+                            addWarning(out, warningCode(error), current.path, error,
+                                "Directory enumeration stopped early", options.maxWarnings);
+                            break;
+                        }
+                        auto* info = reinterpret_cast<FILE_ID_BOTH_DIR_INFO*>(buffer.data());
+                        while (info)
+                        {
+                            const std::wstring name(
+                                info->FileName,
+                                info->FileNameLength / sizeof(wchar_t));
+                            if (L"." != name && L".." != name)
+                            {
+                                if (out.visitedEntries >= options.maxEntries)
+                                {
+                                    out.status = FolderScanStatus::TraversalLimitReached;
+                                    addWarning(out, FolderScanWarningCode::TraversalLimitReached,
+                                        current.path, {},
+                                        "Folder scan global entry limit reached",
+                                        options.maxWarnings);
+                                    stop = true;
+                                    break;
+                                }
+                                if (entries.size() >= options.maxDirectoryEntries)
+                                {
+                                    out.status = FolderScanStatus::CandidateLimitReached;
+                                    addWarning(out, FolderScanWarningCode::CandidateLimitReached,
+                                        current.path, {}, "Directory entry limit reached",
+                                        options.maxWarnings);
+                                    stop = true;
+                                    break;
+                                }
+                                entries.push_back({ name, info->FileAttributes });
+                                ++out.visitedEntries;
+                            }
+                            if (!info->NextEntryOffset || stop)
+                            {
+                                break;
+                            }
+                            info = reinterpret_cast<FILE_ID_BOTH_DIR_INFO*>(
+                                reinterpret_cast<unsigned char*>(info) + info->NextEntryOffset);
+                        }
+                        if (stop)
+                        {
+                            break;
+                        }
+                    }
+                    if (stop)
+                    {
+                        break;
+                    }
+                    std::sort(entries.begin(), entries.end(),
+                        [](const Entry& a, const Entry& b) { return a.name < b.name; });
+
+                    std::vector<WinPendingDirectory> childDirectories;
+                    for (const auto& entry : entries)
+                    {
+                        if (cancellation.isCancellationRequested())
+                        {
+                            return cancelledResult(std::move(out));
+                        }
+                        const auto displayPath = current.path / entry.name;
+                        const bool directory =
+                            0 != (entry.attributes & FILE_ATTRIBUTE_DIRECTORY);
+                        const bool reparse =
+                            0 != (entry.attributes & FILE_ATTRIBUTE_REPARSE_POINT);
+                        if (directory)
+                        {
+                            if (!options.recursive ||
+                                filter.excludesDirectory(ftk::Path(pathString(displayPath))))
+                            {
+                                continue;
+                            }
+                            if (current.depth >= options.maxDepth)
+                            {
+                                addWarning(out, FolderScanWarningCode::DepthLimitReached,
+                                    displayPath, {}, "Directory depth limit reached",
+                                    options.maxWarnings);
+                                continue;
+                            }
+                            WinHandle child = openRelativeDirectory(
+                                current.handle.get(), entry.name, true, error);
+                            if (!child)
+                            {
+                                if (cancellation.isCancellationRequested() ||
+                                    ERROR_OPERATION_ABORTED == error.value())
+                                {
+                                    return cancelledResult(std::move(out));
+                                }
+                                addWarning(out, warningCode(error), displayPath, error,
+                                    "Cannot open directory entry", options.maxWarnings);
+                                continue;
+                            }
+                            FILE_ATTRIBUTE_TAG_INFO actualAttributes = {};
+                            if (!directoryAttributes(child.get(), actualAttributes))
+                            {
+                                error = winError();
+                                addWarning(out, warningCode(error), displayPath, error,
+                                    "Cannot inspect opened directory", options.maxWarnings);
+                                continue;
+                            }
+                            const bool actualDirectory = 0 !=
+                                (actualAttributes.FileAttributes & FILE_ATTRIBUTE_DIRECTORY);
+                            const bool actualReparse = 0 !=
+                                (actualAttributes.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT);
+                            if (!actualDirectory || reparse != actualReparse)
+                            {
+                                addWarning(out, FolderScanWarningCode::LinkSkipped,
+                                    displayPath, {},
+                                    "Directory identity changed during traversal",
+                                    options.maxWarnings);
+                                continue;
+                            }
+                            if (actualReparse)
+                            {
+                                if (!options.followDirectoryLinks)
+                                {
+                                    addWarning(out, FolderScanWarningCode::LinkSkipped,
+                                        displayPath, {}, "Link traversal is disabled",
+                                        options.maxWarnings);
+                                    continue;
+                                }
+                                child = openRelativeDirectory(
+                                    current.handle.get(), entry.name, false, error);
+                                if (!child)
+                                {
+                                    addWarning(out, warningCode(error), displayPath, error,
+                                        "Cannot resolve directory link", options.maxWarnings);
+                                    continue;
+                                }
+                                const std::wstring childFinalPath = finalPath(child.get());
+                                if (childFinalPath.empty() ||
+                                    !isWithinRoot(rootFinalPath, childFinalPath))
+                                {
+                                    addWarning(out, FolderScanWarningCode::LinkSkipped,
+                                        displayPath, {},
+                                        "Directory link escapes the scan root",
+                                        options.maxWarnings);
+                                    continue;
+                                }
+                            }
+                            DirectoryIdentity identity;
+                            if (!getIdentity(child.get(), identity))
+                            {
+                                error = winError();
+                                addWarning(out, warningCode(error), displayPath, error,
+                                    "Cannot identify opened directory", options.maxWarnings);
+                                continue;
+                            }
+                            childDirectories.push_back(
+                                { displayPath, current.depth + 1, std::move(child), identity });
+                        }
+                        else
+                        {
+                            if (reparse && !options.followDirectoryLinks)
+                            {
+                                addWarning(out, FolderScanWarningCode::LinkSkipped,
+                                    displayPath, {}, "Link traversal is disabled",
+                                    options.maxWarnings);
+                                continue;
+                            }
+                            if (out.visitedFiles >= options.maxCandidates)
+                            {
+                                out.status = FolderScanStatus::CandidateLimitReached;
+                                addWarning(out, FolderScanWarningCode::CandidateLimitReached,
+                                    displayPath, {}, "Folder scan candidate limit reached",
+                                    options.maxWarnings);
+                                stop = true;
+                                break;
+                            }
+                            ++out.visitedFiles;
+                            const std::string value = pathString(displayPath);
+                            if (value.size() > CompiledFileFilter::maxCandidateLength)
+                            {
+                                addWarning(out, FolderScanWarningCode::CandidateTooLong,
+                                    displayPath, {}, "Candidate path is too long",
+                                    options.maxWarnings);
+                                continue;
+                            }
+                            const ftk::Path path(value, pathOptions);
+                            const std::string extension = normalizeExtension(path.getExt());
+                            if ((!fileExtensions.empty() && !fileExtensions.count(extension)) ||
+                                !filter.matches(path))
+                            {
+                                continue;
+                            }
+                            out.paths.push_back(path);
+                        }
+                    }
+                    for (auto i = childDirectories.rbegin();
+                        i != childDirectories.rend(); ++i)
+                    {
+                        pending.push_back(std::move(*i));
+                    }
+                }
+
+                std::sort(out.paths.begin(), out.paths.end(),
+                    [](const ftk::Path& a, const ftk::Path& b) { return lessPath(a, b); });
+                if (FolderScanStatus::CandidateLimitReached == out.status ||
+                    FolderScanStatus::TraversalLimitReached == out.status)
+                {
+                    out.paths.clear();
+                }
+                if (options.collapseSequences && !sequenceExtensions.empty())
+                {
+                    out.paths = collapseSequences(out.paths, sequenceExtensions);
+                }
+                if (FolderScanStatus::Completed == out.status &&
+                    options.maxResults > 0 && out.paths.size() > options.maxResults)
+                {
+                    out.status = FolderScanStatus::ResultLimitReached;
+                    addWarning(out, FolderScanWarningCode::ResultLimitReached,
+                        root, {}, "Folder scan result limit reached; use a narrower filter",
+                        options.maxWarnings);
+                    out.paths.clear();
+                }
+                return out;
+            }
+        }
+#endif
+
+        FolderScanResult scanFolder(
+            const std::filesystem::path& root,
+            const CompiledFileFilter& filter,
+            const FolderScanOptions& options,
+            const FolderScanCancellationToken& cancellation)
+        {
+#if defined(_WIN32)
+            return scanFolderWindows(root, filter, options, cancellation);
+#else
+            FolderScanResult out;
+            if (cancellation.isCancellationRequested())
+            {
+                out.status = FolderScanStatus::Cancelled;
+                return out;
+            }
+
+            std::error_code error;
+            const auto rootLinkStatus = std::filesystem::symlink_status(root, error);
+            if (error)
+            {
+                out.status = FolderScanStatus::InvalidRoot;
+                addWarning(out, warningCode(error), root, error, "Cannot inspect scan root", options.maxWarnings);
+                return out;
+            }
+            if (isLink(root, rootLinkStatus) && !options.followDirectoryLinks)
+            {
+                out.status = FolderScanStatus::InvalidRoot;
+                addWarning(
+                    out,
+                    FolderScanWarningCode::LinkSkipped,
+                    root,
+                    std::error_code(),
+                    "Scan root is a link and link traversal is disabled",
+                    options.maxWarnings);
+                return out;
+            }
+            const auto rootStatus = std::filesystem::status(root, error);
+            if (error || !std::filesystem::is_directory(rootStatus))
+            {
+                if (!error)
+                {
+                    error = std::make_error_code(std::errc::not_a_directory);
+                }
+                out.status = FolderScanStatus::InvalidRoot;
+                addWarning(out, warningCode(error), root, error, "Scan root is not a directory", options.maxWarnings);
+                return out;
+            }
+
+            const auto fileExtensions = normalizeExtensions(options.fileExtensions);
+            const auto sequenceExtensions = normalizeExtensions(options.sequenceExtensions);
+            ftk::PathOptions pathOptions;
+            pathOptions.seqMaxDigits = options.sequenceMaxDigits;
+
+            std::vector<PendingDirectory> pending = { { root, 0 } };
+            std::unordered_set<std::string> visitedDirectories;
+            bool stop = false;
+            while (!pending.empty() && !stop)
+            {
+                if (cancellation.isCancellationRequested())
+                {
+                    out.status = FolderScanStatus::Cancelled;
+                    out.paths.clear();
+                    return out;
+                }
+
+                const PendingDirectory current = pending.back();
+                pending.pop_back();
+                if (!visitedDirectories.insert(canonicalKey(current.path)).second)
+                {
+                    continue;
+                }
+                if (out.visitedDirectories >= options.maxDirectories)
+                {
+                    out.status = FolderScanStatus::TraversalLimitReached;
+                    addWarning(
+                        out,
+                        FolderScanWarningCode::TraversalLimitReached,
+                        current.path,
+                        std::error_code(),
+                        "Folder scan directory limit reached",
+                        options.maxWarnings);
+                    stop = true;
+                    break;
+                }
+                ++out.visitedDirectories;
+
+                std::vector<std::filesystem::path> entries;
+                std::filesystem::directory_iterator iterator(
+                    current.path,
+                    std::filesystem::directory_options::none,
+                    error);
+                if (error)
+                {
+                    addWarning(
+                        out,
+                        warningCode(error),
+                        current.path,
+                        error,
+                        "Cannot enumerate directory",
+                        options.maxWarnings);
+                    error.clear();
+                    continue;
+                }
+                const std::filesystem::directory_iterator end;
+                while (iterator != end)
+                {
+                    if (out.visitedEntries >= options.maxEntries)
+                    {
+                        out.status = FolderScanStatus::TraversalLimitReached;
+                        addWarning(
+                            out,
+                            FolderScanWarningCode::TraversalLimitReached,
+                            current.path,
+                            std::error_code(),
+                            "Folder scan global entry limit reached",
+                            options.maxWarnings);
+                        stop = true;
+                        break;
+                    }
+                    if (entries.size() >= options.maxDirectoryEntries)
+                    {
+                        out.status = FolderScanStatus::CandidateLimitReached;
+                        addWarning(
+                            out,
+                            FolderScanWarningCode::CandidateLimitReached,
+                            current.path,
+                            std::error_code(),
+                            "Directory entry limit reached",
+                            options.maxWarnings);
+                        stop = true;
+                        break;
+                    }
+                    entries.push_back(iterator->path());
+                    ++out.visitedEntries;
+                    iterator.increment(error);
+                    if (error)
+                    {
+                        addWarning(
+                            out,
+                            warningCode(error),
+                            current.path,
+                            error,
+                            "Directory enumeration stopped early",
+                            options.maxWarnings);
+                        error.clear();
+                        break;
+                    }
+                }
+                if (stop)
+                {
+                    break;
+                }
+                std::sort(
+                    entries.begin(),
+                    entries.end(),
+                    [](const std::filesystem::path& a, const std::filesystem::path& b)
+                    {
+                        return lessPath(a, b);
+                    });
+
+                std::vector<PendingDirectory> childDirectories;
+                for (const auto& entry : entries)
+                {
+                    if (cancellation.isCancellationRequested())
+                    {
+                        out.status = FolderScanStatus::Cancelled;
+                        out.paths.clear();
+                        return out;
+                    }
+
+                    const auto linkStatus = std::filesystem::symlink_status(entry, error);
+                    if (error)
+                    {
+                        addWarning(out, warningCode(error), entry, error, "Cannot inspect entry", options.maxWarnings);
+                        error.clear();
+                        continue;
+                    }
+                    const bool link = isLink(entry, linkStatus);
+                    if (link && !options.followDirectoryLinks)
+                    {
+                        addWarning(
+                            out,
+                            FolderScanWarningCode::LinkSkipped,
+                            entry,
+                            std::error_code(),
+                            "Link traversal is disabled",
+                            options.maxWarnings);
+                        continue;
+                    }
+
+                    const auto status = link ? std::filesystem::status(entry, error) : linkStatus;
+                    if (error)
+                    {
+                        addWarning(out, warningCode(error), entry, error, "Cannot resolve entry", options.maxWarnings);
+                        error.clear();
+                        continue;
+                    }
+                    if (std::filesystem::is_directory(status))
+                    {
+                        if (!options.recursive || filter.excludesDirectory(ftk::Path(pathString(entry))))
+                        {
+                            continue;
+                        }
+                        if (current.depth >= options.maxDepth)
+                        {
+                            addWarning(
+                                out,
+                                FolderScanWarningCode::DepthLimitReached,
+                                entry,
+                                std::error_code(),
+                                "Directory depth limit reached",
+                                options.maxWarnings);
+                            continue;
+                        }
+                        childDirectories.push_back({ entry, current.depth + 1 });
+                    }
+                    else if (std::filesystem::is_regular_file(status))
+                    {
+                        if (out.visitedFiles >= options.maxCandidates)
+                        {
+                            out.status = FolderScanStatus::CandidateLimitReached;
+                            addWarning(
+                                out,
+                                FolderScanWarningCode::CandidateLimitReached,
+                                entry,
+                                std::error_code(),
+                                "Folder scan candidate limit reached",
+                                options.maxWarnings);
+                            stop = true;
+                            break;
+                        }
+                        ++out.visitedFiles;
+                        const std::string value = pathString(entry);
+                        if (value.size() > CompiledFileFilter::maxCandidateLength)
+                        {
+                            addWarning(
+                                out,
+                                FolderScanWarningCode::CandidateTooLong,
+                                entry,
+                                std::error_code(),
+                                "Candidate path is too long",
+                                options.maxWarnings);
+                            continue;
+                        }
+
+                        const ftk::Path path(value, pathOptions);
+                        const std::string extension = normalizeExtension(path.getExt());
+                        if ((!fileExtensions.empty() && !fileExtensions.count(extension)) ||
+                            !filter.matches(path))
+                        {
+                            continue;
+                        }
+                        out.paths.push_back(path);
+                    }
+                }
+
+                for (auto i = childDirectories.rbegin(); i != childDirectories.rend(); ++i)
+                {
+                    pending.push_back(*i);
+                }
+            }
+
+            std::sort(
+                out.paths.begin(),
+                out.paths.end(),
+                [](const ftk::Path& a, const ftk::Path& b)
+                {
+                    return lessPath(a, b);
+                });
+            if (FolderScanStatus::CandidateLimitReached == out.status ||
+                FolderScanStatus::TraversalLimitReached == out.status)
+            {
+                // A bounded scan is an atomic result; never expose a partial
+                // file set that a caller could mistake for a complete folder.
+                out.paths.clear();
+            }
+            if (options.collapseSequences && !sequenceExtensions.empty())
+            {
+                out.paths = collapseSequences(out.paths, sequenceExtensions);
+            }
+            if (FolderScanStatus::Completed == out.status &&
+                options.maxResults > 0 && out.paths.size() > options.maxResults)
+            {
+                out.status = FolderScanStatus::ResultLimitReached;
+                addWarning(
+                    out,
+                    FolderScanWarningCode::ResultLimitReached,
+                    root,
+                    std::error_code(),
+                    "Folder scan result limit reached; use a narrower filter",
+                    options.maxWarnings);
+                out.paths.clear();
+            }
+            return out;
+#endif
+        }
+    }
+}

--- a/lib/djv/Models/FolderScanner.h
+++ b/lib/djv/Models/FolderScanner.h
@@ -8,6 +8,7 @@
 #include <ftk/Core/Path.h>
 
 #include <cstddef>
+#include <cstdint>
 #include <filesystem>
 #include <memory>
 #include <string>
@@ -117,6 +118,10 @@ namespace djv
             size_t visitedEntries = 0;
             size_t visitedFiles = 0;
             size_t suppressedWarnings = 0;
+
+            //! Deterministic signature of matching file paths and metadata.
+            //! A zero value means the scan did not produce a complete result.
+            uint64_t contentSignature = 0;
         };
 
         //! Scan a directory synchronously. The caller may run this function on

--- a/lib/djv/Models/FolderScanner.h
+++ b/lib/djv/Models/FolderScanner.h
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the DJV project.
+
+#pragma once
+
+#include <djv/Models/FileFilter.h>
+
+#include <ftk/Core/Path.h>
+
+#include <cstddef>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <system_error>
+#include <vector>
+
+namespace djv
+{
+    namespace models
+    {
+        //! Cancellation token shared safely between a scanner and its owner.
+        class FolderScanCancellationToken
+        {
+        public:
+            FolderScanCancellationToken() = default;
+
+            bool isCancellationRequested() const;
+
+            //! Bind/unbind the current synchronous I/O thread so cancellation
+            //! can interrupt a blocked Windows filesystem request.
+            void bindToCurrentThread() const;
+            void unbindFromCurrentThread() const;
+
+        private:
+            struct State;
+            explicit FolderScanCancellationToken(
+                const std::shared_ptr<State>&);
+
+            std::shared_ptr<State> _state;
+
+            friend class FolderScanCancellationSource;
+        };
+
+        //! Owner of a folder scan cancellation token.
+        class FolderScanCancellationSource
+        {
+        public:
+            FolderScanCancellationSource();
+
+            FolderScanCancellationToken getToken() const;
+            void cancel() const;
+
+        private:
+            std::shared_ptr<FolderScanCancellationToken::State> _state;
+        };
+
+        enum class FolderScanStatus
+        {
+            Completed,
+            Cancelled,
+            CandidateLimitReached,
+            TraversalLimitReached,
+            ResultLimitReached,
+            InvalidRoot
+        };
+
+        enum class FolderScanWarningCode
+        {
+            PermissionDenied,
+            IOError,
+            LinkSkipped,
+            CandidateTooLong,
+            CandidateLimitReached,
+            TraversalLimitReached,
+            ResultLimitReached,
+            DepthLimitReached
+        };
+
+        struct FolderScanWarning
+        {
+            FolderScanWarningCode code = FolderScanWarningCode::IOError;
+            std::filesystem::path path;
+            std::error_code error;
+            std::string message;
+        };
+
+        struct FolderScanOptions
+        {
+            bool recursive = true;
+            bool followDirectoryLinks = false;
+            bool collapseSequences = false;
+            size_t sequenceMaxDigits = 9;
+            size_t maxCandidates = 1000000;
+            size_t maxDirectoryEntries = 250000;
+            //! Global traversal limits across the complete request.
+            size_t maxDirectories = 100000;
+            size_t maxEntries = 1000000;
+            //! Maximum final paths after optional sequence collapsing. Zero is unlimited.
+            size_t maxResults = 5000;
+            size_t maxDepth = 128;
+            size_t maxWarnings = 1000;
+
+            //! Empty accepts all extensions. Entries may include a leading dot.
+            std::vector<std::string> fileExtensions;
+
+            //! Extensions eligible for sequence collapsing. Only used when
+            //! collapseSequences is true. Entries may include a leading dot.
+            std::vector<std::string> sequenceExtensions;
+        };
+
+        struct FolderScanResult
+        {
+            FolderScanStatus status = FolderScanStatus::Completed;
+            std::vector<ftk::Path> paths;
+            std::vector<FolderScanWarning> warnings;
+            size_t visitedDirectories = 0;
+            size_t visitedEntries = 0;
+            size_t visitedFiles = 0;
+            size_t suppressedWarnings = 0;
+        };
+
+        //! Scan a directory synchronously. The caller may run this function on
+        //! a worker thread and cancel it through the supplied token.
+        FolderScanResult scanFolder(
+            const std::filesystem::path& root,
+            const CompiledFileFilter& filter,
+            const FolderScanOptions& = FolderScanOptions(),
+            const FolderScanCancellationToken& = FolderScanCancellationToken());
+    }
+}

--- a/lib/djv/Models/PlaylistModel.cpp
+++ b/lib/djv/Models/PlaylistModel.cpp
@@ -1,0 +1,618 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the DJV project.
+
+#include <djv/Models/PlaylistModel.h>
+
+#include <tlRender/Core/URL.h>
+#include <tlRender/Timeline/Util.h>
+
+#include <ftk/Core/FileIO.h>
+#include <ftk/Core/String.h>
+
+#include <opentimelineio/clip.h>
+#include <opentimelineio/externalReference.h>
+#include <opentimelineio/gap.h>
+#include <opentimelineio/track.h>
+
+#include <algorithm>
+#include <filesystem>
+#include <stdexcept>
+
+namespace djv
+{
+    namespace models
+    {
+        namespace
+        {
+            using RetainedComposable =
+                OTIO_NS::SerializableObject::Retainer<OTIO_NS::Composable>;
+            using RetainedClip =
+                OTIO_NS::SerializableObject::Retainer<OTIO_NS::Clip>;
+
+            bool isOTIOPath(const ftk::Path& path)
+            {
+                const std::string ext = ftk::toLower(path.getExt());
+                return ".otio" == ext || ".otioz" == ext;
+            }
+
+            std::string errorText(
+                const OTIO_NS::ErrorStatus& errorStatus,
+                const std::string& fallback)
+            {
+                return OTIO_NS::is_error(errorStatus) && !errorStatus.details.empty() ?
+                    errorStatus.details : fallback;
+            }
+
+            RetainedClip cloneClip(const OTIO_NS::Clip* clip)
+            {
+                OTIO_NS::ErrorStatus errorStatus;
+                auto out = RetainedClip(dynamic_cast<OTIO_NS::Clip*>(
+                    clip ? clip->clone(&errorStatus) : nullptr));
+                if (!out || OTIO_NS::is_error(errorStatus))
+                {
+                    throw std::runtime_error(errorText(errorStatus, "Cannot clone OTIO clip."));
+                }
+                return out;
+            }
+
+            void setClipPath(OTIO_NS::Clip* clip, const ftk::Path& path)
+            {
+                if (!clip)
+                {
+                    return;
+                }
+                const std::string absolute = std::filesystem::absolute(
+                    std::filesystem::u8path(path.get())).u8string();
+                for (const auto& i : clip->media_references())
+                {
+                    if (auto externalReference =
+                        dynamic_cast<OTIO_NS::ExternalReference*>(i.second))
+                    {
+                        externalReference->set_target_url(tl::encodeURL(absolute));
+                    }
+                }
+                clip->set_name(path.getFileName());
+            }
+
+            std::vector<RetainedComposable> retainedChildren(OTIO_NS::Track* track)
+            {
+                std::vector<RetainedComposable> out;
+                if (track)
+                {
+                    for (const auto& child : track->children())
+                    {
+                        out.push_back(child);
+                    }
+                }
+                return out;
+            }
+
+            bool reorderTrack(
+                OTIO_NS::Track* track,
+                size_t from,
+                size_t to,
+                std::string* error)
+            {
+                auto children = retainedChildren(track);
+                if (from >= children.size() || to >= children.size())
+                {
+                    if (error)
+                    {
+                        *error = "Playlist reorder index is out of range.";
+                    }
+                    return false;
+                }
+                const auto child = children[from];
+                OTIO_NS::ErrorStatus errorStatus;
+                if (!track->remove_child(static_cast<int>(from), &errorStatus) ||
+                    OTIO_NS::is_error(errorStatus))
+                {
+                    if (error)
+                    {
+                        *error = errorText(
+                            errorStatus,
+                            "Cannot remove OTIO playlist item for reordering.");
+                    }
+                    return false;
+                }
+                if (!track->insert_child(
+                    static_cast<int>(to), child.value, &errorStatus) ||
+                    OTIO_NS::is_error(errorStatus))
+                {
+                    OTIO_NS::ErrorStatus rollbackStatus;
+                    track->insert_child(
+                        static_cast<int>(std::min(from, track->children().size())),
+                        child.value,
+                        &rollbackStatus);
+                    if (error)
+                    {
+                        *error = errorText(
+                            errorStatus,
+                            "Cannot insert reordered OTIO playlist item.");
+                    }
+                    return false;
+                }
+                return true;
+            }
+        }
+
+        struct PlaylistModel::Private
+        {
+            bool available = false;
+            bool editable = false;
+            bool dirty = false;
+            bool scratch = false;
+            ftk::Path path;
+            std::string readOnlyReason;
+            std::string lastError;
+            std::vector<PlaylistItem> items;
+            OTIO_NS::SerializableObject::Retainer<OTIO_NS::Timeline> timeline;
+            OTIO_NS::Track* videoTrack = nullptr;
+            OTIO_NS::Track* audioTrack = nullptr;
+            std::shared_ptr<ftk::Observable<int> > revision =
+                ftk::Observable<int>::create(0);
+        };
+
+        PlaylistModel::PlaylistModel() :
+            _p(new Private)
+        {}
+
+        PlaylistModel::~PlaylistModel()
+        {}
+
+        std::shared_ptr<PlaylistModel> PlaylistModel::create()
+        {
+            return std::shared_ptr<PlaylistModel>(new PlaylistModel);
+        }
+
+        bool PlaylistModel::isAvailable() const { return _p->available; }
+        bool PlaylistModel::isEditable() const { return _p->editable; }
+        bool PlaylistModel::isDirty() const { return _p->dirty; }
+        bool PlaylistModel::isScratch() const { return _p->scratch; }
+        const ftk::Path& PlaylistModel::getPath() const { return _p->path; }
+        const std::string& PlaylistModel::getReadOnlyReason() const { return _p->readOnlyReason; }
+        const std::string& PlaylistModel::getLastError() const { return _p->lastError; }
+        const std::vector<PlaylistItem>& PlaylistModel::getItems() const { return _p->items; }
+        const OTIO_NS::SerializableObject::Retainer<OTIO_NS::Timeline>& PlaylistModel::getTimeline() const { return _p->timeline; }
+
+        std::shared_ptr<ftk::IObservable<int> > PlaylistModel::observeRevision() const
+        {
+            return _p->revision;
+        }
+
+        void PlaylistModel::clear()
+        {
+            FTK_P();
+            if (!p.available && !p.timeline)
+            {
+                return;
+            }
+            p.available = false;
+            p.editable = false;
+            p.dirty = false;
+            p.scratch = false;
+            p.path = ftk::Path();
+            p.readOnlyReason.clear();
+            p.lastError.clear();
+            p.items.clear();
+            p.timeline = nullptr;
+            p.videoTrack = nullptr;
+            p.audioTrack = nullptr;
+            _changed();
+        }
+
+        void PlaylistModel::setTimeline(
+            const OTIO_NS::SerializableObject::Retainer<OTIO_NS::Timeline>& timeline,
+            const ftk::Path& path,
+            bool dirty,
+            bool scratch)
+        {
+            FTK_P();
+            if (
+                p.timeline.value == timeline.value &&
+                p.path.get() == path.get() &&
+                p.dirty == dirty &&
+                p.scratch == scratch)
+            {
+                return;
+            }
+            p.timeline = timeline;
+            p.path = path;
+            p.dirty = dirty;
+            p.scratch = scratch;
+            p.lastError.clear();
+            _analyze();
+            _changed();
+        }
+
+        bool PlaylistModel::createFromMedia(
+            const std::shared_ptr<ftk::Context>& context,
+            const ftk::Path& readPath,
+            const ftk::Path& referencePath,
+            const ftk::Path& playlistPath,
+            const tl::Options& inputOptions,
+            std::string* error)
+        {
+            FTK_P();
+            try
+            {
+                if (isOTIOPath(referencePath))
+                {
+                    throw std::runtime_error("Select an image or video, not an OTIO timeline.");
+                }
+                tl::Options options = inputOptions;
+                options.pathOptions.seqMaxDigits = 0;
+                options.imageSeqAudio = tl::ImageSeqAudio::None;
+                auto mediaTimeline =
+                    tl::Timeline::create(context, readPath, options);
+                const auto& timeline = mediaTimeline->getTimeline();
+                for (auto clip : timeline->find_children<OTIO_NS::Clip>())
+                {
+                    setClipPath(clip.value, referencePath);
+                }
+                setTimeline(timeline, playlistPath, true, true);
+                if (!isEditable())
+                {
+                    throw std::runtime_error(
+                        p.readOnlyReason.empty() ?
+                        "The selected media could not be converted to a flat playlist." :
+                        p.readOnlyReason);
+                }
+                if (!_write(playlistPath, error))
+                {
+                    return false;
+                }
+                p.dirty = true;
+                p.scratch = true;
+                p.lastError.clear();
+                _changed();
+                return true;
+            }
+            catch (const std::exception& e)
+            {
+                _setError(e.what());
+                if (error)
+                {
+                    *error = e.what();
+                }
+                return false;
+            }
+        }
+
+        bool PlaylistModel::addMedia(
+            const std::shared_ptr<ftk::Context>& context,
+            const ftk::Path& readPath,
+            const ftk::Path& referencePath,
+            const tl::Options& inputOptions,
+            std::string* error)
+        {
+            FTK_P();
+            try
+            {
+                if (!p.editable || !p.videoTrack)
+                {
+                    throw std::runtime_error("The active OTIO timeline is read-only.");
+                }
+                if (isOTIOPath(referencePath))
+                {
+                    throw std::runtime_error("Add images or videos, not another OTIO timeline.");
+                }
+
+                tl::Options options = inputOptions;
+                options.pathOptions.seqMaxDigits = 0;
+                options.imageSeqAudio = tl::ImageSeqAudio::None;
+                auto mediaTimeline =
+                    tl::Timeline::create(context, readPath, options);
+                const auto& timeline = mediaTimeline->getTimeline();
+                const auto videoTracks = timeline->video_tracks();
+                if (videoTracks.size() != 1 || videoTracks[0]->children().empty())
+                {
+                    throw std::runtime_error("The selected file does not contain supported video or image media.");
+                }
+                auto sourceVideo = dynamic_cast<OTIO_NS::Clip*>(
+                    videoTracks[0]->children()[0].value);
+                if (!sourceVideo)
+                {
+                    throw std::runtime_error("The selected media did not produce an OTIO clip.");
+                }
+                auto videoClip = cloneClip(sourceVideo);
+                setClipPath(videoClip.value, referencePath);
+                const OTIO_NS::RationalTime videoDuration = videoClip->duration();
+
+                RetainedClip audioClip;
+                const auto audioTracks = timeline->audio_tracks();
+                if (!audioTracks.empty() && !audioTracks[0]->children().empty())
+                {
+                    if (auto sourceAudio = dynamic_cast<OTIO_NS::Clip*>(
+                        audioTracks[0]->children()[0].value))
+                    {
+                        audioClip = cloneClip(sourceAudio);
+                        setClipPath(audioClip.value, referencePath);
+                    }
+                }
+
+                OTIO_NS::ErrorStatus errorStatus;
+                const size_t previousVideoCount = p.videoTrack->children().size();
+                if (!p.videoTrack->append_child(videoClip.value, &errorStatus) ||
+                    OTIO_NS::is_error(errorStatus))
+                {
+                    throw std::runtime_error(errorText(errorStatus, "Cannot append video clip."));
+                }
+
+                if (audioClip && !p.audioTrack)
+                {
+                    p.audioTrack = new OTIO_NS::Track(
+                        "Audio", std::nullopt, OTIO_NS::Track::Kind::audio);
+                    for (size_t i = 0; i < previousVideoCount; ++i)
+                    {
+                        const auto duration = p.videoTrack->children()[i]->duration(&errorStatus);
+                        if (!p.audioTrack->append_child(new OTIO_NS::Gap(duration), &errorStatus) ||
+                            OTIO_NS::is_error(errorStatus))
+                        {
+                            throw std::runtime_error(errorText(errorStatus, "Cannot append audio gap."));
+                        }
+                    }
+                    if (!p.timeline->tracks()->append_child(p.audioTrack, &errorStatus) ||
+                        OTIO_NS::is_error(errorStatus))
+                    {
+                        throw std::runtime_error(errorText(errorStatus, "Cannot append audio track."));
+                    }
+                }
+                if (p.audioTrack)
+                {
+                    OTIO_NS::Composable* audioChild = audioClip ?
+                        static_cast<OTIO_NS::Composable*>(audioClip.value) :
+                        static_cast<OTIO_NS::Composable*>(new OTIO_NS::Gap(videoDuration));
+                    if (!p.audioTrack->append_child(audioChild, &errorStatus) ||
+                        OTIO_NS::is_error(errorStatus))
+                    {
+                        throw std::runtime_error(errorText(errorStatus, "Cannot append audio playlist item."));
+                    }
+                }
+
+                p.dirty = true;
+                p.lastError.clear();
+                _analyze();
+                _changed();
+                return true;
+            }
+            catch (const std::exception& e)
+            {
+                _setError(e.what());
+                if (error)
+                {
+                    *error = e.what();
+                }
+                return false;
+            }
+        }
+
+        bool PlaylistModel::move(size_t from, size_t to, std::string* error)
+        {
+            FTK_P();
+            if (!p.editable || !p.videoTrack)
+            {
+                if (error) *error = "The active OTIO timeline is read-only.";
+                return false;
+            }
+            if (from == to)
+            {
+                return true;
+            }
+            if (!reorderTrack(p.videoTrack, from, to, error))
+            {
+                _setError(error ? *error : "Cannot reorder playlist.");
+                return false;
+            }
+            if (p.audioTrack && !reorderTrack(p.audioTrack, from, to, error))
+            {
+                _setError(error ? *error : "Cannot reorder playlist audio.");
+                return false;
+            }
+            p.dirty = true;
+            p.lastError.clear();
+            _analyze();
+            _changed();
+            return true;
+        }
+
+        bool PlaylistModel::remove(size_t index, std::string* error)
+        {
+            FTK_P();
+            if (!p.editable || !p.videoTrack)
+            {
+                if (error) *error = "The active OTIO timeline is read-only.";
+                return false;
+            }
+            if (p.videoTrack->children().size() <= 1)
+            {
+                if (error) *error = "A playlist must keep at least one media item.";
+                return false;
+            }
+            if (index >= p.videoTrack->children().size())
+            {
+                if (error) *error = "Playlist remove index is out of range.";
+                return false;
+            }
+            OTIO_NS::ErrorStatus errorStatus;
+            if (!p.videoTrack->remove_child(static_cast<int>(index), &errorStatus) ||
+                OTIO_NS::is_error(errorStatus))
+            {
+                const std::string value = errorText(errorStatus, "Cannot remove video playlist item.");
+                _setError(value);
+                if (error) *error = value;
+                return false;
+            }
+            if (p.audioTrack &&
+                (!p.audioTrack->remove_child(static_cast<int>(index), &errorStatus) ||
+                OTIO_NS::is_error(errorStatus)))
+            {
+                const std::string value = errorText(errorStatus, "Cannot remove audio playlist item.");
+                _setError(value);
+                if (error) *error = value;
+                return false;
+            }
+            p.dirty = true;
+            p.lastError.clear();
+            _analyze();
+            _changed();
+            return true;
+        }
+
+        bool PlaylistModel::save(const ftk::Path& inputPath, std::string* error)
+        {
+            FTK_P();
+            if (!p.available || !p.timeline)
+            {
+                if (error) *error = "No OTIO timeline is active.";
+                return false;
+            }
+            ftk::Path path = inputPath;
+            if (ftk::toLower(path.getExt()) != ".otio")
+            {
+                path = ftk::Path(path.get() + ".otio");
+            }
+            if (!_write(path, error))
+            {
+                return false;
+            }
+            p.path = path;
+            p.dirty = false;
+            p.scratch = false;
+            p.lastError.clear();
+            _analyze();
+            _changed();
+            return true;
+        }
+
+        bool PlaylistModel::_analyze(std::string* error)
+        {
+            FTK_P();
+            p.available = p.timeline && isOTIOPath(p.path);
+            p.editable = false;
+            p.videoTrack = nullptr;
+            p.audioTrack = nullptr;
+            p.items.clear();
+            p.readOnlyReason.clear();
+            if (!p.available)
+            {
+                return false;
+            }
+            if (ftk::toLower(p.path.getExt()) == ".otioz")
+            {
+                p.readOnlyReason = "Packaged .otioz timelines are read-only. Use Save As to create an .otio copy.";
+            }
+
+            const auto videoTracks = p.timeline->video_tracks();
+            const auto audioTracks = p.timeline->audio_tracks();
+            bool simple = videoTracks.size() == 1 && audioTracks.size() <= 1;
+            if (simple)
+            {
+                const auto& stackChildren = p.timeline->tracks()->children();
+                simple = stackChildren.size() == videoTracks.size() + audioTracks.size();
+            }
+            if (simple)
+            {
+                p.videoTrack = videoTracks[0];
+                p.audioTrack = audioTracks.empty() ? nullptr : audioTracks[0];
+                for (const auto& child : p.videoTrack->children())
+                {
+                    if (!dynamic_cast<OTIO_NS::Clip*>(child.value))
+                    {
+                        simple = false;
+                        break;
+                    }
+                }
+                if (simple && p.audioTrack)
+                {
+                    simple = p.audioTrack->children().size() == p.videoTrack->children().size();
+                    for (const auto& child : p.audioTrack->children())
+                    {
+                        if (!dynamic_cast<OTIO_NS::Clip*>(child.value) &&
+                            !dynamic_cast<OTIO_NS::Gap*>(child.value))
+                        {
+                            simple = false;
+                            break;
+                        }
+                    }
+                }
+            }
+            if (!simple)
+            {
+                p.videoTrack = nullptr;
+                p.audioTrack = nullptr;
+                if (p.readOnlyReason.empty())
+                {
+                    p.readOnlyReason = "This OTIO contains multiple, nested, transitioned, or unaligned tracks.";
+                }
+                if (error) *error = p.readOnlyReason;
+                return false;
+            }
+
+            const std::string directory = std::filesystem::u8path(
+                p.path.get()).parent_path().u8string();
+            ftk::PathOptions pathOptions;
+            pathOptions.seqMaxDigits = 0;
+            for (size_t i = 0; i < p.videoTrack->children().size(); ++i)
+            {
+                auto clip = dynamic_cast<OTIO_NS::Clip*>(
+                    p.videoTrack->children()[i].value);
+                PlaylistItem item;
+                item.path = tl::getPath(clip->media_reference(), directory, pathOptions);
+                item.name = clip->name().empty() ? item.path.getFileName() : clip->name();
+                item.duration = clip->duration();
+                item.hasAudio = p.audioTrack &&
+                    dynamic_cast<OTIO_NS::Clip*>(p.audioTrack->children()[i].value);
+                std::error_code errorCode;
+                item.missing = !item.path.isEmpty() && !std::filesystem::exists(
+                    std::filesystem::u8path(item.path.get()), errorCode);
+                p.items.push_back(item);
+            }
+            p.editable = p.readOnlyReason.empty();
+            return p.editable;
+        }
+
+        bool PlaylistModel::_write(const ftk::Path& path, std::string* error)
+        {
+            FTK_P();
+            try
+            {
+                OTIO_NS::AnyDictionary dict;
+                dict["path"] = path.get();
+                dict["audioPath"] = std::string();
+                p.timeline->metadata()["tlRender"] = dict;
+                OTIO_NS::ErrorStatus errorStatus;
+                const std::string json = p.timeline->to_json_string(&errorStatus);
+                if (OTIO_NS::is_error(errorStatus))
+                {
+                    throw std::runtime_error(errorText(errorStatus, "Cannot serialize OTIO timeline."));
+                }
+                const std::filesystem::path fileName = std::filesystem::u8path(path.get());
+                if (!fileName.parent_path().empty())
+                {
+                    std::filesystem::create_directories(fileName.parent_path());
+                }
+                auto fileIO = ftk::FileIO::create(fileName, ftk::FileMode::Write);
+                fileIO->write(json);
+                return true;
+            }
+            catch (const std::exception& e)
+            {
+                _setError(e.what());
+                if (error) *error = e.what();
+                return false;
+            }
+        }
+
+        void PlaylistModel::_setError(const std::string& value)
+        {
+            _p->lastError = value;
+            _changed();
+        }
+
+        void PlaylistModel::_changed()
+        {
+            _p->revision->setAlways(_p->revision->get() + 1);
+        }
+    }
+}

--- a/lib/djv/Models/PlaylistModel.h
+++ b/lib/djv/Models/PlaylistModel.h
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the DJV project.
+
+#pragma once
+
+#include <tlRender/Timeline/Timeline.h>
+
+#include <ftk/Core/Observable.h>
+#include <ftk/Core/Path.h>
+
+namespace djv
+{
+    namespace models
+    {
+        //! An item in an editable OTIO media playlist.
+        struct PlaylistItem
+        {
+            std::string name;
+            ftk::Path path;
+            OTIO_NS::RationalTime duration;
+            bool hasAudio = false;
+            bool missing = false;
+        };
+
+        //! Model for a flat OTIO media playlist.
+        //!
+        //! Editable playlists contain one video track of clips and an optional
+        //! aligned audio track containing clips or gaps. Other OTIO structures
+        //! remain available for inspection and Save As, but are read-only.
+        class PlaylistModel : public std::enable_shared_from_this<PlaylistModel>
+        {
+            FTK_NON_COPYABLE(PlaylistModel);
+
+        protected:
+            PlaylistModel();
+
+        public:
+            ~PlaylistModel();
+
+            static std::shared_ptr<PlaylistModel> create();
+
+            bool isAvailable() const;
+            bool isEditable() const;
+            bool isDirty() const;
+            bool isScratch() const;
+            const ftk::Path& getPath() const;
+            const std::string& getReadOnlyReason() const;
+            const std::string& getLastError() const;
+            const std::vector<PlaylistItem>& getItems() const;
+            const OTIO_NS::SerializableObject::Retainer<OTIO_NS::Timeline>& getTimeline() const;
+
+            std::shared_ptr<ftk::IObservable<int> > observeRevision() const;
+
+            void clear();
+            void setTimeline(
+                const OTIO_NS::SerializableObject::Retainer<OTIO_NS::Timeline>&,
+                const ftk::Path&,
+                bool dirty = false,
+                bool scratch = false);
+
+            bool createFromMedia(
+                const std::shared_ptr<ftk::Context>&,
+                const ftk::Path& readPath,
+                const ftk::Path& referencePath,
+                const ftk::Path& playlistPath,
+                const tl::Options&,
+                std::string* error = nullptr);
+
+            bool addMedia(
+                const std::shared_ptr<ftk::Context>&,
+                const ftk::Path& readPath,
+                const ftk::Path& referencePath,
+                const tl::Options&,
+                std::string* error = nullptr);
+
+            bool move(size_t from, size_t to, std::string* error = nullptr);
+            bool remove(size_t index, std::string* error = nullptr);
+            bool save(const ftk::Path&, std::string* error = nullptr);
+
+        private:
+            bool _analyze(std::string* error = nullptr);
+            bool _write(const ftk::Path&, std::string* error = nullptr);
+            void _setError(const std::string&);
+            void _changed();
+
+            FTK_PRIVATE();
+        };
+    }
+}

--- a/lib/djv/Models/ToolsModel.cpp
+++ b/lib/djv/Models/ToolsModel.cpp
@@ -29,6 +29,7 @@ namespace djv
             p.settings = settings;
 
             p.tools.push_back({ "Files", "Files", "A", true, ftk::Key::F1 });
+            p.tools.push_back({ "OTIO Playlist", "Files", "A1" });
             p.tools.push_back({ "Export", "Export", "B", true, ftk::Key::F2 });
             p.tools.push_back({ "View", "View", "C", true, ftk::Key::F3 });
             p.tools.push_back({ "Color", "ColorControls", "D", true, ftk::Key::F4 });

--- a/lib/djv/ModelsTest/FileFilterTest.cpp
+++ b/lib/djv/ModelsTest/FileFilterTest.cpp
@@ -280,6 +280,8 @@ namespace djv
                 const auto result = models::scanFolder(root, *filter, options);
                 require(models::FolderScanStatus::Completed == result.status,
                     "Folder scan did not complete");
+                require(0 != result.contentSignature,
+                    "Completed scan has no content signature");
                 require(3 == result.paths.size(), "Unexpected scan result count");
                 require(result.paths[0].get() < result.paths[1].get() &&
                     result.paths[1].get() < result.paths[2].get(),
@@ -317,6 +319,22 @@ namespace djv
 
                 const auto result2 = models::scanFolder(root, *filter, options);
                 require(result.paths == result2.paths, "Repeated scan order differs");
+                require(result.contentSignature == result2.contentSignature,
+                    "Repeated scan content signature differs");
+
+                // The collapsed sequence path stays the same, but changing a
+                // frame must still invalidate the folder signature.
+                {
+                    std::ofstream stream(
+                        root / "shot010" / "plate.0002.exr",
+                        std::ios::binary | std::ios::app);
+                    stream << "changed";
+                }
+                const auto changed = models::scanFolder(root, *filter, options);
+                require(result.paths == changed.paths,
+                    "Sequence metadata change unexpectedly changed scan paths");
+                require(result.contentSignature != changed.contentSignature,
+                    "Sequence frame metadata change was not detected");
             }
 
             void cancellationAndLimits()
@@ -332,6 +350,8 @@ namespace djv
                 require(models::FolderScanStatus::Cancelled == cancelled.status,
                     "Pre-cancelled scan did not cancel");
                 require(cancelled.paths.empty(), "Cancelled scan returned paths");
+                require(0 == cancelled.contentSignature,
+                    "Cancelled scan returned a content signature");
 
                 models::FolderScanOptions options;
                 options.maxCandidates = 0;
@@ -339,6 +359,8 @@ namespace djv
                 require(models::FolderScanStatus::CandidateLimitReached == limited.status,
                     "Candidate limit was not enforced");
                 require(limited.paths.empty(), "Candidate-limited scan exposed partial results");
+                require(0 == limited.contentSignature,
+                    "Candidate-limited scan returned a content signature");
                 require(!limited.warnings.empty() &&
                     models::FolderScanWarningCode::CandidateLimitReached ==
                         limited.warnings.back().code,
@@ -385,6 +407,8 @@ namespace djv
                     "Result limit was not enforced");
                 require(resultLimited.paths.empty(),
                     "Result-limited scan exposed partial results");
+                require(0 == resultLimited.contentSignature,
+                    "Result-limited scan returned a content signature");
             }
 
             void warningsAndInvalidRoot()

--- a/lib/djv/ModelsTest/FileFilterTest.cpp
+++ b/lib/djv/ModelsTest/FileFilterTest.cpp
@@ -1,0 +1,502 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the DJV project.
+
+#include <djv/ModelsTest/FileFilterTest.h>
+
+#include <djv/Models/FileFilter.h>
+#include <djv/Models/FolderScanner.h>
+
+#include <chrono>
+#include <atomic>
+#include <cstddef>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+#if defined(_WIN32)
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <Windows.h>
+#include <winioctl.h>
+#endif
+namespace djv
+{
+    namespace models_tests
+    {
+        namespace
+        {
+            void require(bool value, const std::string& message)
+            {
+                if (!value)
+                {
+                    throw std::runtime_error(message);
+                }
+            }
+
+            std::shared_ptr<const models::CompiledFileFilter> compile(
+                const std::string& expression)
+            {
+                const auto result = models::compileFileFilter(expression);
+                require(static_cast<bool>(result), "Filter failed to compile: " + expression);
+                return result.filter;
+            }
+
+            void touch(const std::filesystem::path& path)
+            {
+                std::filesystem::create_directories(path.parent_path());
+                std::ofstream stream(path, std::ios::binary);
+                stream << "x";
+            }
+
+            class TmpDir
+            {
+            public:
+                TmpDir()
+                {
+                    const auto id = std::chrono::steady_clock::now().time_since_epoch().count();
+                    _path = std::filesystem::temp_directory_path() /
+                        ("djv-file-filter-test-" + std::to_string(id));
+                    std::filesystem::create_directories(_path);
+                }
+
+                ~TmpDir()
+                {
+                    std::error_code error;
+                    std::filesystem::remove_all(_path, error);
+                }
+
+                const std::filesystem::path& getPath() const { return _path; }
+
+            private:
+                std::filesystem::path _path;
+            };
+
+#if defined(_WIN32)
+            bool createDirectoryJunction(
+                const std::filesystem::path& link,
+                const std::filesystem::path& target)
+            {
+                struct MountPointReparseData
+                {
+                    DWORD tag;
+                    WORD dataLength;
+                    WORD reserved;
+                    WORD substituteOffset;
+                    WORD substituteLength;
+                    WORD printOffset;
+                    WORD printLength;
+                    wchar_t pathBuffer[1];
+                };
+                if (!CreateDirectoryW(link.c_str(), nullptr))
+                {
+                    return false;
+                }
+                const HANDLE handle = CreateFileW(
+                    link.c_str(), GENERIC_WRITE, 0, nullptr, OPEN_EXISTING,
+                    FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS,
+                    nullptr);
+                if (INVALID_HANDLE_VALUE == handle)
+                {
+                    RemoveDirectoryW(link.c_str());
+                    return false;
+                }
+                const std::wstring printName =
+                    std::filesystem::absolute(target).lexically_normal().wstring();
+                const std::wstring substituteName = L"\\??\\" + printName;
+                const size_t substituteBytes = substituteName.size() * sizeof(wchar_t);
+                const size_t printBytes = printName.size() * sizeof(wchar_t);
+                std::vector<unsigned char> buffer(MAXIMUM_REPARSE_DATA_BUFFER_SIZE, 0);
+                auto* data = reinterpret_cast<MountPointReparseData*>(buffer.data());
+                data->tag = IO_REPARSE_TAG_MOUNT_POINT;
+                data->substituteLength = static_cast<WORD>(substituteBytes);
+                data->printOffset = static_cast<WORD>(substituteBytes + sizeof(wchar_t));
+                data->printLength = static_cast<WORD>(printBytes);
+                std::memcpy(data->pathBuffer, substituteName.c_str(), substituteBytes);
+                std::memcpy(
+                    reinterpret_cast<unsigned char*>(data->pathBuffer) +
+                        substituteBytes + sizeof(wchar_t),
+                    printName.c_str(), printBytes);
+                const size_t inputLength = offsetof(MountPointReparseData, pathBuffer) +
+                    substituteBytes + sizeof(wchar_t) + printBytes + sizeof(wchar_t);
+                data->dataLength = static_cast<WORD>(inputLength - 8);
+                DWORD returned = 0;
+                const BOOL ok = DeviceIoControl(
+                    handle, FSCTL_SET_REPARSE_POINT, data,
+                    static_cast<DWORD>(inputLength), nullptr, 0, &returned, nullptr);
+                CloseHandle(handle);
+                if (!ok)
+                {
+                    RemoveDirectoryW(link.c_str());
+                }
+                return !!ok;
+            }
+
+            void concurrentReparseReplacement()
+            {
+                TmpDir scan;
+                TmpDir outside;
+                const auto victim = scan.getPath() / "victim";
+                const auto held = scan.getPath() / "held";
+                touch(victim / "inside.exr");
+                touch(outside.getPath() / "outside.exr");
+                if (!createDirectoryJunction(scan.getPath() / "probe", outside.getPath()))
+                {
+                    // Junction creation may be denied by machine policy. The
+                    // static reparse test remains covered elsewhere.
+                    return;
+                }
+                RemoveDirectoryW((scan.getPath() / "probe").c_str());
+
+                std::atomic_bool stop(false);
+                std::thread replacer([&]
+                {
+                    while (!stop.load(std::memory_order_acquire))
+                    {
+                        std::error_code error;
+                        std::filesystem::rename(victim, held, error);
+                        if (!error)
+                        {
+                            if (createDirectoryJunction(victim, outside.getPath()))
+                            {
+                                std::this_thread::yield();
+                                RemoveDirectoryW(victim.c_str());
+                            }
+                            error.clear();
+                            std::filesystem::rename(held, victim, error);
+                        }
+                        std::this_thread::yield();
+                    }
+                });
+
+                const auto filter = compile("");
+                for (size_t i = 0; i < 100; ++i)
+                {
+                    const auto result = models::scanFolder(scan.getPath(), *filter);
+                    for (const auto& path : result.paths)
+                    {
+                        require(
+                            std::string::npos == path.get().find("outside.exr"),
+                            "Concurrent junction replacement escaped the scan root");
+                    }
+                }
+                stop.store(true, std::memory_order_release);
+                replacer.join();
+                RemoveDirectoryW(victim.c_str());
+                std::error_code error;
+                if (std::filesystem::exists(held, error))
+                {
+                    std::filesystem::rename(held, victim, error);
+                }
+            }
+#endif
+
+            void grammar()
+            {
+                const auto filter = compile(
+                    "ext:^(exr|mov)$ dir:(shot010|shot020) -name:(proxy|thumb)");
+                require(filter->matches(ftk::Path("/show/shot010/beauty.0001.exr")),
+                    "Expected EXR to match");
+                require(!filter->matches(ftk::Path("/show/shot010/beauty.proxy.0001.exr")),
+                    "Excluded proxy matched");
+                require(!filter->matches(ftk::Path("/show/shot030/beauty.0001.exr")),
+                    "Wrong directory matched");
+                require(!filter->matches(ftk::Path("/show/shot010/beauty.wav")),
+                    "Wrong extension matched");
+
+                const auto aliases = compile("file:beauty extension:^exr$ folder:shot010");
+                require(aliases->matches(ftk::Path("/show/shot010/beauty.0001.EXR")),
+                    "Aliases or ASCII case-insensitive extension failed");
+
+                const std::string unicodeName =
+                    "r\xC3\xA9sum\xC3\xA9.0001.exr";
+                require(compile("name:r\xC3\xA9sum\xC3\xA9")->matches(
+                    ftk::Path("/show/" + unicodeName)),
+                    "UTF-8 literal filter failed");
+            }
+
+            void invalidGrammar()
+            {
+                struct Case
+                {
+                    std::string expression;
+                    models::FileFilterErrorCode code;
+                };
+                const std::vector<Case> cases =
+                {
+                    { "name:", models::FileFilterErrorCode::EmptyPattern },
+                    { "-", models::FileFilterErrorCode::EmptyPattern },
+                    { "mime:exr", models::FileFilterErrorCode::UnknownTarget },
+                    { "name:[", models::FileFilterErrorCode::InvalidRegularExpression },
+                    { "name:(a+)+$", models::FileFilterErrorCode::UnsafeRegularExpression },
+                    { "name:a*a*a*b", models::FileFilterErrorCode::UnsafeRegularExpression },
+                    { "name:(a)\\1", models::FileFilterErrorCode::UnsafeRegularExpression },
+                    { std::string(models::CompiledFileFilter::maxExpressionLength + 1, 'a'),
+                        models::FileFilterErrorCode::ExpressionTooLong },
+                    { "name:" + std::string(models::CompiledFileFilter::maxPatternLength + 1, 'a'),
+                        models::FileFilterErrorCode::PatternTooLong }
+                };
+                for (const auto& test : cases)
+                {
+                    const auto result = models::compileFileFilter(test.expression);
+                    require(!result, "Invalid expression compiled: " + test.expression);
+                    require(result.error.has_value(), "Missing compile error");
+                    require(test.code == result.error->code, "Wrong compile error code");
+                }
+
+                std::string tooManyTerms;
+                for (size_t i = 0; i < models::CompiledFileFilter::maxTermCount + 1; ++i)
+                {
+                    tooManyTerms += (i ? " a" : "a");
+                }
+                const auto result = models::compileFileFilter(tooManyTerms);
+                require(!result, "Too many terms compiled");
+                require(result.error &&
+                    models::FileFilterErrorCode::TooManyTerms == result.error->code,
+                    "Wrong too-many-terms error");
+            }
+
+            void scanner()
+            {
+                TmpDir tmp;
+                const auto root = tmp.getPath();
+                touch(root / "shot020" / "plate.0002.exr");
+                touch(root / "shot010" / "plate.0002.exr");
+                touch(root / "shot010" / "plate.0001.exr");
+                touch(root / "shot010" / "plate.0003.exr");
+                touch(root / "shot010" / "plate.mov");
+                touch(root / "cache" / "plate.0001.exr");
+                touch(root / "shot010" / "plate.0004.txt");
+
+                models::FolderScanOptions options;
+                options.fileExtensions = { ".exr", "mov" };
+                options.collapseSequences = true;
+                options.sequenceExtensions = { "EXR" };
+                const auto filter = compile("-dir:^cache$");
+                const auto result = models::scanFolder(root, *filter, options);
+                require(models::FolderScanStatus::Completed == result.status,
+                    "Folder scan did not complete");
+                require(3 == result.paths.size(), "Unexpected scan result count");
+                require(result.paths[0].get() < result.paths[1].get() &&
+                    result.paths[1].get() < result.paths[2].get(),
+                    "Folder scan result is not sorted");
+
+                size_t sequenceCount = 0;
+                for (const auto& path : result.paths)
+                {
+                    if (path.isSeq())
+                    {
+                        ++sequenceCount;
+                        require(path.getFrames().has_value(), "Sequence has no frame range");
+                        require(1 == path.getFrames()->min() && 3 == path.getFrames()->max(),
+                            "Wrong sequence frame range");
+                    }
+                    require(std::string::npos == path.get().find("cache"),
+                        "Excluded directory was scanned");
+                    require(".txt" != path.getExt(), "Extension allowlist failed");
+                }
+                require(1 == sequenceCount, "EXR sequence was not collapsed exactly once");
+
+                // A path expression that matches a directory itself is not
+                // necessarily inherited by its children. It must never be used
+                // for unsafe subtree pruning.
+                const auto pathAnchorFilter = compile("-path:cache$");
+                const auto pathAnchorResult = models::scanFolder(
+                    root, *pathAnchorFilter, options);
+                bool cacheChildFound = false;
+                for (const auto& path : pathAnchorResult.paths)
+                {
+                    cacheChildFound |= std::string::npos != path.get().find("cache");
+                }
+                require(cacheChildFound,
+                    "Path-only exclusion incorrectly pruned a directory subtree");
+
+                const auto result2 = models::scanFolder(root, *filter, options);
+                require(result.paths == result2.paths, "Repeated scan order differs");
+            }
+
+            void cancellationAndLimits()
+            {
+                TmpDir tmp;
+                touch(tmp.getPath() / "a.exr");
+
+                const auto filter = compile("");
+                models::FolderScanCancellationSource cancellation;
+                cancellation.cancel();
+                const auto cancelled = models::scanFolder(
+                    tmp.getPath(), *filter, {}, cancellation.getToken());
+                require(models::FolderScanStatus::Cancelled == cancelled.status,
+                    "Pre-cancelled scan did not cancel");
+                require(cancelled.paths.empty(), "Cancelled scan returned paths");
+
+                models::FolderScanOptions options;
+                options.maxCandidates = 0;
+                const auto limited = models::scanFolder(tmp.getPath(), *filter, options);
+                require(models::FolderScanStatus::CandidateLimitReached == limited.status,
+                    "Candidate limit was not enforced");
+                require(limited.paths.empty(), "Candidate-limited scan exposed partial results");
+                require(!limited.warnings.empty() &&
+                    models::FolderScanWarningCode::CandidateLimitReached ==
+                        limited.warnings.back().code,
+                    "Candidate limit warning missing");
+
+                std::filesystem::create_directories(tmp.getPath() / "empty-a");
+                std::filesystem::create_directories(tmp.getPath() / "empty-b");
+                options.maxCandidates = 100;
+                options.maxDirectories = 2;
+                const auto traversalLimited = models::scanFolder(
+                    tmp.getPath(), *filter, options);
+                require(models::FolderScanStatus::TraversalLimitReached ==
+                    traversalLimited.status,
+                    "Global directory traversal limit was not enforced");
+                require(traversalLimited.paths.empty(),
+                    "Traversal-limited scan exposed partial results");
+                require(!traversalLimited.warnings.empty() &&
+                    models::FolderScanWarningCode::TraversalLimitReached ==
+                        traversalLimited.warnings.back().code,
+                    "Traversal limit warning missing");
+
+                options.maxDirectories = 100000;
+                options.maxEntries = 2;
+                const auto entryLimited = models::scanFolder(
+                    tmp.getPath(), *filter, options);
+                require(models::FolderScanStatus::TraversalLimitReached ==
+                    entryLimited.status,
+                    "Global entry traversal limit was not enforced");
+                require(2 == entryLimited.visitedEntries,
+                    "Global entry traversal accounting is incorrect");
+                require(entryLimited.paths.empty(),
+                    "Entry-limited scan exposed partial results");
+
+                touch(tmp.getPath() / "b.exr");
+                touch(tmp.getPath() / "c.exr");
+                options.maxCandidates = 100;
+                options.maxDirectories = 100000;
+                options.maxEntries = 1000000;
+                options.maxResults = 2;
+                const auto resultLimited = models::scanFolder(
+                    tmp.getPath(), *filter, options);
+                require(models::FolderScanStatus::ResultLimitReached ==
+                    resultLimited.status,
+                    "Result limit was not enforced");
+                require(resultLimited.paths.empty(),
+                    "Result-limited scan exposed partial results");
+            }
+
+            void warningsAndInvalidRoot()
+            {
+                TmpDir tmp;
+                touch(tmp.getPath() / "real" / "a.exr");
+                const auto filter = compile("");
+
+                const auto missing = models::scanFolder(
+                    tmp.getPath() / "missing", *filter);
+                require(models::FolderScanStatus::InvalidRoot == missing.status,
+                    "Missing root was not rejected");
+                require(!missing.warnings.empty(), "Missing root warning absent");
+
+                std::error_code error;
+                std::filesystem::create_directory_symlink(
+                    tmp.getPath() / "real",
+                    tmp.getPath() / "linked",
+                    error);
+                if (!error)
+                {
+                    const auto linked = models::scanFolder(tmp.getPath(), *filter);
+                    bool foundLinkWarning = false;
+                    for (const auto& warning : linked.warnings)
+                    {
+                        foundLinkWarning |=
+                            models::FolderScanWarningCode::LinkSkipped == warning.code;
+                    }
+                    require(foundLinkWarning, "Skipped link warning absent");
+                    require(1 == linked.paths.size(), "Directory link was followed by default");
+                }
+
+#if !defined(_WIN32)
+                const auto deniedPath = tmp.getPath() / "denied";
+                touch(deniedPath / "private.exr");
+                std::filesystem::permissions(
+                    deniedPath,
+                    std::filesystem::perms::none,
+                    std::filesystem::perm_options::replace,
+                    error);
+                if (!error)
+                {
+                    std::error_code probeError;
+                    std::filesystem::directory_iterator probe(deniedPath, probeError);
+                    (void)probe;
+                    if (probeError == std::errc::permission_denied)
+                    {
+                        const auto denied = models::scanFolder(tmp.getPath(), *filter);
+                        bool foundPermissionWarning = false;
+                        for (const auto& warning : denied.warnings)
+                        {
+                            foundPermissionWarning |=
+                                models::FolderScanWarningCode::PermissionDenied == warning.code;
+                        }
+                        require(foundPermissionWarning, "Permission warning absent");
+                    }
+                    std::filesystem::permissions(
+                        deniedPath,
+                        std::filesystem::perms::owner_all,
+                        std::filesystem::perm_options::replace,
+                        error);
+                }
+#endif
+            }
+
+            void benchmark()
+            {
+                const auto filter = compile("ext:^exr$ name:^plate\\.[0-9]{4}\\.exr$");
+                const auto start = std::chrono::steady_clock::now();
+                size_t matches = 0;
+                for (size_t i = 0; i < 10000; ++i)
+                {
+                    const std::string number = std::to_string(10000 + i).substr(1);
+                    matches += filter->matches(ftk::Path(
+                        "/show/shot010/plate." + number + ".exr")) ? 1 : 0;
+                }
+                const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                    std::chrono::steady_clock::now() - start);
+                require(10000 == matches, "10k synthetic path benchmark mismatched");
+                require(elapsed < std::chrono::seconds(5),
+                    "10k synthetic path benchmark exceeded five seconds");
+                std::cout << "10k-path filter benchmark: " << elapsed.count() << " ms\n";
+            }
+        }
+
+        void FileFilterTest::run()
+        {
+            grammar();
+            invalidGrammar();
+            scanner();
+            cancellationAndLimits();
+            warningsAndInvalidRoot();
+#if defined(_WIN32)
+            concurrentReparseReplacement();
+#endif
+            benchmark();
+        }
+    }
+}
+#if defined(DJV_FILE_FILTER_TEST_STANDALONE)
+int main()
+{
+    try
+    {
+        djv::models_tests::FileFilterTest::run();
+        std::cout << "FileFilterTest: PASS\n";
+        return 0;
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << "FileFilterTest: FAIL: " << e.what() << '\n';
+        return 1;
+    }
+}
+#endif

--- a/lib/djv/ModelsTest/FileFilterTest.h
+++ b/lib/djv/ModelsTest/FileFilterTest.h
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the DJV project.
+
+#pragma once
+
+namespace djv
+{
+    namespace models_tests
+    {
+        //! Focused tests for compiled filtering and folder scanning.
+        class FileFilterTest
+        {
+        public:
+            static void run();
+        };
+    }
+}

--- a/lib/djv/UI/CMakeLists.txt
+++ b/lib/djv/UI/CMakeLists.txt
@@ -3,6 +3,7 @@ set(HEADERS
     AudioPopup.h
     ColorWidgets.h
     FileThumbnail.h
+    OpenFolderFilterDialog.h
     SeparateAudioDialog.h
     SettingsWidgets.h
     SetupDialog.h
@@ -17,6 +18,7 @@ set(SOURCE
     AudioPopup.cpp
     ColorWidgets.cpp
     FileThumbnail.cpp
+    OpenFolderFilterDialog.cpp
     SeparateAudioDialog.cpp
     SettingsWidgets.cpp
     SetupDialog.cpp

--- a/lib/djv/UI/OpenFolderFilterDialog.cpp
+++ b/lib/djv/UI/OpenFolderFilterDialog.cpp
@@ -1,0 +1,272 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the DJV project.
+
+#include <djv/UI/OpenFolderFilterDialog.h>
+
+#include <ftk/UI/ComboBox.h>
+#include <ftk/UI/Divider.h>
+#include <ftk/UI/FileBrowser.h>
+#include <ftk/UI/FileEdit.h>
+#include <ftk/UI/FormLayout.h>
+#include <ftk/UI/Label.h>
+#include <ftk/UI/LineEdit.h>
+#include <ftk/UI/PushButton.h>
+#include <ftk/UI/RowLayout.h>
+#include <ftk/UI/Spacer.h>
+
+namespace djv
+{
+    namespace ui
+    {
+        struct OpenFolderFilterWidget::Private
+        {
+            std::vector<std::string> recentFilters;
+            std::vector<std::string> filterPresets;
+
+            std::shared_ptr<ftk::FileEdit> folderEdit;
+            std::shared_ptr<ftk::LineEdit> filterEdit;
+            std::shared_ptr<ftk::ComboBox> recentComboBox;
+            std::shared_ptr<ftk::ComboBox> presetComboBox;
+            std::shared_ptr<ftk::PushButton> okButton;
+            std::shared_ptr<ftk::PushButton> cancelButton;
+            std::shared_ptr<ftk::VerticalLayout> layout;
+
+            std::function<void(const ftk::Path&, const std::string&)> callback;
+            std::function<void(void)> cancelCallback;
+        };
+
+        void OpenFolderFilterWidget::_init(
+            const std::shared_ptr<ftk::Context>& context,
+            const std::shared_ptr<IWidget>& parent)
+        {
+            IMouseWidget::_init(
+                context,
+                "djv::ui::OpenFolderFilterWidget",
+                parent);
+            FTK_P();
+
+            _setMouseHoverEnabled(true);
+            _setMousePressEnabled(true);
+
+            p.folderEdit = ftk::FileEdit::create(context, ftk::FileBrowserMode::Dir);
+            p.folderEdit->setTooltip("Folder to open recursively.");
+
+            p.filterEdit = ftk::LineEdit::create(context);
+            p.filterEdit->setHStretch(ftk::Stretch::Expanding);
+            p.filterEdit->setFormat(std::string(40, '#'));
+            p.filterEdit->setTooltip(
+                "Filter loaded files with case-insensitive regex tokens.\n"
+                "\n"
+                "Examples:\n"
+                "* plate render\n"
+                "* name:exr$\n"
+                "* dir:(shot010|shot020)\n"
+                "* -dir:(cache|tmp)\n"
+                "* -name:proxy");
+
+            p.recentComboBox = ftk::ComboBox::create(context);
+            p.recentComboBox->setHStretch(ftk::Stretch::Expanding);
+            p.recentComboBox->setTooltip("Recent folder filters.");
+
+            p.presetComboBox = ftk::ComboBox::create(context);
+            p.presetComboBox->setHStretch(ftk::Stretch::Expanding);
+            p.presetComboBox->setTooltip("Preset folder filters.");
+
+            p.okButton = ftk::PushButton::create(context, "OK");
+            p.cancelButton = ftk::PushButton::create(context, "Cancel");
+
+            p.layout = ftk::VerticalLayout::create(context, shared_from_this());
+            p.layout->setSpacingRole(ftk::SizeRole::None);
+            auto label = ftk::Label::create(context, "Open Folder With Filter", p.layout);
+            label->setFontSize(14);
+            label->setMarginRole(ftk::SizeRole::Margin);
+            label->setBackgroundRole(ftk::ColorRole::Button);
+            auto formLayout = ftk::FormLayout::create(context, p.layout);
+            formLayout->setVStretch(ftk::Stretch::Expanding);
+            formLayout->setMarginRole(ftk::SizeRole::Margin);
+            formLayout->setSpacingRole(ftk::SizeRole::SpacingSmall);
+            formLayout->addRow("Folder:", p.folderEdit);
+            formLayout->addRow("Filter:", p.filterEdit);
+            formLayout->addRow("Recent:", p.recentComboBox);
+            formLayout->addRow("Preset:", p.presetComboBox);
+            ftk::Divider::create(context, ftk::Orientation::Vertical, p.layout);
+            auto hLayout = ftk::HorizontalLayout::create(context, p.layout);
+            hLayout->setMarginRole(ftk::SizeRole::MarginSmall);
+            hLayout->setSpacingRole(ftk::SizeRole::SpacingSmall);
+            auto spacer = ftk::Spacer::create(context, ftk::Orientation::Horizontal, hLayout);
+            spacer->setSpacingRole(ftk::SizeRole::None);
+            spacer->setHStretch(ftk::Stretch::Expanding);
+            p.okButton->setParent(hLayout);
+            p.cancelButton->setParent(hLayout);
+
+            p.recentComboBox->setIndexCallback(
+                [this](int value)
+                {
+                    if (value >= 0 && value < static_cast<int>(_p->recentFilters.size()))
+                    {
+                        _p->filterEdit->setText(_p->recentFilters[value]);
+                    }
+                });
+
+            p.presetComboBox->setIndexCallback(
+                [this](int value)
+                {
+                    if (value >= 0 && value < static_cast<int>(_p->filterPresets.size()))
+                    {
+                        _p->filterEdit->setText(_p->filterPresets[value]);
+                    }
+                });
+
+            p.okButton->setClickedCallback(
+                [this]
+                {
+                    if (_p->callback)
+                    {
+                        _p->callback(
+                            ftk::Path(_p->folderEdit->getPath()),
+                            _p->filterEdit->getText());
+                    }
+                });
+
+            p.cancelButton->setClickedCallback(
+                [this]
+                {
+                    if (_p->cancelCallback)
+                    {
+                        _p->cancelCallback();
+                    }
+                });
+
+            _recentFiltersUpdate();
+            _filterPresetsUpdate();
+        }
+
+        OpenFolderFilterWidget::OpenFolderFilterWidget() :
+            _p(new Private)
+        {}
+
+        OpenFolderFilterWidget::~OpenFolderFilterWidget()
+        {}
+
+        std::shared_ptr<OpenFolderFilterWidget> OpenFolderFilterWidget::create(
+            const std::shared_ptr<ftk::Context>& context,
+            const std::shared_ptr<IWidget>& parent)
+        {
+            auto out = std::shared_ptr<OpenFolderFilterWidget>(new OpenFolderFilterWidget);
+            out->_init(context, parent);
+            return out;
+        }
+
+        void OpenFolderFilterWidget::setRecentFilters(const std::vector<std::string>& value)
+        {
+            _p->recentFilters = value;
+            _recentFiltersUpdate();
+        }
+
+        void OpenFolderFilterWidget::setFilterPresets(const std::vector<std::string>& value)
+        {
+            _p->filterPresets = value;
+            _filterPresetsUpdate();
+        }
+
+        void OpenFolderFilterWidget::setCallback(const std::function<void(
+            const ftk::Path&,
+            const std::string&)>& value)
+        {
+            _p->callback = value;
+        }
+
+        void OpenFolderFilterWidget::setCancelCallback(const std::function<void(void)>& value)
+        {
+            _p->cancelCallback = value;
+        }
+
+        ftk::Size2I OpenFolderFilterWidget::getSizeHint() const
+        {
+            ftk::Size2I out = _p->layout->getSizeHint();
+            out.w *= 2;
+            return out;
+        }
+
+        void OpenFolderFilterWidget::setGeometry(const ftk::Box2I& value)
+        {
+            IMouseWidget::setGeometry(value);
+            _p->layout->setGeometry(value);
+        }
+
+        void OpenFolderFilterWidget::_recentFiltersUpdate()
+        {
+            FTK_P();
+            p.recentComboBox->setItems(p.recentFilters);
+            p.recentComboBox->setEnabled(!p.recentFilters.empty());
+            p.recentComboBox->setCurrentIndex(-1);
+        }
+
+        void OpenFolderFilterWidget::_filterPresetsUpdate()
+        {
+            FTK_P();
+            p.presetComboBox->setItems(p.filterPresets);
+            p.presetComboBox->setEnabled(!p.filterPresets.empty());
+            p.presetComboBox->setCurrentIndex(-1);
+        }
+
+        struct OpenFolderFilterDialog::Private
+        {
+            std::shared_ptr<OpenFolderFilterWidget> widget;
+        };
+
+        void OpenFolderFilterDialog::_init(
+            const std::shared_ptr<ftk::Context>& context,
+            const std::shared_ptr<IWidget>& parent)
+        {
+            IDialog::_init(
+                context,
+                "djv::ui::OpenFolderFilterDialog",
+                parent);
+            FTK_P();
+
+            p.widget = OpenFolderFilterWidget::create(
+                context,
+                shared_from_this());
+
+            p.widget->setCancelCallback(
+                [this]
+                {
+                    close();
+                });
+        }
+
+        OpenFolderFilterDialog::OpenFolderFilterDialog() :
+            _p(new Private)
+        {}
+
+        OpenFolderFilterDialog::~OpenFolderFilterDialog()
+        {}
+
+        std::shared_ptr<OpenFolderFilterDialog> OpenFolderFilterDialog::create(
+            const std::shared_ptr<ftk::Context>& context,
+            const std::shared_ptr<IWidget>& parent)
+        {
+            auto out = std::shared_ptr<OpenFolderFilterDialog>(new OpenFolderFilterDialog);
+            out->_init(context, parent);
+            return out;
+        }
+
+        void OpenFolderFilterDialog::setRecentFilters(const std::vector<std::string>& value)
+        {
+            _p->widget->setRecentFilters(value);
+        }
+
+        void OpenFolderFilterDialog::setFilterPresets(const std::vector<std::string>& value)
+        {
+            _p->widget->setFilterPresets(value);
+        }
+
+        void OpenFolderFilterDialog::setCallback(const std::function<void(
+            const ftk::Path&,
+            const std::string&)>& value)
+        {
+            _p->widget->setCallback(value);
+        }
+    }
+}

--- a/lib/djv/UI/OpenFolderFilterDialog.cpp
+++ b/lib/djv/UI/OpenFolderFilterDialog.cpp
@@ -27,6 +27,7 @@ namespace djv
             std::shared_ptr<ftk::LineEdit> filterEdit;
             std::shared_ptr<ftk::ComboBox> recentComboBox;
             std::shared_ptr<ftk::ComboBox> presetComboBox;
+            std::shared_ptr<ftk::Label> statusLabel;
             std::shared_ptr<ftk::PushButton> okButton;
             std::shared_ptr<ftk::PushButton> cancelButton;
             std::shared_ptr<ftk::VerticalLayout> layout;
@@ -89,6 +90,8 @@ namespace djv
             formLayout->addRow("Filter:", p.filterEdit);
             formLayout->addRow("Recent:", p.recentComboBox);
             formLayout->addRow("Preset:", p.presetComboBox);
+            p.statusLabel = ftk::Label::create(context, std::string(), p.layout);
+            p.statusLabel->setMarginRole(ftk::SizeRole::MarginSmall);
             ftk::Divider::create(context, ftk::Orientation::Vertical, p.layout);
             auto hLayout = ftk::HorizontalLayout::create(context, p.layout);
             hLayout->setMarginRole(ftk::SizeRole::MarginSmall);
@@ -181,6 +184,29 @@ namespace djv
             _p->cancelCallback = value;
         }
 
+        void OpenFolderFilterWidget::setBusy(
+            bool value,
+            const std::string& status)
+        {
+            FTK_P();
+            p.folderEdit->setEnabled(!value);
+            p.filterEdit->setEnabled(!value);
+            p.recentComboBox->setEnabled(
+                !value && !p.recentFilters.empty());
+            p.presetComboBox->setEnabled(
+                !value && !p.filterPresets.empty());
+            p.okButton->setEnabled(!value);
+            if (!status.empty())
+            {
+                p.statusLabel->setText(status);
+            }
+        }
+
+        void OpenFolderFilterWidget::setStatus(const std::string& value)
+        {
+            _p->statusLabel->setText(value);
+        }
+
         ftk::Size2I OpenFolderFilterWidget::getSizeHint() const
         {
             ftk::Size2I out = _p->layout->getSizeHint();
@@ -267,6 +293,18 @@ namespace djv
             const std::string&)>& value)
         {
             _p->widget->setCallback(value);
+        }
+
+        void OpenFolderFilterDialog::setBusy(
+            bool value,
+            const std::string& status)
+        {
+            _p->widget->setBusy(value, status);
+        }
+
+        void OpenFolderFilterDialog::setStatus(const std::string& value)
+        {
+            _p->widget->setStatus(value);
         }
     }
 }

--- a/lib/djv/UI/OpenFolderFilterDialog.h
+++ b/lib/djv/UI/OpenFolderFilterDialog.h
@@ -42,6 +42,13 @@ namespace djv
 
             void setCancelCallback(const std::function<void(void)>&);
 
+            //! Keep cancellation available while an asynchronous scan owns
+            //! the form inputs.
+            void setBusy(bool, const std::string& status = std::string());
+
+            //! Set a validation or scan status message.
+            void setStatus(const std::string&);
+
             ftk::Size2I getSizeHint() const override;
             void setGeometry(const ftk::Box2I&) override;
 
@@ -78,6 +85,9 @@ namespace djv
             void setCallback(const std::function<void(
                 const ftk::Path&,
                 const std::string&)>&);
+
+            void setBusy(bool, const std::string& status = std::string());
+            void setStatus(const std::string&);
 
         private:
             FTK_PRIVATE();

--- a/lib/djv/UI/OpenFolderFilterDialog.h
+++ b/lib/djv/UI/OpenFolderFilterDialog.h
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the DJV project.
+
+#pragma once
+
+#include <ftk/UI/IDialog.h>
+#include <ftk/Core/Path.h>
+
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace djv
+{
+    namespace ui
+    {
+        //! Open folder with filter widget.
+        class OpenFolderFilterWidget : public ftk::IMouseWidget
+        {
+            FTK_NON_COPYABLE(OpenFolderFilterWidget);
+
+        protected:
+            void _init(
+                const std::shared_ptr<ftk::Context>&,
+                const std::shared_ptr<IWidget>& parent);
+
+            OpenFolderFilterWidget();
+
+        public:
+            virtual ~OpenFolderFilterWidget();
+
+            static std::shared_ptr<OpenFolderFilterWidget> create(
+                const std::shared_ptr<ftk::Context>&,
+                const std::shared_ptr<IWidget>& parent = nullptr);
+
+            void setRecentFilters(const std::vector<std::string>&);
+            void setFilterPresets(const std::vector<std::string>&);
+
+            void setCallback(const std::function<void(
+                const ftk::Path&,
+                const std::string&)>&);
+
+            void setCancelCallback(const std::function<void(void)>&);
+
+            ftk::Size2I getSizeHint() const override;
+            void setGeometry(const ftk::Box2I&) override;
+
+        private:
+            void _recentFiltersUpdate();
+            void _filterPresetsUpdate();
+
+            FTK_PRIVATE();
+        };
+
+        //! Open folder with filter dialog.
+        class OpenFolderFilterDialog : public ftk::IDialog
+        {
+            FTK_NON_COPYABLE(OpenFolderFilterDialog);
+
+        protected:
+            void _init(
+                const std::shared_ptr<ftk::Context>&,
+                const std::shared_ptr<IWidget>& parent);
+
+            OpenFolderFilterDialog();
+
+        public:
+            virtual ~OpenFolderFilterDialog();
+
+            static std::shared_ptr<OpenFolderFilterDialog> create(
+                const std::shared_ptr<ftk::Context>&,
+                const std::shared_ptr<IWidget>& parent = nullptr);
+
+            void setRecentFilters(const std::vector<std::string>&);
+            void setFilterPresets(const std::vector<std::string>&);
+
+            //! Set the callback.
+            void setCallback(const std::function<void(
+                const ftk::Path&,
+                const std::string&)>&);
+
+        private:
+            FTK_PRIVATE();
+        };
+    }
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,3 +14,40 @@ set_target_properties(djvPlaylistModelTest PROPERTIES FOLDER tests)
 add_test(
     NAME djvPlaylistModelTest
     COMMAND $<TARGET_FILE:djvPlaylistModelTest>)
+
+add_executable(
+    djvFileFilterTest
+    ../lib/djv/ModelsTest/FileFilterTest.cpp
+    ../lib/djv/Models/FileFilter.cpp
+    ../lib/djv/Models/FolderScanner.cpp)
+target_compile_definitions(
+    djvFileFilterTest
+    PRIVATE DJV_FILE_FILTER_TEST_STANDALONE FTK_ASSERT)
+target_include_directories(
+    djvFileFilterTest
+    PRIVATE ${PROJECT_SOURCE_DIR}/lib)
+target_link_libraries(djvFileFilterTest ftkCore)
+set_target_properties(djvFileFilterTest PROPERTIES FOLDER tests)
+add_test(NAME djv-file-filter COMMAND djvFileFilterTest)
+set_tests_properties(
+    djv-file-filter
+    PROPERTIES LABELS "unit;models;filesystem" TIMEOUT 30)
+
+add_executable(
+    djvFolderScanServiceTest
+    ../lib/djv/AppTest/FolderScanServiceTest.cpp
+    ../lib/djv/App/FolderScanService.cpp
+    ../lib/djv/Models/FileFilter.cpp
+    ../lib/djv/Models/FolderScanner.cpp)
+target_compile_definitions(
+    djvFolderScanServiceTest
+    PRIVATE DJV_FOLDER_SCAN_SERVICE_TEST_MAIN FTK_ASSERT)
+target_include_directories(
+    djvFolderScanServiceTest
+    PRIVATE ${PROJECT_SOURCE_DIR}/lib)
+target_link_libraries(djvFolderScanServiceTest ftkCore)
+set_target_properties(djvFolderScanServiceTest PROPERTIES FOLDER tests)
+add_test(NAME djv-folder-scan-service COMMAND djvFolderScanServiceTest)
+set_tests_properties(
+    djv-folder-scan-service
+    PROPERTIES LABELS "unit;app;filesystem;concurrency" TIMEOUT 180)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,1 +1,16 @@
 add_subdirectory(djv-test)
+
+add_executable(djvPlaylistModelTest PlaylistModelTest.cpp)
+target_link_libraries(
+    djvPlaylistModelTest
+    djvModels
+    tlRender::tlUI
+    ftk::ftkUI)
+target_compile_definitions(
+    djvPlaylistModelTest
+    PRIVATE DJV_TEST_SAMPLE_DATA="${CMAKE_SOURCE_DIR}/etc/SampleData")
+set_target_properties(djvPlaylistModelTest PROPERTIES FOLDER tests)
+
+add_test(
+    NAME djvPlaylistModelTest
+    COMMAND $<TARGET_FILE:djvPlaylistModelTest>)

--- a/tests/PlaylistModelTest.cpp
+++ b/tests/PlaylistModelTest.cpp
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the DJV project.
+
+#include <djv/Models/PlaylistModel.h>
+#include <djv/Models/FileFilter.h>
+
+#include <tlRender/Timeline/Init.h>
+
+#include <ftk/Core/Context.h>
+
+#include <opentimelineio/clip.h>
+#include <opentimelineio/externalReference.h>
+#include <opentimelineio/gap.h>
+#include <opentimelineio/stack.h>
+#include <opentimelineio/track.h>
+
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <stdexcept>
+
+namespace
+{
+    using TimelineRetainer =
+        OTIO_NS::SerializableObject::Retainer<OTIO_NS::Timeline>;
+
+    void require(bool value, const std::string& message)
+    {
+        if (!value)
+        {
+            throw std::runtime_error(message);
+        }
+    }
+
+    OTIO_NS::Clip* makeClip(
+        const std::string& name,
+        const std::string& path,
+        double frames)
+    {
+        const OTIO_NS::TimeRange range(
+            OTIO_NS::RationalTime(0.0, 24.0),
+            OTIO_NS::RationalTime(frames, 24.0));
+        auto out = new OTIO_NS::Clip;
+        out->set_name(name);
+        out->set_source_range(range);
+        out->set_media_reference(new OTIO_NS::ExternalReference(path, range));
+        return out;
+    }
+
+    void append(
+        OTIO_NS::Composition* composition,
+        OTIO_NS::Composable* child,
+        const std::string& message)
+    {
+        OTIO_NS::ErrorStatus errorStatus;
+        require(
+            composition->append_child(child, &errorStatus) &&
+                !OTIO_NS::is_error(errorStatus),
+            message);
+    }
+
+    TimelineRetainer makePlaylist()
+    {
+        auto video = new OTIO_NS::Track(
+            "Video", std::nullopt, OTIO_NS::Track::Kind::video);
+        append(video, makeClip("A", "A.png", 1.0), "Cannot append A.");
+        append(video, makeClip("B", "B.mov", 48.0), "Cannot append B.");
+        append(video, makeClip("C", "C.jpg", 1.0), "Cannot append C.");
+
+        auto audio = new OTIO_NS::Track(
+            "Audio", std::nullopt, OTIO_NS::Track::Kind::audio);
+        append(
+            audio,
+            new OTIO_NS::Gap(OTIO_NS::RationalTime(1.0, 24.0)),
+            "Cannot append first audio gap.");
+        append(audio, makeClip("B audio", "B.mov", 48.0), "Cannot append audio.");
+        append(
+            audio,
+            new OTIO_NS::Gap(OTIO_NS::RationalTime(1.0, 24.0)),
+            "Cannot append second audio gap.");
+
+        auto stack = new OTIO_NS::Stack;
+        append(stack, video, "Cannot append video track.");
+        append(stack, audio, "Cannot append audio track.");
+
+        TimelineRetainer out(new OTIO_NS::Timeline("Playlist"));
+        out->set_tracks(stack);
+        return out;
+    }
+
+    void testEditablePlaylist(const std::filesystem::path& directory)
+    {
+        auto model = djv::models::PlaylistModel::create();
+        model->setTimeline(
+            makePlaylist(),
+            ftk::Path((directory / "input.otio").u8string()));
+
+        require(model->isAvailable(), "The OTIO playlist should be available.");
+        require(model->isEditable(), "The flat OTIO playlist should be editable.");
+        require(model->getItems().size() == 3, "The playlist should have three items.");
+        require(model->getItems()[1].hasAudio, "The movie item should keep its audio.");
+
+        std::string error;
+        require(model->move(0, 2, &error), error);
+        require(model->getItems()[0].name == "B", "Move should put B first.");
+        require(model->getItems()[2].name == "A", "Move should put A last.");
+        require(model->getItems()[0].hasAudio, "Audio should move with its media item.");
+
+        require(model->remove(1, &error), error);
+        require(model->getItems().size() == 2, "Remove should keep two items.");
+        require(model->getItems()[0].name == "B", "B should remain first.");
+        require(model->getItems()[1].name == "A", "A should remain second.");
+
+        const ftk::Path output((directory / "saved-playlist").u8string());
+        require(model->save(output, &error), error);
+        const std::filesystem::path saved = directory / "saved-playlist.otio";
+        require(std::filesystem::exists(saved), "Save should add the .otio extension.");
+
+        TimelineRetainer parsed(dynamic_cast<OTIO_NS::Timeline*>(
+            OTIO_NS::Timeline::from_json_file(saved.u8string())));
+        require(parsed.value, "The saved OTIO file should parse.");
+        require(parsed->video_tracks().size() == 1, "Saved OTIO should have one video track.");
+        require(
+            parsed->video_tracks()[0]->children().size() == 2,
+            "Saved OTIO should preserve the edited item count.");
+    }
+
+    void testReadOnlyContracts(const std::filesystem::path& directory)
+    {
+        auto model = djv::models::PlaylistModel::create();
+        model->setTimeline(
+            makePlaylist(),
+            ftk::Path((directory / "packaged.otioz").u8string()));
+        require(model->isAvailable(), "An .otioz timeline should be available.");
+        require(!model->isEditable(), "An .otioz timeline should be read-only.");
+
+        auto complex = makePlaylist();
+        append(
+            complex->tracks(),
+            new OTIO_NS::Track("Extra", std::nullopt, OTIO_NS::Track::Kind::video),
+            "Cannot append extra track.");
+        model->setTimeline(
+            complex,
+            ftk::Path((directory / "complex.otio").u8string()));
+        require(!model->isEditable(), "A multi-video-track OTIO should be read-only.");
+    }
+
+    void testNumberedImagesStayIndependent(
+        const std::shared_ptr<ftk::Context>& context,
+        const std::filesystem::path& directory)
+    {
+        const std::filesystem::path sampleData = DJV_TEST_SAMPLE_DATA;
+        const ftk::Path first(
+            (sampleData / "BART_2021-02-07.0000.jpg").u8string());
+        const ftk::Path second(
+            (sampleData / "BART_2021-02-07.0050.jpg").u8string());
+        auto model = djv::models::PlaylistModel::create();
+        std::string error;
+        require(
+            model->createFromMedia(
+                context,
+                first,
+                first,
+                ftk::Path((directory / "numbered-images.otio").u8string()),
+                tl::Options(),
+                &error),
+            error);
+        require(model->getItems().size() == 1, "The first numbered image must stay a still.");
+        require(
+            model->getItems()[0].duration.value() == 1.0,
+            "A numbered still must be one frame, not an inferred sequence.");
+        require(
+            model->addMedia(context, second, second, tl::Options(), &error),
+            error);
+        require(model->getItems().size() == 2, "The second numbered image must be a separate item.");
+        require(
+            model->getItems()[1].duration.value() == 1.0,
+            "The second numbered still must also stay one frame.");
+    }
+
+    void testFilteredFolderScan(const std::filesystem::path& directory)
+    {
+        const auto scanDirectory = directory / "folder-import";
+        std::filesystem::create_directories(scanDirectory / "plates");
+        std::filesystem::create_directories(scanDirectory / "cache");
+        std::ofstream(scanDirectory / "plates" / "beauty.exr").put('\n');
+        std::ofstream(scanDirectory / "plates" / "proxy.exr").put('\n');
+        std::ofstream(scanDirectory / "plates" / "notes.txt").put('\n');
+        std::ofstream(scanDirectory / "cache" / "beauty.exr").put('\n');
+
+        const auto result = djv::models::scanFiles(
+            ftk::Path(scanDirectory.u8string()),
+            "name:beauty -dir:cache",
+            { ".exr" });
+        require(result.error.empty(), result.error);
+        require(!result.truncated, "The small folder scan must not truncate.");
+        require(result.paths.size() == 1, "The filter should select one EXR.");
+        require(
+            result.paths[0].getFileName() == "beauty.exr",
+            "The filtered path should be deterministic.");
+
+        djv::models::FileScanOptions limits;
+        limits.maxResults = 1;
+        const auto limited = djv::models::scanFiles(
+            ftk::Path(scanDirectory.u8string()),
+            std::string(),
+            { ".exr" },
+            limits);
+        require(
+            limited.truncated,
+            "Reaching the result limit must be reported.");
+        require(
+            limited.paths.size() == 1,
+            "The result limit must bound the imported path list.");
+    }
+}
+
+int main()
+{
+    try
+    {
+        const std::filesystem::path directory =
+            std::filesystem::temp_directory_path() / "djv-playlist-model-test";
+        std::filesystem::remove_all(directory);
+        std::filesystem::create_directories(directory);
+        auto context = ftk::Context::create();
+        tl::init(context);
+        testEditablePlaylist(directory);
+        testReadOnlyContracts(directory);
+        testNumberedImagesStayIndependent(context, directory);
+        testFilteredFolderScan(directory);
+        std::filesystem::remove_all(directory);
+        std::cout << "DJV OTIO playlist model test passed." << std::endl;
+        return 0;
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << e.what() << std::endl;
+        return 1;
+    }
+}

--- a/tests/PlaylistModelTest.cpp
+++ b/tests/PlaylistModelTest.cpp
@@ -3,6 +3,7 @@
 
 #include <djv/Models/PlaylistModel.h>
 #include <djv/Models/FileFilter.h>
+#include <djv/Models/FolderScanner.h>
 
 #include <tlRender/Timeline/Init.h>
 
@@ -188,30 +189,38 @@ namespace
         std::ofstream(scanDirectory / "plates" / "notes.txt").put('\n');
         std::ofstream(scanDirectory / "cache" / "beauty.exr").put('\n');
 
-        const auto result = djv::models::scanFiles(
-            ftk::Path(scanDirectory.u8string()),
-            "name:beauty -dir:cache",
-            { ".exr" });
-        require(result.error.empty(), result.error);
-        require(!result.truncated, "The small folder scan must not truncate.");
+        const auto filter = djv::models::compileFileFilter(
+            "name:beauty -dir:cache");
+        require(static_cast<bool>(filter), "The folder filter must compile.");
+        djv::models::FolderScanOptions options;
+        options.fileExtensions = { ".exr" };
+        options.collapseSequences = false;
+        const auto result = djv::models::scanFolder(
+            scanDirectory,
+            *filter.filter,
+            options);
+        require(
+            result.status == djv::models::FolderScanStatus::Completed,
+            "The small folder scan must complete.");
         require(result.paths.size() == 1, "The filter should select one EXR.");
         require(
             result.paths[0].getFileName() == "beauty.exr",
             "The filtered path should be deterministic.");
 
-        djv::models::FileScanOptions limits;
+        djv::models::FolderScanOptions limits = options;
         limits.maxResults = 1;
-        const auto limited = djv::models::scanFiles(
-            ftk::Path(scanDirectory.u8string()),
-            std::string(),
-            { ".exr" },
+        const auto emptyFilter = djv::models::compileFileFilter(std::string());
+        require(static_cast<bool>(emptyFilter), "The empty filter must compile.");
+        const auto limited = djv::models::scanFolder(
+            scanDirectory,
+            *emptyFilter.filter,
             limits);
         require(
-            limited.truncated,
+            limited.status == djv::models::FolderScanStatus::ResultLimitReached,
             "Reaching the result limit must be reported.");
         require(
-            limited.paths.size() == 1,
-            "The result limit must bound the imported path list.");
+            limited.paths.empty(),
+            "A limited scan must not publish a partial playlist.");
     }
 }
 


### PR DESCRIPTION
## Summary
- add an editable OTIO playlist model for the deliberately small, safe subset: one video track and an optional aligned audio/gap track
- add a visible **OTIO Playlist** tool with add, remove, drag-to-reorder, save, and save-as actions
- create or extend a playlist from asynchronously discovered folder media without blocking the UI
- compile explicit folder filters (`name:`, `ext:`, `dir:`, `path:`, include/exclude terms) and reject invalid expressions instead of silently broadening the scan
- keep traversal deterministic and confined to the selected root, skip directory links by default, collapse image sequences by default, and publish no partial path list on cancellation or hard-limit failure
- bound the worker queue, traversal, result count, warnings, filter complexity, and shutdown lifecycle
- add command-line playlist generation plus a Windows batch helper for launching DJV from a folder root
- add an optional in-process folder watcher that rescans in the background and updates the same playlist only when matching file metadata changes
- keep complex, multitrack, transitioned, nested, and `.otioz` timelines read-only instead of flattening them silently

This intentionally combines playlist editing, filtered folder ingestion, and the hardened background scanner as one user workflow: folder discovery produces the ordered media list that the OTIO playlist owns.

## Command line

```console
djv -playlistFolder . -playlistFilter "ext:^(mov|mp4)$ -dir:(cache|proxy)"
djv -playlistFolder . -playlistWatch -playlistOutput review.otio
djv -playlistFolder . -playlistOutput review.otio -playback Forward -loop Loop
```

Optional flags:
- `-playlistTopLevel`: do not recurse into subfolders
- `-playlistFrames`: keep numbered image frames separate instead of collapsing sequences
- `-playlistOutput <file.otio>`: save the generated playlist while opening it
- `-playlistWatch`: rescan about every two seconds while DJV is open and refresh the watched playlist when a matching path, size, or modification time changes

On Windows, `etc\Windows\djv-playlist-folder.bat` uses the current directory and forwards all additional DJV options, including `-playlistWatch`. Without that flag, the playlist is rebuilt once at launch. The watcher runs inside DJV and stops when DJV exits; no separate batch process remains active.

Watch mode updates only its own active playlist tab. If another playlist is active, the changed signature remains pending until the watched tab is active again. Closing the watched playlist stops its watcher. If the folder temporarily has no matching media, DJV keeps the last playable playlist and continues watching for media to return.

## Verification
- `git diff --check`
- focused CTest run passes:
  - `djv-file-filter`
  - `djv-folder-scan-service`
- folder signatures are deterministic and detect metadata changes to individual frames before sequence collapsing; cancelled or limited scans expose no usable signature
- the folder service test covers cancellation, queue saturation, shutdown, root confinement, deterministic traversal, sequence collapsing, hard limits, and a 10k-entry benchmark
- complete C++ source compilation succeeds for the changed `djvModels`, `djvUI`, and `djvApp` targets
- `djvPlaylistModelTest.cpp` compiles and covers playlist editing, save round-trip, numbered stills, read-only structures, filtered selection, and atomic scan limits
- the Windows batch helper was exercised with a probe executable to verify the current folder and forwarded `-playlistWatch` option

## Local build limitation
The full linked DJV/test build cannot complete in the current local dependency matrix because the unmodified pinned tlRender source fails first in `tlRender/Core/Time.cpp` against the installed nlohmann/OTIO versions. The new focused tests link and pass independently, and all changed DJV translation units compile successfully before that unrelated baseline failure.

## Review notes
- Folder scanning and watching are asynchronous, cancellable, bounded, and single-worker by design.
- Watch mode uses periodic bounded rescans instead of adding a platform-specific filesystem dependency.
- Complex OTIO timelines remain readable but are not rewritten into the editable subset.
- The PR remains a draft pending a maintainer runtime/UX pass on a fully aligned dependency build.