### PR TITLE
Add full-screen playback overlay controls

### DIFF
--- a/etc/Icons/PlaybackFullScreen.svg
+++ b/etc/Icons/PlaybackFullScreen.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="20"
+    height="20"
+    viewBox="0 0 20 20">
+  <path
+      fill="#f0f0f0"
+      d="M2 8V2h6v2H4v4H2zm10-6h6v6h-2V4h-4V2zM2 12h2v4h4v2H2v-6zm14 0h2v6h-6v-2h4v-4z"/>
+</svg>

--- a/etc/Icons/PlaybackPin.svg
+++ b/etc/Icons/PlaybackPin.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="20"
+    height="20"
+    viewBox="0 0 20 20">
+  <path
+      fill="#f0f0f0"
+      d="M7 2h6l-1 5 3 3v2h-4v6l-1 1-1-1v-6H5v-2l3-3-1-5zm2.35 2 .65 3.27L7.27 10h5.46L10 7.27 10.65 4h-1.3z"/>
+</svg>

--- a/lib/djv/App/BottomToolBar.cpp
+++ b/lib/djv/App/BottomToolBar.cpp
@@ -19,6 +19,7 @@
 #include <tlRender/Timeline/Player.h>
 
 #include <ftk/UI/DoubleModel.h>
+#include <ftk/UI/IconSystem.h>
 #include <ftk/UI/Label.h>
 #include <ftk/UI/RowLayout.h>
 #include <ftk/UI/ScreenshotTag.h>
@@ -26,6 +27,14 @@
 #include <ftk/UI/Spacer.h>
 #include <ftk/UI/ToolButton.h>
 #include <ftk/Core/Format.h>
+
+#include <vector>
+
+namespace djv_resource
+{
+    extern std::vector<uint8_t> PlaybackFullScreen;
+    extern std::vector<uint8_t> PlaybackPin;
+}
 
 namespace djv
 {
@@ -51,6 +60,8 @@ namespace djv
             std::shared_ptr<ftk::ToolButton> audioButton;
             std::shared_ptr<ui::AudioPopup> audioPopup;
             std::shared_ptr<ftk::HorizontalLayout> layout;
+            std::function<void(bool)> fullScreenCallback;
+            std::function<void(bool)> pinCallback;
 
             std::shared_ptr<ftk::Observer<std::shared_ptr<tl::Player> > > playerObserver;
             std::shared_ptr<ftk::Observer<double> > speedObserver;
@@ -79,6 +90,12 @@ namespace djv
 
             p.app = app;
 
+            auto iconSystem = context->getSystem<ftk::IconSystem>();
+            iconSystem->add(
+                "PlaybackFullScreen",
+                djv_resource::PlaybackFullScreen);
+            iconSystem->add("PlaybackPin", djv_resource::PlaybackPin);
+
             p.speedModel = ftk::DoubleModel::create();
             p.speedModel->setRange(ftk::RangeD(0.0, 1000000.0));
             p.speedModel->setStep(1.F);
@@ -88,6 +105,23 @@ namespace djv
             p.buttons["Stop"] = ftk::ToolButton::create(context, actions["Stop"]);
             p.buttons["Forward"] = ftk::ToolButton::create(context, actions["Forward"]);
             p.buttons["Reverse"] = ftk::ToolButton::create(context, actions["Reverse"]);
+            p.buttons["FullScreen"] = ftk::ToolButton::create(context);
+            p.buttons["FullScreen"]->setIcon("PlaybackFullScreen");
+            p.buttons["FullScreen"]->setCheckable(true);
+            p.buttons["FullScreen"]->setTooltip(
+                "Toggle full-screen playback. Double-clicking the video does the same.");
+            ftk::setScreenshotTag(
+                p.buttons["FullScreen"],
+                "Playback.FullScreen");
+            p.buttons["Pin"] = ftk::ToolButton::create(context);
+            p.buttons["Pin"]->setIcon("PlaybackPin");
+            p.buttons["Pin"]->setCheckable(true);
+            p.buttons["Pin"]->setTooltip(
+                "Keep the playback controls visible in full-screen.");
+            p.buttons["Pin"]->setVisible(false);
+            ftk::setScreenshotTag(
+                p.buttons["Pin"],
+                "Playback.Pin");
 
             p.loopWidget = tl::ui::PlaybackLoopWidget::create(context);
             ftk::setScreenshotTag(p.loopWidget, "Playback.Loop");
@@ -148,6 +182,8 @@ namespace djv
             p.buttons["Reverse"]->setParent(hLayout2);
             p.buttons["Stop"]->setParent(hLayout2);
             p.buttons["Forward"]->setParent(hLayout2);
+            p.buttons["FullScreen"]->setParent(hLayout2);
+            p.buttons["Pin"]->setParent(hLayout2);
             p.loopWidget->setParent(hLayout2);
             p.playbackShuttle->setParent(hLayout2);
             hLayout2 = ftk::HorizontalLayout::create(context, hLayout);
@@ -254,6 +290,26 @@ namespace djv
                     _showAudioPopup();
                 });
 
+            p.buttons["FullScreen"]->setCheckedCallback(
+                [this](bool value)
+                {
+                    FTK_P();
+                    if (p.fullScreenCallback)
+                    {
+                        p.fullScreenCallback(value);
+                    }
+                });
+
+            p.buttons["Pin"]->setCheckedCallback(
+                [this](bool value)
+                {
+                    FTK_P();
+                    if (p.pinCallback)
+                    {
+                        p.pinCallback(value);
+                    }
+                });
+
             p.playerObserver = ftk::Observer<std::shared_ptr<tl::Player> >::create(
                 app->observePlayer(),
                 [this](const std::shared_ptr<tl::Player>& value)
@@ -317,6 +373,34 @@ namespace djv
                 _p->currentTimeEdit->takeKeyFocus();
                 _p->currentTimeEdit->selectAll();
             }
