### PR TITLE
Compact media information beside playback controls

### DIFF
--- a/lib/djv/App/MainWindow.cpp
+++ b/lib/djv/App/MainWindow.cpp
@@ -109,6 +109,7 @@ namespace djv
             std::shared_ptr<TabBar> tabBar;
             std::shared_ptr<BottomToolBar> bottomToolBar;
             std::shared_ptr<StatusBar> statusBar;
+            std::shared_ptr<ftk::HorizontalLayout> bottomRow;
             std::shared_ptr<ToolsWidget> toolsWidget;
             std::shared_ptr<ui::SetupDialog> setupDialog;
             std::shared_ptr<ui::AboutDialog> aboutDialog;
@@ -293,9 +294,15 @@ namespace djv
             p.toolsWidget->setParent(p.splitter2);
             p.timelineWidget->setParent(p.splitter);
             p.dividers["Bottom"] = ftk::Divider::create(context, ftk::Orientation::Vertical, p.layout);
-            p.bottomToolBar->setParent(p.layout);
-            p.dividers["Status"] = ftk::Divider::create(context, ftk::Orientation::Vertical, p.layout);
-            p.statusBar->setParent(p.layout);
+            p.bottomRow = ftk::HorizontalLayout::create(context, p.layout);
+            p.bottomRow->setSpacingRole(ftk::SizeRole::None);
+            ftk::setScreenshotTag(p.bottomRow, "MainWindow.BottomRow");
+            p.bottomToolBar->setParent(p.bottomRow);
+            p.dividers["BottomStatus"] = ftk::Divider::create(
+                context,
+                ftk::Orientation::Horizontal,
+                p.bottomRow);
+            p.statusBar->setParent(p.bottomRow);
 
             auto miscSettings = app->getSettingsModel()->getMisc();
             if (miscSettings.showSetup && !app->getHideSetup())
@@ -656,11 +663,17 @@ namespace djv
 
                 p.timelineWidget->setVisible(settings.timeline && !presentMode);
 
-                p.bottomToolBar->setVisible(settings.bottomToolBar && !presentMode);
-                p.dividers["Bottom"]->setVisible(settings.bottomToolBar && !presentMode);
-
-                p.statusBar->setVisible(settings.statusToolBar && !presentMode);
-                p.dividers["Status"]->setVisible(settings.statusToolBar && !presentMode);
+                const bool bottomVisible =
+                    settings.bottomToolBar && !presentMode;
+                const bool statusVisible =
+                    settings.statusToolBar && !presentMode;
+                p.bottomToolBar->setVisible(bottomVisible);
+                p.statusBar->setVisible(statusVisible);
+                p.dividers["BottomStatus"]->setVisible(
+                    bottomVisible && statusVisible);
+                p.bottomRow->setVisible(bottomVisible || statusVisible);
+                p.dividers["Bottom"]->setVisible(
+                    bottomVisible || statusVisible);
             }
         }
     }

--- a/lib/djv/App/StatusBar.cpp
+++ b/lib/djv/App/StatusBar.cpp
@@ -11,14 +11,18 @@
 #include <djv/Models/ViewportModel.h>
 
 #include <ftk/UI/Divider.h>
+#include <ftk/UI/IWindow.h>
 #include <ftk/UI/Label.h>
 #include <ftk/UI/RowLayout.h>
+#include <ftk/UI/ScreenshotTag.h>
 #include <ftk/UI/SysLogModel.h>
 #include <ftk/UI/ToolButton.h>
 #include <ftk/Core/Context.h>
 #include <ftk/Core/Format.h>
 #include <ftk/Core/String.h>
 #include <ftk/Core/Timer.h>
+
+#include <algorithm>
 
 namespace djv
 {
@@ -36,9 +40,11 @@ namespace djv
             bool lutEnabled = false;
             bool colorEnabled = false;
             bool audioOffsetEnabled = false;
+            bool compactInfo = false;
 
             std::shared_ptr<ftk::Label> messagesLabel;
             std::shared_ptr<ftk::Label> infoLabel;
+            std::shared_ptr<ftk::ToolButton> infoButton;
             std::shared_ptr<ftk::ToolButton> indicatorButton;
             std::shared_ptr<ui::StatusIndicatorPopup> indicatorPopup;
             std::shared_ptr<ftk::HorizontalLayout> layout;
@@ -86,6 +92,18 @@ namespace djv
             p.infoLabel = ftk::Label::create(context);
             p.infoLabel->setMarginRole(ftk::SizeRole::MarginSmall, ftk::SizeRole::MarginInside);
             p.infoLabel->setClipText(true);
+            ftk::setScreenshotTag(p.infoLabel, "StatusBar.MediaInfo");
+
+            p.infoButton = ftk::ToolButton::create(context);
+            p.infoButton->setIcon("Info");
+            p.infoButton->setTooltip(
+                "Display information about the current file.\n"
+                "\n"
+                "Click to open the information tool.");
+            p.infoButton->setVisible(false);
+            ftk::setScreenshotTag(
+                p.infoButton,
+                "StatusBar.MediaInfoButton");
 
             p.indicatorButton = ftk::ToolButton::create(context);
             p.indicatorButton->setIcon("MenuChecked");
@@ -99,6 +117,7 @@ namespace djv
             p.messagesLabel->setParent(p.layout);
             ftk::Divider::create(context, ftk::Orientation::Horizontal, p.layout);
             p.infoLabel->setParent(p.layout);
+            p.infoButton->setParent(p.layout);
             ftk::Divider::create(context, ftk::Orientation::Horizontal, p.layout);
             p.indicatorButton->setParent(p.layout);
 
@@ -214,6 +233,12 @@ namespace djv
                 {
                     _showIndicatorPopup();
                 });
