### PR TITLE
Load timelines asynchronously with cancellation

### DIFF
--- a/lib/djv/App/App.cpp
+++ b/lib/djv/App/App.cpp
@@ -18,6 +18,7 @@
 #include <djv/App/SettingsTool.h>
 #include <djv/App/StatusBar.h>
 #include <djv/App/SysLogTool.h>
+#include <djv/App/TimelineLoadService.h>
 #include <djv/App/ViewTool.h>
 #include <djv/App/Viewport.h>
 #include <djv/UI/SeparateAudioDialog.h>
@@ -54,7 +55,10 @@
 #include <ftk/Core/OS.h>
 #include <ftk/Core/Timer.h>
 
+#include <chrono>
 #include <filesystem>
+#include <future>
+#include <map>
 #include <optional>
 
 namespace djv
@@ -157,6 +161,11 @@ namespace djv
             std::vector<std::shared_ptr<models::FilesModelItem> > activeFiles;
             std::shared_ptr<models::RecentFilesModel> recentFilesModel;
             std::vector<std::shared_ptr<tl::Timeline> > timelines;
+            std::unique_ptr<TimelineLoadService> timelineLoadService;
+            std::map<models::FilesModelItem*, TimelineLoadRequest> timelineLoadRequests;
+            std::shared_ptr<ftk::Timer> timelineLoadTimer;
+            bool inputOptionsPending = false;
+            std::optional<int64_t> reloadFramePending;
             std::shared_ptr<ftk::Observable<std::shared_ptr<tl::Player> > > player;
             std::shared_ptr<models::ColorModel> colorModel;
             std::shared_ptr<models::ViewportModel> viewportModel;
@@ -455,7 +464,21 @@ namespace djv
         {}
 
         App::~App()
-        {}
+        {
+            FTK_P();
+            if (p.timelineLoadTimer)
+            {
+                p.timelineLoadTimer->stop();
+            }
+            if (p.timelineLoadService)
+            {
+                for (const auto& request : p.timelineLoadRequests)
+                {
+                    p.timelineLoadService->cancel(request.second.id);
+                }
+                p.timelineLoadService->shutdown();
+            }
+        }
 
         std::shared_ptr<App> App::create(
             const std::shared_ptr<ftk::Context>& context,
@@ -608,6 +631,12 @@ namespace djv
             const auto files = p.files;
             for (const auto& i : activeFiles)
             {
+                const auto request = p.timelineLoadRequests.find(i.get());
+                if (request != p.timelineLoadRequests.end())
+                {
+                    p.timelineLoadService->cancel(request->second.id);
+                    p.timelineLoadRequests.erase(request);
+                }
                 const auto j = std::find(p.files.begin(), p.files.end(), i);
                 if (j != p.files.end())
                 {
@@ -654,29 +683,11 @@ namespace djv
             auto thumbnailSytem = _context->getSystem<tl::ui::ThumbnailSystem>();
             thumbnailSytem->clearCache();
 
+            // Timeline creation is asynchronous. Preserve a restructured
+            // reload's media frame until the replacement player exists.
+            p.reloadFramePending = frame;
             _filesUpdate(files);
             _activeUpdate(activeFiles);
-
-            if (frame.has_value())
-            {
-                if (auto player = p.player->get())
-                {
-                    // Asked against the start rather than where playback was
-                    // left, which may be past the end of a timeline that has
-                    // just become shorter. A frame the new timeline does not
-                    // hold snaps to one it does.
-                    const auto& timeRange = player->getTimeRange();
-                    if (const auto time =
-                        player->getTimeline()->getTimelineTime(
-                            timeRange.start_time(),
-                            OTIO_NS::RationalTime(
-                                static_cast<double>(frame.value()),
-                                timeRange.duration().rate())))
-                    {
-                        player->seek(time.value());
-                    }
-                }
-            }
         }
 
         std::shared_ptr<ftk::IObservable<std::shared_ptr<tl::Player> > > App::observePlayer() const
@@ -850,7 +861,6 @@ namespace djv
 
             _modelsInit();
             _observersInit();
-            _inputFilesInit();
             
             _uiInit();
 
@@ -866,6 +876,11 @@ namespace djv
             }
             
             _mainWindowInit();
+
+            // Create the visible shell before opening command-line media. A
+            // slow source must not delay the first window, and closing the app
+            // can cancel the owned timeline initialization.
+            _inputFilesInit();
 
             if (p.cmdLine.listCommands->found())
             {
@@ -1340,59 +1355,69 @@ namespace djv
                     open(path, ftk::Path(audioFileName), frameRange);
                     // Only the first file opened takes the range.
                     frameRange.reset();
-
-                    if (auto player = p.player->get())
-                    {
-                        if (p.cmdLine.speed->found())
-                        {
-                            player->setSpeed(p.cmdLine.speed->getValue());
-                        }
-                        if (p.cmdLine.timeUnits->found())
-                        {
-                            p.timeUnitsModel->setTimeUnits(p.cmdLine.timeUnits->getValue());
-                        }
-                        const double speed = player->getSpeed();
-                        const tl::TimeUnits timeUnits = p.timeUnitsModel->getTimeUnits();
-                        if (p.cmdLine.inPoint->found())
-                        {
-                            const auto inOutRange = OTIO_NS::TimeRange::range_from_start_end_time_inclusive(
-                                tl::textToTime(
-                                    p.cmdLine.inPoint->getValue(),
-                                    speed,
-                                    timeUnits),
-                                player->getInOutRange().end_time_inclusive());
-                            player->setInOutRange(inOutRange);
-                            player->seek(inOutRange.start_time());
-                        }
-                        if (p.cmdLine.outPoint->found())
-                        {
-                            const auto inOutRange = OTIO_NS::TimeRange::range_from_start_end_time_inclusive(
-                                player->getInOutRange().start_time(),
-                                tl::textToTime(
-                                    p.cmdLine.outPoint->getValue(),
-                                    speed,
-                                    timeUnits));
-                            player->setInOutRange(inOutRange);
-                            player->seek(inOutRange.start_time());
-                        }
-                        if (p.cmdLine.seek->found())
-                        {
-                            player->seek(tl::textToTime(
-                                p.cmdLine.seek->getValue(),
-                                speed,
-                                timeUnits));
-                        }
-                        if (p.cmdLine.loop->found())
-                        {
-                            player->setLoop(p.cmdLine.loop->getValue());
-                        }
-                        if (p.cmdLine.playback->found())
-                        {
-                            player->setPlayback(p.cmdLine.playback->getValue());
-                        }
-                    }
                 }
+                p.inputOptionsPending = true;
             }