+        }
+
+        void BottomToolBar::setFullScreen(bool value)
+        {
+            FTK_P();
+            p.buttons["FullScreen"]->setChecked(value);
+            p.buttons["Pin"]->setVisible(value);
+            if (!value)
+            {
+                setPinned(false);
+            }
+        }
+
+        void BottomToolBar::setPinned(bool value)
+        {
+            _p->buttons["Pin"]->setChecked(value);
+        }
+
+        void BottomToolBar::setFullScreenCallback(
+            const std::function<void(bool)>& value)
+        {
+            _p->fullScreenCallback = value;
+        }
+
+        void BottomToolBar::setPinCallback(
+            const std::function<void(bool)>& value)
+        {
+            _p->pinCallback = value;
         }
 
         ftk::Size2I BottomToolBar::getSizeHint() const

--- a/lib/djv/App/BottomToolBar.h
+++ b/lib/djv/App/BottomToolBar.h
@@ -7,6 +7,8 @@
 
 #include <ftk/UI/IWidget.h>
 
+#include <functional>
+
 namespace djv
 {
     namespace app
@@ -45,6 +47,18 @@ namespace djv
 
             //! Focus the current frame widget.
             void focusCurrentFrame();
+
+            //! Set whether playback full-screen is active.
+            void setFullScreen(bool);
+
+            //! Set whether the full-screen playback bar is pinned.
+            void setPinned(bool);
+
+            //! Set the playback full-screen callback.
+            void setFullScreenCallback(const std::function<void(bool)>&);
+
+            //! Set the playback bar pin callback.
+            void setPinCallback(const std::function<void(bool)>&);
 
             ftk::Size2I getSizeHint() const override;
             void setGeometry(const ftk::Box2I&) override;

--- a/lib/djv/App/CMakeLists.txt
+++ b/lib/djv/App/CMakeLists.txt
@@ -31,6 +31,7 @@ set(HEADERS
     MessagesTool.h
     PlaybackActions.h
     PlaybackMenu.h
+    PlaybackUIState.h
     SecondaryWindow.h
     SettingsTool.h
     StatusBar.h
@@ -85,6 +86,7 @@ set(SOURCE
     MessagesTool.cpp
     PlaybackActions.cpp
     PlaybackMenu.cpp
+    PlaybackUIState.cpp
     SecondaryWindow.cpp
     SettingsTool.cpp
     StatusBar.cpp

--- a/lib/djv/App/MainWindow.cpp
+++ b/lib/djv/App/MainWindow.cpp
@@ -21,6 +21,7 @@
 #include <djv/App/HelpMenu.h>
 #include <djv/App/PlaybackActions.h>
 #include <djv/App/PlaybackMenu.h>
+#include <djv/App/PlaybackUIState.h>
 #include <djv/App/StatusBar.h>
 #include <djv/App/TabBar.h>
 #include <djv/App/TimelineActions.h>
@@ -50,6 +51,7 @@
 
 #include <ftk/UI/ButtonGroup.h>
 #include <ftk/UI/Divider.h>
+#include <ftk/UI/DrawUtil.h>
 #include <ftk/UI/IconSystem.h>
 #include <ftk/UI/Label.h>
 #include <ftk/UI/Menu.h>
@@ -59,6 +61,11 @@
 #include <ftk/UI/Splitter.h>
 #include <ftk/UI/ToolButton.h>
 #include <ftk/Core/Format.h>
+#include <ftk/Core/Timer.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
 
 namespace djv_resource
 {
@@ -100,6 +107,118 @@ namespace djv
                         return out;
                     };
             }
+
+            class PlaybackProgressWidget : public ftk::IWidget
+            {
+            protected:
+                void _init(
+                    const std::shared_ptr<ftk::Context>& context,
+                    const std::shared_ptr<ftk::IWidget>& parent)
+                {
+                    IWidget::_init(
+                        context,
+                        "djv::app::PlaybackProgressWidget",
+                        parent);
+                    setHStretch(ftk::Stretch::Expanding);
+                    setTooltip(
+                        "Current position in the complete media duration.");
+                }
+
+                PlaybackProgressWidget() = default;
+
+            public:
+                static std::shared_ptr<PlaybackProgressWidget> create(
+                    const std::shared_ptr<ftk::Context>& context,
+                    const std::shared_ptr<ftk::IWidget>& parent = nullptr)
+                {
+                    auto out = std::shared_ptr<PlaybackProgressWidget>(
+                        new PlaybackProgressWidget);
+                    out->_init(context, parent);
+                    return out;
+                }
+
+                void setPlayer(const std::shared_ptr<tl::Player>& player)
+                {
+                    _currentTimeObserver.reset();
+                    _timeRange = player ?
+                        player->getTimeRange() :
+                        tl::invalidTimeRange;
+                    if (player)
+                    {
+                        _setCurrentTime(player->getCurrentTime());
+                        _currentTimeObserver =
+                            ftk::Observer<OTIO_NS::RationalTime>::create(
+                                player->observeCurrentTime(),
+                                [this](const OTIO_NS::RationalTime& value)
+                                {
+                                    _setCurrentTime(value);
+                                });
+                    }
+                    else
+                    {
+                        _progress = 0.0;
+                        setDrawUpdate();
+                    }
+                }
+
+                ftk::Size2I getSizeHint() const override
+                {
+                    return ftk::Size2I(1, _height);
+                }
+
+                void sizeHintEvent(
+                    const ftk::SizeHintEvent& event) override
+                {
+                    IWidget::sizeHintEvent(event);
+                    _height = std::max(
+                        2,
+                        static_cast<int>(
+                            std::round(2.F * event.displayScale)));
+                }
+
+                void drawEvent(
+                    const ftk::Box2I& drawRect,
+                    const ftk::DrawEvent& event) override
+                {
+                    IWidget::drawEvent(drawRect, event);
+                    const ftk::Box2I& g = getGeometry();
+                    event.render->drawRect(
+                        g,
+                        event.style->getColorRole(ftk::ColorRole::Base));
+                    const int width = std::clamp(
+                        static_cast<int>(std::round(_progress * g.w())),
+                        0,
+                        g.w());
+                    if (width > 0)
+                    {
+                        event.render->drawRect(
+                            ftk::Box2I(g.x(), g.y(), width, g.h()),
+                            event.style->getColorRole(ftk::ColorRole::Red));
+                    }
+                }
+
+            private:
+                void _setCurrentTime(
+                    const OTIO_NS::RationalTime& value)
+                {
+                    const double progress = getPlaybackProgress(
+                        value.rescaled_to(1.0).value(),
+                        _timeRange.start_time().rescaled_to(1.0).value(),
+                        _timeRange.duration().rescaled_to(1.0).value());
+                    if (progress != _progress)
+                    {
+                        _progress = progress;
+                        setDrawUpdate();
+                    }
+                }
+
+                int _height = 2;
+                double _progress = 0.0;
+                OTIO_NS::TimeRange _timeRange = tl::invalidTimeRange;
+                std::shared_ptr<
+                    ftk::Observer<OTIO_NS::RationalTime> >
+                    _currentTimeObserver;
+            };
         }
 
         struct MainWindow::Private
@@ -142,6 +261,16 @@ namespace djv
             std::shared_ptr<TabBar> tabBar;
             std::shared_ptr<BottomToolBar> bottomToolBar;
             std::shared_ptr<StatusBar> statusBar;
+            std::shared_ptr<PlaybackProgressWidget> playbackProgress;
+            std::shared_ptr<ftk::VerticalLayout> playbackBar;
+            std::shared_ptr<ftk::HorizontalLayout> playbackRow;
+            std::shared_ptr<ftk::VerticalLayout> normalBottomContainer;
+            std::shared_ptr<ftk::VerticalLayout> normalStatusContainer;
+            std::shared_ptr<ftk::VerticalLayout> overlayBottomContainer;
+            std::shared_ptr<ftk::VerticalLayout> overlayStatusContainer;
+            std::shared_ptr<ftk::Divider> playbackStatusDivider;
+            PlaybackOverlayState playbackOverlayState;
+            std::shared_ptr<ftk::Timer> playbackOverlayTimer;
             std::shared_ptr<ToolsWidget> toolsWidget;
             std::shared_ptr<ui::SetupDialog> setupDialog;
             std::shared_ptr<ui::AboutDialog> aboutDialog;
@@ -162,6 +291,7 @@ namespace djv
             std::shared_ptr<ftk::Observer<models::TimelineSettings> > timelineSettingsObserver;
             std::shared_ptr<ftk::Observer<bool> > timelineFrameViewObserver;
             std::shared_ptr<ftk::Observer<models::WindowSettings> > windowSettingsObserver;
+            std::shared_ptr<ftk::Observer<bool> > fullScreenObserver;
         };
 
         void MainWindow::_init(
@@ -289,6 +419,52 @@ namespace djv
             p.statusBar = app->createStatusBar();
             ftk::setScreenshotTag(p.statusBar, "MainWindow.StatusBar");
 
+            const auto playbackWindowWeak = std::weak_ptr<MainWindow>(
+                std::dynamic_pointer_cast<MainWindow>(
+                    shared_from_this()));
+            p.bottomToolBar->setFullScreenCallback(
+                [playbackWindowWeak](bool value)
+                {
+                    if (auto window = playbackWindowWeak.lock())
+                    {
+                        window->setFullScreen(value);
+                    }
+                });
+            p.bottomToolBar->setPinCallback(
+                [playbackWindowWeak](bool value)
+                {
+                    if (auto window = playbackWindowWeak.lock())
+                    {
+                        window->_setPlaybackPinned(value);
+                    }
+                });
+            p.viewport->setFullScreenCallback(
+                [playbackWindowWeak]
+                {
+                    if (auto window = playbackWindowWeak.lock())
+                    {
+                        if (window->hasPresentMode())
+                        {
+                            window->setPresentMode(false);
+                        }
+                        else
+                        {
+                            window->setFullScreen(
+                                !window->isFullScreen());
+                        }
+                    }
+                });
+            p.viewport->setMouseActivityCallback(
+                [playbackWindowWeak]
+                {
+                    if (auto window = playbackWindowWeak.lock())
+                    {
+                        window->_playbackActivity();
+                    }
+                });
+            p.playbackOverlayTimer = ftk::Timer::create(context);
+            p.playbackOverlayTimer->setRepeating(true);
+
             p.toolsWidget = ToolsWidget::create(
                 context,
                 app,
@@ -326,9 +502,54 @@ namespace djv
             p.toolsWidget->setParent(p.splitter2);
             p.timelineWidget->setParent(p.splitter);
             p.dividers["Bottom"] = ftk::Divider::create(context, ftk::Orientation::Vertical, p.layout);
-            p.bottomToolBar->setParent(p.layout);
+            p.normalBottomContainer = ftk::VerticalLayout::create(
+                context,
+                p.layout);
+            p.normalBottomContainer->setSpacingRole(ftk::SizeRole::None);
+            p.bottomToolBar->setParent(p.normalBottomContainer);
             p.dividers["Status"] = ftk::Divider::create(context, ftk::Orientation::Vertical, p.layout);
-            p.statusBar->setParent(p.layout);
+            p.normalStatusContainer = ftk::VerticalLayout::create(
+                context,
+                p.layout);
+            p.normalStatusContainer->setSpacingRole(ftk::SizeRole::None);
+            p.statusBar->setParent(p.normalStatusContainer);
+
+            p.playbackBar = ftk::VerticalLayout::create(
+                context);
+            p.playbackBar->setSpacingRole(ftk::SizeRole::None);
+            p.playbackBar->setBackgroundRole(ftk::ColorRole::Window);
+            ftk::setScreenshotTag(
+                p.playbackBar,
+                "MainWindow.PlaybackBar");
+
+            p.playbackProgress = PlaybackProgressWidget::create(
+                context,
+                p.playbackBar);
+            p.playbackProgress->setVisible(false);
+            ftk::setScreenshotTag(
+                p.playbackProgress,
+                "Playback.FullScreenProgress");
+
+            p.playbackRow = ftk::HorizontalLayout::create(
+                context,
+                p.playbackBar);
+            p.playbackRow->setSpacingRole(ftk::SizeRole::None);
+            ftk::setScreenshotTag(
+                p.playbackRow,
+                "MainWindow.FullScreenPlaybackRow");
+            p.overlayBottomContainer = ftk::VerticalLayout::create(
+                context,
+                p.playbackRow);
+            p.overlayBottomContainer->setSpacingRole(ftk::SizeRole::None);
+            p.overlayBottomContainer->setHStretch(ftk::Stretch::Expanding);
+            p.playbackStatusDivider = ftk::Divider::create(
+                context,
+                ftk::Orientation::Horizontal,
+                p.playbackRow);
+            p.overlayStatusContainer = ftk::VerticalLayout::create(
+                context,
+                p.playbackRow);
+            p.overlayStatusContainer->setSpacingRole(ftk::SizeRole::None);
 
             // Each context menu offers the band it belongs to, and only
             // that band; the Window menu remains the one place that lists
@@ -413,6 +634,7 @@ namespace djv
                     FTK_P();
                     p.viewport->setPlayer(player);
                     p.timelineWidget->setPlayer(player);
+                    p.playbackProgress->setPlayer(player);
                 });
 
             p.compareOptionsObserver = ftk::Observer<tl::CompareOptions>::create(
@@ -484,8 +706,15 @@ namespace djv
             p.windowSettingsObserver = ftk::Observer<models::WindowSettings>::create(
                 p.settingsModel->observeWindow(),
                 [this](const models::WindowSettings&)
+                    {
+                        _windowUpdate();
+                    });
+
+            p.fullScreenObserver = ftk::Observer<bool>::create(
+                observeFullScreen(),
+                [this](bool value)
                 {
-                    _windowUpdate();
+                    _fullScreenUpdate(value);
                 });
         }
 