+
+            p.infoButton->setPressedCallback(
+                [this]
+                {
+                    _toggleTool("Information");
+                });
         }
 
         StatusBar::StatusBar() :
@@ -241,7 +266,31 @@ namespace djv
         void StatusBar::setGeometry(const ftk::Box2I & value)
         {
             IMouseWidget::setGeometry(value);
-            _p->layout->setGeometry(value);
+            FTK_P();
+            float displayScale = 1.F;
+            if (auto window = getWindow())
+            {
+                displayScale = window->getDisplayScale();
+            }
+            const int messageReserve =
+                std::max(1, static_cast<int>(180.F * displayScale));
+            const int infoLimit =
+                std::max(1, static_cast<int>(480.F * displayScale));
+            const int infoWidth = std::min(
+                infoLimit,
+                p.infoLabel->getSizeHint().w);
+            const int fixedWidth =
+                p.indicatorButton->getSizeHint().w +
+                std::max(1, static_cast<int>(32.F * displayScale));
+            const bool compactInfo =
+                value.w() < messageReserve + infoWidth + fixedWidth;
+            if (compactInfo != p.compactInfo)
+            {
+                p.compactInfo = compactInfo;
+                p.infoLabel->setVisible(!compactInfo);
+                p.infoButton->setVisible(compactInfo);
+            }
+            p.layout->setGeometry(value);
         }
 
         void StatusBar::mousePressEvent(ftk::MouseClickEvent& event)
@@ -260,18 +309,15 @@ namespace djv
             {
                 tool = "Messages";
             }
-            else if (ftk::contains(p.infoLabel->getGeometry(), event.pos))
+            else if (
+                p.infoLabel->isVisible(false) &&
+                ftk::contains(p.infoLabel->getGeometry(), event.pos))
             {
-                tool = "Infofrmation";
+                tool = "Information";
             }
             if (!tool.empty())
             {
-                if (auto app = p.app.lock())
-                {
-                    auto toolsModel = app->getToolsModel();
-                    const auto active = toolsModel->getActiveTool();
-                    toolsModel->setActiveTool(tool != active ? tool : std::string());
-                }
+                _toggleTool(tool);
             }
         }
 
@@ -374,8 +420,22 @@ namespace djv
                     arg(tl::getLabel(info.audio))));
             }
             const std::string tooltip = ftk::join(s, "\n");
-            p.infoLabel->setTooltip(ftk::Format(tooltipFormat).
-                arg(!tooltip.empty() ? tooltip : tooltipDefault));
+            const std::string tooltipText = ftk::Format(tooltipFormat).
+                arg(!tooltip.empty() ? tooltip : tooltipDefault);
+            p.infoLabel->setTooltip(tooltipText);
+            p.infoButton->setTooltip(tooltipText);
+        }
+
+        void StatusBar::_toggleTool(const std::string& tool)
+        {
+            FTK_P();
+            if (auto app = p.app.lock())
+            {
+                auto toolsModel = app->getToolsModel();
+                const auto active = toolsModel->getActiveTool();
+                toolsModel->setActiveTool(
+                    tool != active ? tool : std::string());
+            }
         }
 
         void StatusBar::_showIndicatorPopup()

--- a/lib/djv/App/StatusBar.h
+++ b/lib/djv/App/StatusBar.h
@@ -50,6 +50,7 @@ namespace djv
             
         private:
             void _infoUpdate(const ftk::Path&, const tl::IOInfo&);
+            void _toggleTool(const std::string&);
             void _showIndicatorPopup();
 
             FTK_PRIVATE();


### PR DESCRIPTION
## Summary

- place media information beside the playback controls in the bottom row
- reserve horizontal space for messages and errors
- collapse media details to an information icon when the window is narrow
- preserve the detailed tooltip and the click action that opens the Information tool

## Why

The media information currently occupies a separate full-width row. Keeping it beside the playback controls reduces vertical space while retaining access to the complete information in constrained windows.

## Validation

- `git diff --check`
- all modified `djvApp` sources compile with MSVC in Release mode
- verified that the compact icon keeps the detailed tooltip and Information tool callback

A complete local build is currently blocked in the unmodified tlRender submodule by an `ItemOptions.cpp` / OpenTimelineIO API mismatch; the modified DJV sources compile successfully.