+        }
+
+        void App::_applyInputOptions()
+        {
+            FTK_P();
+            auto player = p.player->get();
+            if (!player)
+            {
+                return;
+            }
+            if (p.cmdLine.speed->found())
+            {
+                player->setSpeed(p.cmdLine.speed->getValue());
+            }
+            if (p.cmdLine.timeUnits->found())
+            {
+                p.timeUnitsModel->setTimeUnits(p.cmdLine.timeUnits->getValue());
+            }
+            const double speed = player->getSpeed();
+            const tl::TimeUnits timeUnits = p.timeUnitsModel->getTimeUnits();
+            if (p.cmdLine.inPoint->found())
+            {
+                const auto inOutRange =
+                    OTIO_NS::TimeRange::range_from_start_end_time_inclusive(
+                        tl::textToTime(
+                            p.cmdLine.inPoint->getValue(),
+                            speed,
+                            timeUnits),
+                        player->getInOutRange().end_time_inclusive());
+                player->setInOutRange(inOutRange);
+                player->seek(inOutRange.start_time());
+            }
+            if (p.cmdLine.outPoint->found())
+            {
+                const auto inOutRange =
+                    OTIO_NS::TimeRange::range_from_start_end_time_inclusive(
+                        player->getInOutRange().start_time(),
+                        tl::textToTime(
+                            p.cmdLine.outPoint->getValue(),
+                            speed,
+                            timeUnits));
+                player->setInOutRange(inOutRange);
+                player->seek(inOutRange.start_time());
+            }
+            if (p.cmdLine.seek->found())
+            {
+                player->seek(tl::textToTime(
+                    p.cmdLine.seek->getValue(),
+                    speed,
+                    timeUnits));
+            }
+            if (p.cmdLine.loop->found())
+            {
+                player->setLoop(p.cmdLine.loop->getValue());
+            }
+            if (p.cmdLine.playback->found())
+            {
+                player->setPlayback(p.cmdLine.playback->getValue());
+            }
+            p.inputOptionsPending = false;
         }
 
         void App::_uiInit()