@@ -497,6 +726,7 @@ namespace djv
         {
             FTK_P();
 
+            p.playbackOverlayTimer->stop();
             _makeCurrent();
             p.viewport->setParent(nullptr);
             p.viewport.reset();
@@ -578,6 +808,7 @@ namespace djv
                     app->getViewportModel()->setHUDOptions(options);
                 }
                 setFullScreen(value);
+                _fullScreenUpdate(isFullScreen());
                 _windowUpdate();
             }
         }
@@ -622,17 +853,35 @@ namespace djv
             FTK_P();
             p.shown = true;
             p.layout->setGeometry(value);
+            if (p.playbackOverlayState.isFullScreen())
+            {
+                _playbackOverlayUpdate();
+            }
         }
 
         void MainWindow::keyPressEvent(ftk::KeyEvent& event)
         {
             FTK_P();
             if (0 == event.modifiers &&
-                ftk::Key::Escape == event.key &&
-                p.presentMode->get())
+                ftk::Key::Escape == event.key)
             {
-                event.accept = true;
-                setPresentMode(false);
+                if (p.presentMode->get())
+                {
+                    event.accept = true;
+                    setPresentMode(false);
+                }
+                else if (isFullScreen())
+                {
+                    event.accept = true;
+                    setFullScreen(false);
+                }
+                else
+                {
+                    event.accept =
+                        p.menuBar->shortcut(
+                            event.key,
+                            event.modifiers);
+                }
             }
             else
             {
@@ -706,6 +955,131 @@ namespace djv
             }
         }
 
