### PR TITLE
fix(ui): size the setup dialog to its content

### DIFF
--- a/lib/djv/UI/SetupDialog.cpp
+++ b/lib/djv/UI/SetupDialog.cpp
@@ -133,10 +133,9 @@ namespace djv
 
             p.layout = ftk::VerticalLayout::create(context, shared_from_this());
             p.layout->setSpacingRole(ftk::SizeRole::None);
-            p.layout->setHStretch(ftk::Stretch::Expanding);
             label->setParent(p.layout);
             ftk::Divider::create(context, ftk::Orientation::Vertical, p.layout);
-            auto scrollWidget = ftk::ScrollWidget::create(context, ftk::ScrollType::Both, p.layout);
+            auto scrollWidget = ftk::ScrollWidget::create(context, ftk::ScrollType::Vertical, p.layout);
             scrollWidget->setBorder(false);
             scrollWidget->setWidget(p.stackLayout);
             ftk::Divider::create(context, ftk::Orientation::Vertical, p.layout);


### PR DESCRIPTION
The setup dialog sets `Stretch::Expanding` on its layout, so it grows to
the full window width. On a wide screen the content ends up in a narrow
column with a large empty margin on the right.

The same layout uses a `ScrollType::Both` scroll area, which adds a
horizontal scroll bar the dialog never needs — its content is a stack of
settings pages that wrap to the available width.

This drops the horizontal stretch and scrolls vertically only, so the
dialog is as wide as what it contains.