@@ -1512,62 +1537,163 @@ namespace djv
 
             for (size_t i = 0; i < files.size(); ++i)
             {
-                if (!timelines[i])
+                if (!timelines[i] &&
+                    p.timelineLoadRequests.find(files[i].get()) ==
+                    p.timelineLoadRequests.end())
                 {
-                    try
+                    tl::Options options;
+                    const models::ImageSeqSettings imageSeq =
+                        p.settingsModel->getImageSeq();
+                    options.imageSeqAudio = imageSeq.audio;
+                    options.imageSeqAudioExts = imageSeq.audioExts;
+                    options.imageSeqAudioFileName = imageSeq.audioFileName;
+                    const models::OTIOSettings otio = p.settingsModel->getOTIO();
+                    options.spatial = otio.spatial;
+                    options.compat = otio.compat;
+                    options.ioOptions = p.settingsModel->getIOOptions();
+                    options.pathOptions.seqMaxDigits = imageSeq.maxDigits;
+                    options.readThreadCount = imageSeq.readThreadCount;
+                    // A range that was asked for is used as it is. One that
+                    // was not is looked for on disk, so reopening can pick up
+                    // frames rendered since.
+                    options.seqExpand = !files[i]->framesStated;
+                    if (!p.timelineLoadService)
                     {
-                        tl::Options options;
-                        const models::ImageSeqSettings imageSeq = p.settingsModel->getImageSeq();
-                        options.imageSeqAudio = imageSeq.audio;
-                        options.imageSeqAudioExts = imageSeq.audioExts;
-                        options.imageSeqAudioFileName = imageSeq.audioFileName;
-                        const models::OTIOSettings otio = p.settingsModel->getOTIO();
-                        options.spatial = otio.spatial;
-                        options.compat = otio.compat;
-                        options.ioOptions = p.settingsModel->getIOOptions();
-                        options.pathOptions.seqMaxDigits = imageSeq.maxDigits;
-                        options.readThreadCount = imageSeq.readThreadCount;
-
-                        // A range that was asked for is used as it is. One
-                        // that was not is looked for on disk, so that
-                        // reopening picks up frames rendered since.
-                        options.seqExpand = !files[i]->framesStated;
-                        timelines[i] = tl::Timeline::create(
+                        p.timelineLoadService =
+                            std::make_unique<TimelineLoadService>();
+                    }
+                    p.timelineLoadRequests[files[i].get()] =
+                        p.timelineLoadService->request(
                             _context,
                             files[i]->path,
                             files[i]->audioPath,
                             options);
-
-                        // Opening a sequence finds the frames on disk, which
-                        // the path does not know about when it names one
-                        // file. Kept beside the path rather than folded into
-                        // it: a path carrying a range is taken as a range
-                        // that was asked for, and reopening would stop
-                        // looking for frames that have arrived since.
-                        files[i]->timeRange = timelines[i]->getTimeRange();
-
-                        // Replaced rather than added to: a file that is
-                        // reopened comes back through here with its layers
-                        // already listed from the time before.
-                        files[i]->videoLayers.clear();
-                        for (const auto& video : timelines[i]->getIOInfo().video)
-                        {
-                            files[i]->videoLayers.push_back(video.name);
-                        }
-                        if (files[i]->videoLayer >= files[i]->videoLayers.size())
-                        {
-                            files[i]->videoLayer = 0;
-                        }
-                    }
-                    catch (const std::exception& e)
+                    if (!p.timelineLoadTimer)
                     {
-                        _context->log("djv::app::App", e.what(), ftk::LogType::Error);
+                        p.timelineLoadTimer = ftk::Timer::create(_context);
+                        p.timelineLoadTimer->setRepeating(true);
                     }
+                    p.timelineLoadTimer->start(
+                        std::chrono::milliseconds(10),
+                        [this] { _timelineLoadsPoll(); });
                 }
             }
 
             p.files = files;
             p.timelines = timelines;
+
+            for (auto i = p.timelineLoadRequests.begin();
+                i != p.timelineLoadRequests.end();)
+            {
+                const bool found = std::any_of(
+                    files.begin(),
+                    files.end(),
+                    [i](const auto& file) { return file.get() == i->first; });
+                if (!found)
+                {
+                    p.timelineLoadService->cancel(i->second.id);
+                    i = p.timelineLoadRequests.erase(i);
+                }
+                else
+                {
+                    ++i;
+                }
+            }
+        }
+
+        void App::_timelineLoadsPoll()
+        {
+            FTK_P();
+            bool activeTimelineChanged = false;
+            for (auto i = p.timelineLoadRequests.begin();
+                i != p.timelineLoadRequests.end();)
+            {
+                if (std::future_status::ready !=
+                    i->second.future.wait_for(std::chrono::milliseconds(0)))
+                {
+                    ++i;
+                    continue;
+                }
+
+                const TimelineLoadResult result = i->second.future.get();
+                const auto fileIt = std::find_if(
+                    p.files.begin(),
+                    p.files.end(),
+                    [i](const auto& file) { return file.get() == i->first; });
+                if (fileIt != p.files.end())
+                {
+                    const size_t index = fileIt - p.files.begin();
+                    const auto& file = *fileIt;
+                    p.timelines[index] = result.timeline;
+                    file->videoLayers.clear();
+                    if (result.timeline)
+                    {
+                        // Keep the discovered sequence range beside the path.
+                        // A stated range stays authoritative while an
+                        // unstated range can be rediscovered on reload.
+                        file->timeRange = result.timeline->getTimeRange();
+                        for (const auto& video : result.timeline->getIOInfo().video)
+                        {
+                            file->videoLayers.push_back(video.name);
+                        }
+                    }
+                    else if (!result.cancelled && !result.error.empty())
+                    {
+                        _context->log(
+                            "djv::app::App",
+                            result.error,
+                            ftk::LogType::Error);
+                    }
+                    p.filesModel->touchMetadata(file);
+                    const bool active =
+                        std::find(
+                            p.activeFiles.begin(),
+                            p.activeFiles.end(),
+                            file) != p.activeFiles.end();
+                    activeTimelineChanged |= active;
+                    if (active &&
+                        !p.activeFiles.empty() &&
+                        file == p.activeFiles.front() &&
+                        !result.timeline)
+                    {
+                        p.reloadFramePending.reset();
+                    }
+                }
+                i = p.timelineLoadRequests.erase(i);
+            }
+
+            if (p.timelineLoadRequests.empty() && p.timelineLoadTimer)
+            {
+                p.timelineLoadTimer->stop();
+            }
+            if (activeTimelineChanged)
+            {
+                _activeUpdate(p.activeFiles);
+                if (p.reloadFramePending.has_value())
+                {
+                    if (auto player = p.player->get())
+                    {
+                        // Ask against the replacement timeline start. A frame
+                        // outside its new range snaps to one it contains.
+                        const auto& timeRange = player->getTimeRange();
+                        if (const auto time =
+                            player->getTimeline()->getTimelineTime(
+                                timeRange.start_time(),
+                                OTIO_NS::RationalTime(
+                                    static_cast<double>(
+                                        p.reloadFramePending.value()),
+                                    timeRange.duration().rate())))
+                        {
+                            player->seek(time.value());
+                        }
+                        p.reloadFramePending.reset();
+                    }
+                }
+                if (p.inputOptionsPending)
+                {
+                    _applyInputOptions();
+                }
+            }
         }
 
         void App::_reloadUpdate(const std::shared_ptr<models::FilesModelItem>& item)