+        void MainWindow::_fullScreenUpdate(bool value)
+        {
+            FTK_P();
+            const bool playbackFullScreen =
+                value && !p.presentMode->get();
+            const auto now = PlaybackOverlayState::Clock::now();
+            p.playbackOverlayState.setFullScreen(
+                playbackFullScreen,
+                now);
+            p.bottomToolBar->setFullScreen(playbackFullScreen);
+            p.playbackProgress->setVisible(playbackFullScreen);
+
+            if (playbackFullScreen)
+            {
+                if (p.bottomToolBar->getParent() !=
+                    p.overlayBottomContainer)
+                {
+                    p.bottomToolBar->setParent(
+                        p.overlayBottomContainer);
+                }
+                if (p.statusBar->getParent() !=
+                    p.overlayStatusContainer)
+                {
+                    p.statusBar->setParent(
+                        p.overlayStatusContainer);
+                }
+                if (p.playbackBar->getParent() !=
+                    std::dynamic_pointer_cast<ftk::IWidget>(
+                        shared_from_this()))
+                {
+                    p.playbackBar->setParent(shared_from_this());
+                }
+                p.playbackOverlayTimer->start(
+                    std::chrono::milliseconds(16),
+                    [this](
+                        const std::chrono::steady_clock::time_point& now,
+                        const std::chrono::microseconds&)
+                    {
+                        _p->playbackOverlayState.tick(now);
+                        _playbackOverlayUpdate();
+                    });
+            }
+            else
+            {
+                p.playbackOverlayTimer->stop();
+                if (p.bottomToolBar->getParent() !=
+                    p.normalBottomContainer)
+                {
+                    p.bottomToolBar->setParent(
+                        p.normalBottomContainer);
+                }
+                if (p.statusBar->getParent() !=
+                    p.normalStatusContainer)
+                {
+                    p.statusBar->setParent(
+                        p.normalStatusContainer);
+                }
+                if (p.playbackBar->getParent())
+                {
+                    p.playbackBar->setParent(nullptr);
+                }
+            }
+
+            _windowUpdate();
+            setGeometry(getGeometry());
+        }
+
+        void MainWindow::_playbackActivity()
+        {
+            FTK_P();
+            if (p.playbackOverlayState.isFullScreen())
+            {
+                p.playbackOverlayState.activity(
+                    PlaybackOverlayState::Clock::now());
+                p.playbackBar->setVisible(true);
+                _playbackOverlayUpdate();
+            }
+        }
+
+        void MainWindow::_playbackOverlayUpdate()
+        {
+            FTK_P();
+            if (!p.playbackOverlayState.isFullScreen())
+            {
+                return;
+            }
+
+            const auto now = PlaybackOverlayState::Clock::now();
+            const double visibility =
+                p.playbackOverlayState.getVisibility();
+            const bool visible =
+                visibility > .0001 ||
+                p.playbackOverlayState.wantsVisible(now);
+            p.playbackBar->setVisible(visible);
+            if (visible)
+            {
+                const ftk::Box2I& g = getGeometry();
+                const int height = std::max(
+                    1,
+                    p.playbackBar->getSizeHint().h);
+                const int y =
+                    g.y() +
+                    g.h() -
+                    static_cast<int>(
+                        std::round(height * visibility));
+                p.playbackBar->setGeometry(
+                    ftk::Box2I(
+                        g.x(),
+                        y,
+                        g.w(),
+                        height));
+                moveToFront(p.playbackBar);
+            }
+        }
+
+        void MainWindow::_setPlaybackPinned(bool value)
+        {
+            FTK_P();
+            const auto now = PlaybackOverlayState::Clock::now();
+            p.playbackOverlayState.setPinned(value, now);
+            p.bottomToolBar->setPinned(
+                p.playbackOverlayState.isPinned());
+            _playbackActivity();
+        }
+
         void MainWindow::_windowUpdate()
         {
             FTK_P();
@@ -713,44 +1087,78 @@ namespace djv
             {
                 auto settings = p.settingsModel->getWindow();
                 const bool presentMode = p.presentMode->get();
+                const bool playbackFullScreen =
+                    isFullScreen() && !presentMode;
+                const bool focusMode =
+                    presentMode || playbackFullScreen;
 
-                p.menuBar->setVisible(!presentMode);
-                p.dividers["MenuBar"]->setVisible(!presentMode);
+                p.menuBar->setVisible(!focusMode);
+                p.dividers["MenuBar"]->setVisible(!focusMode);
 
-                p.fileToolBar->setVisible(settings.fileToolBar && !presentMode);
-                p.dividers["File"]->setVisible(settings.fileToolBar && !presentMode);
+                p.fileToolBar->setVisible(settings.fileToolBar && !focusMode);
+                p.dividers["File"]->setVisible(settings.fileToolBar && !focusMode);
 
-                p.compareToolBar->setVisible(settings.compareToolBar && !presentMode);
-                p.dividers["Compare"]->setVisible(settings.compareToolBar && !presentMode);
+                p.compareToolBar->setVisible(settings.compareToolBar && !focusMode);
+                p.dividers["Compare"]->setVisible(settings.compareToolBar && !focusMode);
 
-                p.windowToolBar->setVisible(settings.windowToolBar && !presentMode);
-                p.dividers["Window"]->setVisible(settings.windowToolBar && !presentMode);
+                p.windowToolBar->setVisible(settings.windowToolBar && !focusMode);
+                p.dividers["Window"]->setVisible(settings.windowToolBar && !focusMode);
 
-                p.viewToolBar->setVisible(settings.viewToolBar && !presentMode);
-                p.dividers["View"]->setVisible(settings.viewToolBar && !presentMode);
+                p.viewToolBar->setVisible(settings.viewToolBar && !focusMode);
+                p.dividers["View"]->setVisible(settings.viewToolBar && !focusMode);
 
-                p.toolsToolBar->setVisible(settings.toolsToolBar && !presentMode);
+                p.toolsToolBar->setVisible(settings.toolsToolBar && !focusMode);
 
                 p.dividers["ToolBars"]->setVisible(
                     (settings.fileToolBar ||
                     settings.compareToolBar ||
                     settings.windowToolBar ||
                     settings.viewToolBar ||
-                    settings.toolsToolBar) && !presentMode);
+                    settings.toolsToolBar) && !focusMode);
 
-                p.tabBar->setVisible(settings.tabBar && !presentMode);
+                p.tabBar->setVisible(settings.tabBar && !focusMode);
 
                 p.toolsWidget->setVisible(
                     !app->getToolsModel()->getActiveTool().empty() &&
-                    !presentMode);
+                    !focusMode);
 
-                p.timelineWidget->setVisible(settings.timeline && !presentMode);
+                p.timelineWidget->setVisible(settings.timeline && !focusMode);
 
-                p.bottomToolBar->setVisible(settings.bottomToolBar && !presentMode);
-                p.dividers["Bottom"]->setVisible(settings.bottomToolBar && !presentMode);
+                const bool bottomVisible =
+                    (settings.bottomToolBar || playbackFullScreen) &&
+                    !presentMode;
+                const bool statusVisible =
+                    (settings.statusToolBar || playbackFullScreen) &&
+                    !presentMode;
+                p.bottomToolBar->setVisible(bottomVisible);
+                p.statusBar->setVisible(statusVisible);
+                p.playbackStatusDivider->setVisible(
+                    playbackFullScreen &&
+                    bottomVisible &&
+                    statusVisible);
+                p.playbackProgress->setVisible(playbackFullScreen);
+                p.bottomToolBar->setFullScreen(playbackFullScreen);
 
-                p.statusBar->setVisible(settings.statusToolBar && !presentMode);
-                p.dividers["Status"]->setVisible(settings.statusToolBar && !presentMode);
+                if (playbackFullScreen)
+                {
+                    const auto now =
+                        PlaybackOverlayState::Clock::now();
+                    p.playbackBar->setVisible(
+                        p.playbackOverlayState.getVisibility() > .0001 ||
+                        p.playbackOverlayState.wantsVisible(now));
+                    p.dividers["Bottom"]->setVisible(false);
+                    p.dividers["Status"]->setVisible(false);
+                    p.normalBottomContainer->setVisible(false);
+                    p.normalStatusContainer->setVisible(false);
+                }
+                else
+                {
+                    p.playbackBar->setVisible(false);
+                    p.normalBottomContainer->setVisible(bottomVisible);
+                    p.normalStatusContainer->setVisible(statusVisible);
+                    p.dividers["Bottom"]->setVisible(bottomVisible);
+                    p.dividers["Status"]->setVisible(statusVisible);
+                }
             }
         }
     }