@@ -1576,6 +1702,13 @@ namespace djv
             if (!item)
             {
                 return;
+            }
+
+            const auto request = p.timelineLoadRequests.find(item.get());
+            if (request != p.timelineLoadRequests.end())
+            {
+                p.timelineLoadService->cancel(request->second.id);
+                p.timelineLoadRequests.erase(request);
             }
 
             // Keep where playback had got to. _activeUpdate saves this for a
@@ -1637,7 +1770,9 @@ namespace djv
             std::shared_ptr<tl::Player> player;
             if (!activeFiles.empty())
             {
-                if (!p.activeFiles.empty() && activeFiles[0] == p.activeFiles[0])
+                if (!p.activeFiles.empty() &&
+                    activeFiles[0] == p.activeFiles[0] &&
+                    p.player->get())
                 {
                     player = p.player->get();
                 }

--- a/lib/djv/App/App.h
+++ b/lib/djv/App/App.h
@@ -173,6 +173,8 @@ namespace djv
             // carried over as they are, since both are in timeline time.
             void _reload(bool restructured);
             void _reloadUpdate(const std::shared_ptr<models::FilesModelItem>&);
+            void _timelineLoadsPoll();
+            void _applyInputOptions();
             void _layersUpdate(const std::vector<int>&);
             void _audioUpdate();
 

--- a/lib/djv/App/CMakeLists.txt
+++ b/lib/djv/App/CMakeLists.txt
@@ -37,6 +37,7 @@ set(HEADERS
     SysLogTool.h
     TabBar.h
     TimelineActions.h
+    TimelineLoadService.h
     TimelineMenu.h
     ToolsActions.h
     ToolsMenu.h
@@ -91,6 +92,7 @@ set(SOURCE
     SysLogTool.cpp
     TabBar.cpp
     TimelineActions.cpp
+    TimelineLoadService.cpp
     TimelineMenu.cpp
     ToolsActions.cpp
     ToolsMenu.cpp

--- a/lib/djv/App/FileActions.cpp
+++ b/lib/djv/App/FileActions.cpp
@@ -18,6 +18,7 @@ namespace djv
         {
             std::shared_ptr<ftk::ListObserver<std::shared_ptr<models::FilesModelItem> > > filesObserver;
             std::shared_ptr<ftk::Observer<std::shared_ptr<models::FilesModelItem> > > aObserver;
+            std::shared_ptr<ftk::Observer<std::shared_ptr<models::FilesModelItem> > > metadataObserver;
             std::shared_ptr<ftk::Observer<std::shared_ptr<tl::Player> > > playerObserver;
         };
 
@@ -266,6 +267,23 @@ namespace djv
                 {
                     _actions["NextLayer"]->setEnabled(value ? value->videoLayers.size() > 1 : false);
                     _actions["PrevLayer"]->setEnabled(value ? value->videoLayers.size() > 1 : false);
+                });
+
+            p.metadataObserver = ftk::Observer<std::shared_ptr<models::FilesModelItem> >::create(
+                app->getFilesModel()->observeMetadata(),
+                [this, appWeak](const std::shared_ptr<models::FilesModelItem>& value)
+                {
+                    if (auto app = appWeak.lock())
+                    {
+                        const auto& current = app->getFilesModel()->getA();
+                        if (value == current)
+                        {
+                            const bool enabled =
+                                current && current->videoLayers.size() > 1;
+                            _actions["NextLayer"]->setEnabled(enabled);
+                            _actions["PrevLayer"]->setEnabled(enabled);
+                        }
+                    }
                 });
 
             p.playerObserver = ftk::Observer<std::shared_ptr<tl::Player> >::create(

--- a/lib/djv/App/FileMenu.cpp
+++ b/lib/djv/App/FileMenu.cpp
@@ -32,6 +32,7 @@ namespace djv
 
             std::shared_ptr<ftk::ListObserver<std::shared_ptr<models::FilesModelItem> > > filesObserver;
             std::shared_ptr<ftk::Observer<std::shared_ptr<models::FilesModelItem> > > aObserver;
+            std::shared_ptr<ftk::Observer<std::shared_ptr<models::FilesModelItem> > > metadataObserver;
             std::shared_ptr<ftk::Observer<int> > aIndexObserver;
             std::shared_ptr<ftk::ListObserver<int> > layersObserver;
             std::shared_ptr<ftk::ListObserver<std::filesystem::path> > recentObserver;
@@ -87,6 +88,19 @@ namespace djv
                 [this](const std::shared_ptr<models::FilesModelItem>& value)
                 {
                     _aUpdate(value);
+                });
+
+            p.metadataObserver = ftk::Observer<std::shared_ptr<models::FilesModelItem> >::create(
+                app->getFilesModel()->observeMetadata(),
+                [this](const std::shared_ptr<models::FilesModelItem>& value)
+                {
+                    if (auto app = _p->app.lock())
+                    {
+                        if (value == app->getFilesModel()->getA())
+                        {
+                            _aUpdate(value);
+                        }
+                    }
                 });
 
             p.aIndexObserver = ftk::Observer<int>::create(

--- a/lib/djv/App/FilesTool.cpp
+++ b/lib/djv/App/FilesTool.cpp
@@ -73,6 +73,7 @@ namespace djv
             ftk::RangeI64 rangeValue;
 
             std::shared_ptr<ftk::ListObserver<std::shared_ptr<models::FilesModelItem> > > filesObserver;
+            std::shared_ptr<ftk::Observer<std::shared_ptr<models::FilesModelItem> > > metadataObserver;
             std::shared_ptr<ftk::Observer<std::shared_ptr<models::FilesModelItem> > > aObserver;
             std::shared_ptr<ftk::ListObserver<std::shared_ptr<models::FilesModelItem> > > bObserver;
             std::shared_ptr<ftk::ListObserver<int> > layersObserver;
@@ -264,6 +265,21 @@ namespace djv
                 [this](const std::vector<std::shared_ptr<models::FilesModelItem> >& value)
                 {
                     _filesUpdate(value);
+                });
+
+            p.metadataObserver = ftk::Observer<std::shared_ptr<models::FilesModelItem> >::create(
+                app->getFilesModel()->observeMetadata(),
+                [this](const std::shared_ptr<models::FilesModelItem>& value)
+                {
+                    for (auto& widget : _p->widgets)
+                    {
+                        if (widget.item == value)
+                        {
+                            widget.layerComboBox->setItems(value->videoLayers);
+                            widget.layerComboBox->setCurrentIndex(value->videoLayer);
+                            break;
+                        }
+                    }
                 });
 
             p.aObserver = ftk::Observer<std::shared_ptr<models::FilesModelItem> >::create(

--- a/lib/djv/App/TimelineLoadService.cpp
+++ b/lib/djv/App/TimelineLoadService.cpp
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the DJV project.
+
+#include <djv/App/TimelineLoadService.h>
+
+#include <condition_variable>
+#include <deque>
+#include <mutex>
+#include <thread>
+
+namespace djv
+{
+    namespace app
+    {
+        struct TimelineLoadService::Private
+        {
+            struct Job
+            {
+                uint64_t id = 0;
+                std::shared_ptr<ftk::Context> context;
+                ftk::Path path;
+                ftk::Path audioPath;
+                tl::Options options;
+                std::shared_ptr<tl::TimelineInitCancellation> cancellation =
+                    std::make_shared<tl::TimelineInitCancellation>();
+                std::promise<TimelineLoadResult> promise;
+                std::shared_future<TimelineLoadResult> future =
+                    promise.get_future().share();
+            };
+
+            explicit Private(const Loader& value) :
+                loader(
+                    value ?
+                    value :
+                    [](const auto& context,
+                        const auto& path,
+                        const auto& audioPath,
+                        const auto& options,
+                        const auto& cancellation)
+                    {
+                        return tl::Timeline::create(
+                            context,
+                            path,
+                            audioPath,
+                            options,
+                            cancellation);
+                    })
+            {
+                thread = std::thread([this] { run(); });
+            }
+
+            void run()
+            {
+                for (;;)
+                {
+                    std::shared_ptr<Job> job;
+                    {
+                        std::unique_lock<std::mutex> lock(mutex);
+                        cv.wait(
+                            lock,
+                            [this] { return stopping || !queue.empty(); });
+                        if (stopping && queue.empty())
+                        {
+                            break;
+                        }
+                        job = queue.front();
+                        queue.pop_front();
+                        current = job;
+                    }
+
+                    TimelineLoadResult result;
+                    if (job->cancellation->isCancelled())
+                    {
+                        result.cancelled = true;
+                        result.error = "Timeline loading cancelled";
+                    }
+                    else
+                    {
+                        try
+                        {
+                            result.timeline = loader(
+                                job->context,
+                                job->path,
+                                job->audioPath,
+                                job->options,
+                                job->cancellation);
+                            result.cancelled =
+                                job->cancellation->isCancelled();
+                            if (result.cancelled && result.error.empty())
+                            {
+                                result.timeline.reset();
+                                result.error = "Timeline loading cancelled";
+                            }
+                        }
+                        catch (const std::exception& e)
+                        {
+                            result.cancelled =
+                                job->cancellation->isCancelled();
+                            result.error = result.cancelled ?
+                                "Timeline loading cancelled" :
+                                e.what();
+                        }
+                        catch (...)
+                        {
+                            result.cancelled =
+                                job->cancellation->isCancelled();
+                            result.error = result.cancelled ?
+                                "Timeline loading cancelled" :
+                                "Unknown timeline loading error";
+                        }
+                    }
+                    job->promise.set_value(std::move(result));
+                    {
+                        std::lock_guard<std::mutex> lock(mutex);
+                        if (current == job)
+                        {
+                            current.reset();
+                        }
+                    }
+                }
+            }
+
+            Loader loader;
+            std::mutex mutex;
+            std::condition_variable cv;
+            std::deque<std::shared_ptr<Job> > queue;
+            std::shared_ptr<Job> current;
+            std::thread thread;
+            uint64_t nextId = 1;
+            bool stopping = false;
+            std::mutex shutdownMutex;
+        };
+
+        TimelineLoadService::TimelineLoadService(const Loader& loader) :
+            _p(new Private(loader))
+        {}
+
+        TimelineLoadService::~TimelineLoadService()
+        {
+            shutdown();
+        }
+
+        TimelineLoadRequest TimelineLoadService::request(
+            const std::shared_ptr<ftk::Context>& context,
+            const ftk::Path& path,
+            const ftk::Path& audioPath,
+            const tl::Options& options)
+        {
+            auto job = std::make_shared<Private::Job>();
+            job->context = context;
+            job->path = path;
+            job->audioPath = audioPath;
+            job->options = options;
+            TimelineLoadRequest out;
+            {
+                std::lock_guard<std::mutex> lock(_p->mutex);
+                if (_p->stopping)
+                {
+                    return out;
+                }
+                job->id = _p->nextId++;
+                _p->queue.push_back(job);
+                out.id = job->id;
+                out.future = job->future;
+            }
+            _p->cv.notify_one();
+            return out;
+        }
+
+        bool TimelineLoadService::cancel(uint64_t id)
+        {
+            std::lock_guard<std::mutex> lock(_p->mutex);
+            if (_p->current && _p->current->id == id)
+            {
+                _p->current->cancellation->cancel();
+                return true;
+            }
+            for (const auto& job : _p->queue)
+            {
+                if (job->id == id)
+                {
+                    job->cancellation->cancel();
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        void TimelineLoadService::shutdown()
+        {
+            std::lock_guard<std::mutex> shutdownLock(_p->shutdownMutex);
+            {
+                std::lock_guard<std::mutex> lock(_p->mutex);
+                if (_p->stopping && !_p->thread.joinable())
+                {
+                    return;
+                }
+                _p->stopping = true;
+                if (_p->current)
+                {
+                    _p->current->cancellation->cancel();
+                }
+                for (const auto& job : _p->queue)
+                {
+                    job->cancellation->cancel();
+                }
+            }
+            _p->cv.notify_all();
+            if (_p->thread.joinable())
+            {
+                _p->thread.join();
+            }
+        }
+    }
+}

--- a/lib/djv/App/TimelineLoadService.h
+++ b/lib/djv/App/TimelineLoadService.h
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the DJV project.
+
+#pragma once
+
+#include <tlRender/Timeline/Timeline.h>
+
+#include <ftk/Core/Path.h>
+
+#include <cstdint>
+#include <functional>
+#include <future>
+#include <memory>
+#include <string>
+
+namespace ftk { class Context; }
+
+namespace djv
+{
+    namespace app
+    {
+        struct TimelineLoadResult
+        {
+            std::shared_ptr<tl::Timeline> timeline;
+            std::string error;
+            bool cancelled = false;
+        };
+
+        struct TimelineLoadRequest
+        {
+            uint64_t id = 0;
+            std::shared_future<TimelineLoadResult> future;
+
+            explicit operator bool() const
+            {
+                return id && future.valid();
+            }
+        };
+
+        //! Single-owner timeline initialization queue. Work never detaches:
+        //! shutdown cancels the active tlRender reader and joins the worker.
+        class TimelineLoadService
+        {
+        public:
+            using Loader = std::function<std::shared_ptr<tl::Timeline>(
+                const std::shared_ptr<ftk::Context>&,
+                const ftk::Path&,
+                const ftk::Path&,
+                const tl::Options&,
+                const std::shared_ptr<tl::TimelineInitCancellation>&)>;
+
+            explicit TimelineLoadService(const Loader& = Loader());
+            ~TimelineLoadService();
+
+            TimelineLoadService(const TimelineLoadService&) = delete;
+            TimelineLoadService& operator = (const TimelineLoadService&) = delete;
+
+            TimelineLoadRequest request(
+                const std::shared_ptr<ftk::Context>&,
+                const ftk::Path&,
+                const ftk::Path&,
+                const tl::Options&);
+            bool cancel(uint64_t);
+            void shutdown();
+
+        private:
+            struct Private;
+            std::unique_ptr<Private> _p;
+        };
+    }
+}

--- a/lib/djv/Models/FilesModel.cpp
+++ b/lib/djv/Models/FilesModel.cpp
@@ -15,6 +15,7 @@ namespace djv
             std::shared_ptr<ftk::Settings> settings;
 
             std::shared_ptr<ftk::ObservableList<std::shared_ptr<FilesModelItem> > > files;
+            std::shared_ptr<ftk::Observable<std::shared_ptr<FilesModelItem> > > metadata;
             std::shared_ptr<ftk::Observable<std::shared_ptr<FilesModelItem> > > a;
             std::shared_ptr<ftk::Observable<int> > aIndex;
             std::shared_ptr<ftk::ObservableList<std::shared_ptr<FilesModelItem> > > b;
@@ -33,6 +34,7 @@ namespace djv
             p.settings = settings;
 
             p.files = ftk::ObservableList<std::shared_ptr<FilesModelItem> >::create();
+            p.metadata = ftk::Observable<std::shared_ptr<FilesModelItem> >::create();
             p.a = ftk::Observable<std::shared_ptr<FilesModelItem> >::create();
             p.reload = ftk::Observable<std::shared_ptr<FilesModelItem> >::create();
             p.aIndex = ftk::Observable<int>::create();
@@ -83,6 +85,34 @@ namespace djv
         std::shared_ptr<ftk::IObservableList<std::shared_ptr<FilesModelItem> > > FilesModel::observeFiles() const
         {
             return _p->files;
+        }
+
+        std::shared_ptr<ftk::IObservable<std::shared_ptr<FilesModelItem> > >
+            FilesModel::observeMetadata() const
+        {
+            return _p->metadata;
+        }
+
+        void FilesModel::touchMetadata(
+            const std::shared_ptr<FilesModelItem>& value)
+        {
+            FTK_P();
+            const int index = _getIndex(value);
+            if (-1 != index)
+            {
+                if (value->videoLayers.empty())
+                {
+                    value->videoLayer = 0;
+                }
+                else
+                {
+                    value->videoLayer = (std::min)(
+                        value->videoLayer,
+                        value->videoLayers.size() - 1);
+                }
+                p.layers->setIfChanged(_getLayers());
+            }
+            p.metadata->setAlways(value);
         }
 
         const std::shared_ptr<FilesModelItem>& FilesModel::getA() const
@@ -164,6 +194,7 @@ namespace djv
             if (index >= 0 && index < static_cast<int>(files.size()))
             {
                 const int aPrevIndex = _getIndex(p.a->get());
+                const auto removed = files[index];
 
                 files.erase(files.begin() + index);
                 p.files->setIfChanged(files);
@@ -195,6 +226,11 @@ namespace djv
                 p.active->setIfChanged(_getActive());
                 p.layers->setIfChanged(_getLayers());
 
+                if (p.metadata->get() == removed)
+                {
+                    p.metadata->setIfChanged(nullptr);
+                }
+
                 if (files.size() <= 1)
                 {
                     auto compareOptions = p.compareOptions->get();
@@ -218,6 +254,7 @@ namespace djv
 
             p.active->setIfChanged(_getActive());
             p.layers->setIfChanged(_getLayers());
+            p.metadata->setIfChanged(nullptr);
         }
 
         void FilesModel::setA(int index)

--- a/lib/djv/Models/FilesModel.h
+++ b/lib/djv/Models/FilesModel.h
@@ -68,6 +68,14 @@ namespace djv
             //! Observe the files.
             std::shared_ptr<ftk::IObservableList<std::shared_ptr<FilesModelItem> > > observeFiles() const;
 
+            //! Observe metadata changes on an existing file item, such as
+            //! layers becoming available after an asynchronous timeline load.
+            std::shared_ptr<ftk::IObservable<std::shared_ptr<FilesModelItem> > >
+                observeMetadata() const;
+
+            //! Publish metadata changes made to an existing file item.
+            void touchMetadata(const std::shared_ptr<FilesModelItem>&);
+
             //! Get the "A" file.
             const std::shared_ptr<FilesModelItem>& getA() const;
 

--- a/lib/djv/ModelsTest/FilesModelTest.cpp
+++ b/lib/djv/ModelsTest/FilesModelTest.cpp
@@ -66,6 +66,11 @@ namespace djv
             auto filesObserver = ftk::ListObserver<std::shared_ptr<models::FilesModelItem> >::create(
                 model->observeFiles(),
                 [&count](const Items& value) { count = value.size(); });
+            std::shared_ptr<models::FilesModelItem> metadata;
+            auto metadataObserver =
+                ftk::Observer<std::shared_ptr<models::FilesModelItem> >::create(
+                    model->observeMetadata(),
+                    [&metadata](const auto& value) { metadata = value; });
 
             // Empty by default.
             FTK_ASSERT(model->getFiles().empty());
@@ -88,9 +93,18 @@ namespace djv
             FTK_ASSERT(item2 == model->getA());
             FTK_ASSERT(2 == model->getAIndex());
 
+            // Metadata can arrive after the file list notification. Publishing
+            // it clamps stale layer indexes and notifies existing UI rows.
+            item1->videoLayers = { "Beauty", "Depth" };
+            item1->videoLayer = 9;
+            model->touchMetadata(item1);
+            FTK_ASSERT(item1 == metadata);
+            FTK_ASSERT(1 == item1->videoLayer);
+
             // Closing a file removes it and re-clamps the "A" index.
             model->close(1);
             FTK_ASSERT(2 == model->getFiles().size());
+            FTK_ASSERT(!metadata);
 
             // Closing all empties the list and clears the "A" file.
             model->closeAll();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,1 +1,19 @@
 add_subdirectory(djv-test)
+
+add_executable(
+    djvTimelineLoadServiceTest
+    TimelineLoadServiceTest.cpp)
+target_compile_definitions(
+    djvTimelineLoadServiceTest
+    PRIVATE FTK_ASSERT)
+target_include_directories(
+    djvTimelineLoadServiceTest
+    PRIVATE ${PROJECT_SOURCE_DIR}/lib)
+target_link_libraries(djvTimelineLoadServiceTest djvApp)
+set_target_properties(djvTimelineLoadServiceTest PROPERTIES FOLDER tests)
+add_test(
+    NAME djv-timeline-load-service
+    COMMAND djvTimelineLoadServiceTest)
+set_tests_properties(
+    djv-timeline-load-service
+    PROPERTIES LABELS "unit;app;concurrency;cancellation" TIMEOUT 30)

--- a/tests/TimelineLoadServiceTest.cpp
+++ b/tests/TimelineLoadServiceTest.cpp
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the DJV project.
+
+#include <djv/App/TimelineLoadService.h>
+
+#include <ftk/Core/Assert.h>
+
+#include <chrono>
+#include <condition_variable>
+#include <iostream>
+#include <mutex>
+#include <thread>
+
+int main()
+{
+    try
+    {
+        std::mutex mutex;
+        std::condition_variable cv;
+        bool entered = false;
+        djv::app::TimelineLoadService service(
+            [&](const auto&,
+                const auto&,
+                const auto&,
+                const auto&,
+                const auto& cancellation)
+            {
+                {
+                    std::lock_guard<std::mutex> lock(mutex);
+                    entered = true;
+                }
+                cv.notify_one();
+                while (!cancellation->isCancelled())
+                {
+                    std::this_thread::sleep_for(
+                        std::chrono::milliseconds(2));
+                }
+                throw std::runtime_error(
+                    "Synthetic blocked initialization cancelled");
+                return std::shared_ptr<tl::Timeline>();
+            });
+
+        const auto request = service.request(
+            nullptr,
+            ftk::Path("blocked.mov"),
+            ftk::Path(),
+            tl::Options());
+        FTK_ASSERT(request);
+        {
+            std::unique_lock<std::mutex> lock(mutex);
+            FTK_ASSERT(
+                cv.wait_for(
+                    lock,
+                    std::chrono::seconds(2),
+                    [&] { return entered; }));
+        }
+
+        const auto start = std::chrono::steady_clock::now();
+        service.shutdown();
+        const auto elapsed = std::chrono::steady_clock::now() - start;
+        FTK_ASSERT(elapsed < std::chrono::milliseconds(500));
+        FTK_ASSERT(
+            std::future_status::ready ==
+            request.future.wait_for(std::chrono::milliseconds(0)));
+        const auto result = request.future.get();
+        FTK_ASSERT(result.cancelled);
+        FTK_ASSERT(!result.timeline);
+
+        // Shutdown is idempotent and rejects new work.
+        service.shutdown();
+        FTK_ASSERT(!service.request(
+            nullptr,
+            ftk::Path("late.mov"),
+            ftk::Path(),
+            tl::Options()));
+
+        std::cout << "TimelineLoadServiceTest: PASS\n";
+        return 0;
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr <<
+            "TimelineLoadServiceTest: FAIL: " <<
+            e.what() <<
+            '\n';
+        return 1;
+    }
+}


### PR DESCRIPTION
## Summary
- move media and timeline initialization off the UI thread into an owned single-worker service
- cancel active and queued loads when files are closed, reloaded, or the application exits
- join the worker during shutdown instead of detaching background work
- publish asynchronously discovered layer metadata to existing menus and file widgets
- preserve command-line playback options after the asynchronous player becomes available
- add a focused shutdown/cancellation test and metadata notification coverage

## Dependency
This is a stacked draft and depends on grizzlypeak3d/tlRender#151, which provides the optional timeline-initialization cancellation handle used here.

## Testing
- CMake configure: Visual Studio 2022 / x64 / Release with the tlRender dependency branch
- `djvApp`, `djvModelsTest`, and `djvTimelineLoadServiceTest` translation units compiled successfully
- `git diff --check` passed

The test executable is intentionally left to clean CI after the tlRender dependency lands; the local link cannot use the new API from the currently installed tlRender library.