--- a/lib/djv/App/MainWindow.h
+++ b/lib/djv/App/MainWindow.h
@@ -93,6 +93,10 @@ namespace djv
         private:
             void _settingsUpdate(const models::MouseSettings&);
             void _settingsUpdate(const models::TimelineSettings&);
+            void _fullScreenUpdate(bool);
+            void _playbackActivity();
+            void _playbackOverlayUpdate();
+            void _setPlaybackPinned(bool);
             void _windowUpdate();
 
             FTK_PRIVATE();

--- a/lib/djv/App/PlaybackUIState.cpp
+++ b/lib/djv/App/PlaybackUIState.cpp
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the DJV project.
+
+#include <djv/App/PlaybackUIState.h>
+
+#include <algorithm>
+#include <cmath>
+
+namespace djv
+{
+    namespace app
+    {
+        namespace
+        {
+            const auto doubleClickDuration = std::chrono::milliseconds(500);
+            const auto overlayHideDelay = std::chrono::milliseconds(2200);
+            const auto overlayAnimationDuration = std::chrono::milliseconds(180);
+        }
+
+        bool PlaybackDoubleClickDetector::release(
+            int x,
+            int y,
+            const Clock::time_point& time,
+            int maxDistance)
+        {
+            bool out = false;
+            if (_hasClick)
+            {
+                const auto elapsed = time - _time;
+                const int dx = x - _x;
+                const int dy = y - _y;
+                const int maxDistance2 = maxDistance * maxDistance;
+                out =
+                    elapsed >= Clock::duration::zero() &&
+                    elapsed <= doubleClickDuration &&
+                    dx * dx + dy * dy <= maxDistance2;
+            }
+
+            if (out)
+            {
+                reset();
+            }
+            else
+            {
+                _hasClick = true;
+                _x = x;
+                _y = y;
+                _time = time;
+            }
+            return out;
+        }
+
+        void PlaybackDoubleClickDetector::reset()
+        {
+            _hasClick = false;
+            _x = 0;
+            _y = 0;
+            _time = Clock::time_point();
+        }
+
+        void PlaybackOverlayState::setFullScreen(
+            bool value,
+            const Clock::time_point& time)
+        {
+            _fullScreen = value;
+            _pinned = false;
+            _lastActivity = time;
+            _lastTick = time;
+            _visibility = value ? 1.0 : 0.0;
+        }
+
+        bool PlaybackOverlayState::isFullScreen() const
+        {
+            return _fullScreen;
+        }
+
+        void PlaybackOverlayState::setPinned(
+            bool value,
+            const Clock::time_point& time)
+        {
+            _pinned = _fullScreen && value;
+            activity(time);
+        }
+
+        bool PlaybackOverlayState::isPinned() const
+        {
+            return _pinned;
+        }
+
+        void PlaybackOverlayState::activity(const Clock::time_point& time)
+        {
+            if (_fullScreen)
+            {
+                _lastActivity = time;
+            }
+        }
+
+        bool PlaybackOverlayState::wantsVisible(
+            const Clock::time_point& time) const
+        {
+            return
+                _fullScreen &&
+                (_pinned || time - _lastActivity < overlayHideDelay);
+        }
+
+        bool PlaybackOverlayState::tick(const Clock::time_point& time)
+        {
+            if (!_fullScreen)
+            {
+                return false;
+            }
+
+            const double previous = _visibility;
+            const auto elapsed = std::max(
+                Clock::duration::zero(),
+                time - _lastTick);
+            const double duration = static_cast<double>(
+                std::chrono::duration_cast<std::chrono::microseconds>(
+                    overlayAnimationDuration).count());
+            const double step =
+                duration > 0.0 ?
+                static_cast<double>(
+                    std::chrono::duration_cast<std::chrono::microseconds>(
+                        elapsed).count()) / duration :
+                1.0;
+
+            if (wantsVisible(time))
+            {
+                _visibility = std::min(1.0, _visibility + step);
+            }
+            else
+            {
+                _visibility = std::max(0.0, _visibility - step);
+            }
+            _lastTick = time;
+            return std::abs(_visibility - previous) > .0001;
+        }
+
+        double PlaybackOverlayState::getVisibility() const
+        {
+            return _visibility;
+        }
+
+        double getPlaybackProgress(
+            double currentTime,
+            double startTime,
+            double duration)
+        {
+            if (!std::isfinite(currentTime) ||
+                !std::isfinite(startTime) ||
+                !std::isfinite(duration) ||
+                duration <= 0.0)
+            {
+                return 0.0;
+            }
+            return std::clamp(
+                (currentTime - startTime) / duration,
+                0.0,
+                1.0);
+        }
+    }
+}

--- a/lib/djv/App/PlaybackUIState.h
+++ b/lib/djv/App/PlaybackUIState.h
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the DJV project.
+
+#pragma once
+
+#include <chrono>
+
+namespace djv
+{
+    namespace app
+    {
+        //! Detect consecutive releases that form a pointer double-click.
+        class PlaybackDoubleClickDetector
+        {
+        public:
+            using Clock = std::chrono::steady_clock;
+
+            bool release(
+                int x,
+                int y,
+                const Clock::time_point&,
+                int maxDistance = 6);
+
+            void reset();
+
+        private:
+            bool _hasClick = false;
+            int _x = 0;
+            int _y = 0;
+            Clock::time_point _time;
+        };
+
+        //! Full-screen playback controls visibility and animation state.
+        class PlaybackOverlayState
+        {
+        public:
+            using Clock = std::chrono::steady_clock;
+
+            void setFullScreen(bool, const Clock::time_point&);
+            bool isFullScreen() const;
+
+            void setPinned(bool, const Clock::time_point&);
+            bool isPinned() const;
+
+            void activity(const Clock::time_point&);
+            bool wantsVisible(const Clock::time_point&) const;
+
+            //! Advance the slide animation and return whether it changed.
+            bool tick(const Clock::time_point&);
+
+            //! Current slide visibility in the inclusive range [0, 1].
+            double getVisibility() const;
+
+        private:
+            bool _fullScreen = false;
+            bool _pinned = false;
+            double _visibility = 0.0;
+            Clock::time_point _lastActivity;
+            Clock::time_point _lastTick;
+        };
+
+        //! Normalize absolute media progress to the inclusive range [0, 1].
+        double getPlaybackProgress(
+            double currentTime,
+            double startTime,
+            double duration);
+    }
+}

--- a/lib/djv/App/Viewport.cpp
+++ b/lib/djv/App/Viewport.cpp
@@ -4,6 +4,7 @@
 #include <djv/App/Viewport.h>
 
 #include <djv/App/App.h>
+#include <djv/App/PlaybackUIState.h>
 #include <djv/Models/ColorModel.h>
 #include <djv/Models/FilesModel.h>
 #include <djv/Models/SettingsModel.h>
@@ -49,6 +50,11 @@ namespace djv
             std::shared_ptr<ftk::Observable<ftk::V2I> > pick;
             std::shared_ptr<ftk::Observable<ftk::V2I> > samplePos;
             std::shared_ptr<ftk::Observable<ftk::Color4F> > colorSample;
+            PlaybackDoubleClickDetector doubleClickDetector;
+            bool clickCandidate = false;
+            ftk::V2I clickPos;
+            std::function<void(void)> fullScreenCallback;
+            std::function<void(void)> mouseActivityCallback;
 
             std::shared_ptr<ftk::Label> fileNameLabel;
             std::shared_ptr<ftk::Label> cacheLabel;
@@ -411,6 +417,18 @@ namespace djv
             _hudUpdate();
         }
 
+        void Viewport::setFullScreenCallback(
+            const std::function<void(void)>& value)
+        {
+            _p->fullScreenCallback = value;
+        }
+
+        void Viewport::setMouseActivityCallback(
+            const std::function<void(void)>& value)
+        {
+            _p->mouseActivityCallback = value;
+        }
+
         void Viewport::setPlayer(const std::shared_ptr<tl::Player>& player)
         {
             tl::ui::Viewport::setPlayer(player);
@@ -484,25 +502,45 @@ namespace djv
         {
             tl::ui::Viewport::mouseMoveEvent(event);
             FTK_P();
+            if (
+                event.pos != event.prev &&
+                p.mouseActivityCallback)
+            {
+                p.mouseActivityCallback();
+            }
+            if (p.clickCandidate)
+            {
+                const int dx = event.pos.x - p.clickPos.x;
+                const int dy = event.pos.y - p.clickPos.y;
+                if (dx * dx + dy * dy > 36)
+                {
+                    p.clickCandidate = false;
+                    p.doubleClickDetector.reset();
+                }
+            }
             switch (p.mouse.mode)
             {
             case Private::MouseMode::Shuttle:
                 if (auto player = getPlayer())
                 {
-                    const OTIO_NS::RationalTime offset = OTIO_NS::RationalTime(
-                        (event.pos.x - _getMousePressPos().x) * .05F * p.frameShuttleScale,
-                        p.mouse.shuttleStart.rate()).round();
-                    const OTIO_NS::TimeRange& timeRange = player->getTimeRange();
-                    OTIO_NS::RationalTime t = p.mouse.shuttleStart + offset;
-                    if (t < timeRange.start_time())
+                    const int dx =
+                        event.pos.x - _getMousePressPos().x;
+                    const int dy =
+                        event.pos.y - _getMousePressPos().y;
+                    if (dx * dx + dy * dy > 36)
                     {
-                        t = timeRange.end_time_exclusive() - (timeRange.start_time() - t);
+                        player->stop();
+                        const OTIO_NS::RationalTime offset =
+                            OTIO_NS::RationalTime(
+                                dx * .05F * p.frameShuttleScale,
+                                p.mouse.shuttleStart.rate()).round();
+                        const OTIO_NS::TimeRange& timeRange =
+                            player->getTimeRange();
+                        player->seek(
+                            tl::loop(
+                                p.mouse.shuttleStart + offset,
+                                timeRange));
                     }
-                    else if (t > timeRange.end_time_exclusive())
-                    {
-                        t = timeRange.start_time() + (t - timeRange.end_time_exclusive());
-                    }
-                    player->seek(t);
                 }
                 break;
             case Private::MouseMode::Picker:
@@ -526,6 +564,17 @@ namespace djv
         {
             tl::ui::Viewport::mousePressEvent(event);
             FTK_P();
+            p.clickCandidate =
+                ftk::MouseButton::Left == event.button &&
+                0 == event.modifiers;
+            if (p.clickCandidate)
+            {
+                p.clickPos = event.pos;
+            }
+            else
+            {
+                p.doubleClickDetector.reset();
+            }
             if (p.pickBinding.button == event.button &&
                 ftk::checkKeyModifier(p.pickBinding.modifier, event.modifiers))
             {
@@ -552,7 +601,6 @@ namespace djv
                 p.mouse.mode = Private::MouseMode::Shuttle;
                 if (auto player = getPlayer())
                 {
-                    player->stop();
                     p.mouse.shuttleStart = player->getCurrentTime();
                 }
             }
@@ -562,7 +610,20 @@ namespace djv
         {
             tl::ui::Viewport::mouseReleaseEvent(event);
             FTK_P();
+            const bool toggleFullScreen =
+                p.clickCandidate &&
+                ftk::MouseButton::Left == event.button &&
+                0 == event.modifiers &&
+                p.doubleClickDetector.release(
+                    event.pos.x,
+                    event.pos.y,
+                    PlaybackDoubleClickDetector::Clock::now());
             p.mouse = Private::MouseData();
+            p.clickCandidate = false;
+            if (toggleFullScreen && p.fullScreenCallback)
+            {
+                p.fullScreenCallback();
+            }
         }
 
         void Viewport::_videoUpdate()

--- a/lib/djv/App/Viewport.h
+++ b/lib/djv/App/Viewport.h
@@ -5,6 +5,8 @@
 
 #include <tlRender/UI/Viewport.h>
 
+#include <functional>
+
 namespace djv
 {
     namespace app
@@ -44,6 +46,12 @@ namespace djv
             //! Sample the image at the given image pixel, as the pick mouse
             //! action would. Used by the documentation screenshot capture.
             void pick(const ftk::V2I& imagePos);
+
+            //! Set the callback used to toggle playback full-screen.
+            void setFullScreenCallback(const std::function<void(void)>&);
+
+            //! Set the callback used to reveal full-screen playback controls.
+            void setMouseActivityCallback(const std::function<void(void)>&);
 
             void setPlayer(const std::shared_ptr<tl::Player>&) override;
 

--- a/lib/djv/Resource/CMakeLists.txt
+++ b/lib/djv/Resource/CMakeLists.txt
@@ -1,7 +1,9 @@
 set(HEADERS)
 set(SOURCE)
 set(RESOURCES
-    etc/Icons/DJV_Icon.svg)
+    etc/Icons/DJV_Icon.svg
+    etc/Icons/PlaybackFullScreen.svg
+    etc/Icons/PlaybackPin.svg)
 foreach(RESOURCE ${RESOURCES})
     get_filename_component(RESOURCE_BASE ${RESOURCE} NAME_WE)
     add_custom_command(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,1 +1,17 @@
 add_subdirectory(djv-test)
+
+add_executable(
+    djv-playback-ui-state-test
+    PlaybackUIStateTest.cpp
+    ../lib/djv/App/PlaybackUIState.cpp)
+target_include_directories(
+    djv-playback-ui-state-test
+    PRIVATE
+        ../lib)
+set_target_properties(
+    djv-playback-ui-state-test
+    PROPERTIES
+        FOLDER tests)
+add_test(
+    NAME djv-playback-ui-state
+    COMMAND djv-playback-ui-state-test)

--- a/tests/PlaybackUIStateTest.cpp
+++ b/tests/PlaybackUIStateTest.cpp
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the DJV project.
+
+#include <djv/App/PlaybackUIState.h>
+
+#include <cmath>
+#include <iostream>
+
+namespace
+{
+    bool check(bool value, const char* message)
+    {
+        if (!value)
+        {
+            std::cerr << message << std::endl;
+        }
+        return value;
+    }
+}
+
+int main()
+{
+    using namespace djv::app;
+    using Clock = PlaybackOverlayState::Clock;
+    using namespace std::chrono_literals;
+
+    bool ok = true;
+    const auto t0 = Clock::time_point();
+
+    PlaybackDoubleClickDetector doubleClick;
+    ok &= check(
+        !doubleClick.release(10, 10, t0),
+        "The first click must not toggle full-screen.");
+    ok &= check(
+        doubleClick.release(14, 12, t0 + 200ms),
+        "A nearby second click must toggle full-screen.");
+    ok &= check(
+        !doubleClick.release(10, 10, t0 + 1s),
+        "A new click sequence must start after a double-click.");
+    ok &= check(
+        !doubleClick.release(30, 30, t0 + 1100ms),
+        "A distant second click must not toggle full-screen.");
+
+    PlaybackOverlayState overlay;
+    overlay.setFullScreen(true, t0);
+    ok &= check(
+        overlay.isFullScreen() && overlay.wantsVisible(t0),
+        "The overlay must be visible when full-screen starts.");
+    overlay.tick(t0 + 2190ms);
+    overlay.tick(t0 + 2210ms);
+    ok &= check(
+        overlay.getVisibility() > 0.0 &&
+        overlay.getVisibility() < 1.0,
+        "The overlay must slide out after pointer inactivity.");
+    overlay.tick(t0 + 2390ms);
+    ok &= check(
+        std::abs(overlay.getVisibility()) < .0001,
+        "The overlay must finish outside the window.");
+    overlay.activity(t0 + 2400ms);
+    overlay.tick(t0 + 2416ms);
+    ok &= check(
+        overlay.getVisibility() > 0.0,
+        "Pointer activity must slide the overlay back in.");
+    overlay.setPinned(true, t0 + 2500ms);
+    ok &= check(
+        overlay.isPinned() &&
+        overlay.wantsVisible(t0 + 10s),
+        "A pinned overlay must remain visible.");
+    overlay.setFullScreen(false, t0 + 11s);
+    ok &= check(
+        !overlay.isFullScreen() &&
+        !overlay.isPinned(),
+        "Leaving full-screen must clear the pin.");
+
+    ok &= check(
+        std::abs(getPlaybackProgress(50.0, 0.0, 100.0) - .5) < .0001,
+        "Playback progress must be normalized.");
+    ok &= check(
+        0.0 == getPlaybackProgress(-20.0, 0.0, 100.0) &&
+        1.0 == getPlaybackProgress(120.0, 0.0, 100.0) &&
+        0.0 == getPlaybackProgress(10.0, 0.0, 0.0),
+        "Playback progress must be clamped and reject invalid duration.");
+
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

- add a full-screen toggle immediately after the forward playback button
- toggle full-screen by double-clicking the video without stopping active playback
- leave full-screen with Escape
- slide the playback overlay in on pointer activity and out after inactivity
- add a full-screen-only pin control
- show an orange full-width media progress indicator above the controls

## Layout isolation

The normal bottom toolbar and status bar keep their existing upstream layout. They are moved into a dedicated horizontal overlay only while playback full-screen is active, then restored to their original containers on exit. This keeps the change independent from #799, which separately proposes compact media information in the normal window layout.

Cursor hiding is not included because the current implementation is Win32-specific and FTK does not expose a portable cursor-visibility API.

## Validation

- `djv-playback-ui-state`: 1/1 test passed
- all modified `djvApp` sources compile with MSVC in Release mode
- new icon resources generate and `djvResource` compiles
- `djvApp` static library compiles
- `git diff --check`

A complete local executable build is currently blocked in the unmodified tlRender submodule by an `ItemOptions.cpp` / OpenTimelineIO API mismatch; the modified DJV sources and resources compile successfully.