### PR TITLE
feat(review): save, reopen and annotate review sessions

### DIFF
--- a/cmake/Modules/Package.cmake
+++ b/cmake/Modules/Package.cmake
@@ -130,6 +130,25 @@ if(WIN32)
     set(CPACK_NSIS_MUI_UNIICON ${PROJECT_SOURCE_DIR}/etc/Windows/DJV_Icon.ico)
     set(CPACK_NSIS_INSTALLED_ICON_NAME bin/djv.exe)
 
+    # Associate review files (".djvr") with DJV so double-clicking one opens it.
+    # The application already routes a ".djvr" argument to the review (see
+    # App::_inputFilesInit); these registry entries tell Windows which command to
+    # run. The installer is elevated (Program Files), so HKCR resolves to the
+    # system-wide HKLM\Software\Classes. SHChangeNotify refreshes the icon cache.
+    set(CPACK_NSIS_EXTRA_INSTALL_COMMANDS "
+        WriteRegStr HKCR '.djvr' '' 'DJV.Review'
+        WriteRegStr HKCR 'DJV.Review' '' 'DJV Review Session'
+        WriteRegStr HKCR 'DJV.Review\\DefaultIcon' '' '\"$INSTDIR\\bin\\djv.exe\",0'
+        WriteRegStr HKCR 'DJV.Review\\shell\\open\\command' '' '\"$INSTDIR\\bin\\djv.exe\" \"%1\"'
+        System::Call 'shell32::SHChangeNotify(i 0x08000000, i 0, i 0, i 0)'
+    ")
+    set(CPACK_NSIS_EXTRA_UNINSTALL_COMMANDS "
+        DeleteRegKey HKCR 'DJV.Review'
+        DeleteRegValue HKCR '.djvr' ''
+        DeleteRegKey /ifempty HKCR '.djvr'
+        System::Call 'shell32::SHChangeNotify(i 0x08000000, i 0, i 0, i 0)'
+    ")
+
 elseif(APPLE)
 
     if(DJV_MACOS_PACKAGE)

--- a/docs/files.md
+++ b/docs/files.md
@@ -83,6 +83,122 @@ Shortcuts:
 * Next file: <kbd>Ctrl+Page Down</kbd>
 * Previous file: <kbd>Ctrl+Page Up</kbd>
 
+## Reviews
+
+A *review* is a saved session. Instead of re-opening each file and rebuilding a
+comparison by hand, you can save the whole setup to a `.djvr` file and reopen it
+later in one step. A review stores:
+
+- The open files, including any separate audio, the active layer, and each
+  file's speed, current frame, and in/out range.
+- The active tab (the **A** file) and the comparison setup: mode, **B** files,
+  wipe, overlay, and the relative/absolute time mode.
+- The viewport state: framing, pan, and zoom.
+- Color and display state: OCIO, LUT, display, background, foreground, aspect
+  ratio, and HUD.
+- The interface: the active tool panel and the window layout.
+
+Opening a review replaces the current session. File paths are stored relative to
+the `.djvr` when possible, so a review stays valid when moved together with its
+media; any files that cannot be found are reported in the **Messages** tool.
+
+The window title shows the open review's path, with a trailing `*` while it has
+unsaved changes. **Close Review** closes the review and returns DJV to its empty
+startup state; if there are unsaved changes it prompts to save first, as does
+quitting the application.
+
+While a saved review has unsaved changes, DJV keeps a periodic autosave backup.
+If the application does not exit cleanly, the next launch offers to recover those
+changes.
+
+### Building a review: make "A" the primary source
+
+A review can hold any number of files, but **the "A" file is always the master**.
+Set it to the source the review is *about* — the shot being reviewed — and use
+the "B" files for what you compare it against.
+
+This is not a stylistic preference: "A" drives playback and timing. The player is
+built from "A", so its duration, frame rate and audio govern the session; the
+timeline shows "A"; comparison times are resolved relative to it; and **Fit to A**
+scales the other sources to match it. A review whose "A" is a reference still
+plays, but every timing decision then follows the wrong source.
+
+How many "B" files you may add depends on the comparison mode:
+
+| Mode | "B" files |
+|---|---|
+| A, B, Wipe, Overlay, Difference, Horizontal, Vertical | one |
+| Tile | any number |
+
+Selecting a second "B" in a single-buffer mode replaces the first, and switching
+from **Tile** to any other mode keeps only one "B". This is by design, and it is
+why reviews are saved with the mode: reopening a tiled review with four sources
+restores all of them, while the single-buffer modes restore one. In every mode
+"A" is restored exactly as it was saved.
+
+The recommended way to build a review:
+
+1. Open the primary source first, so it becomes "A".
+2. Open the sources to compare against, and mark them as "B".
+3. Choose the comparison mode — **Tile** if you need more than two sources.
+4. Save the review.
+
+Locations: **File** menu
+
+Shortcuts:
+
+* Open review: <kbd>Ctrl+Shift+O</kbd>
+* Save review: <kbd>Ctrl+Shift+S</kbd>
+
+Reviews can also be opened from the command line:
+
+```
+djv session.djvr
+```
+
+Personal preferences — keyboard shortcuts, style, cache size, and the audio
+device — are deliberately **not** stored in a review, so opening one received
+from someone else does not reconfigure your installation.
+
+## Annotating a review
+
+The **Review** tool holds everything you add on top of the footage: drawings and
+notes, in one panel so that marking up a frame and commenting on it stay
+visible together.
+
+Locations: **Tools** menu, **Tools** toolbar
+
+Shortcut: <kbd>F9</kbd>
+
+### Drawing
+
+Pick the **pen** or the **eraser** in the *Drawing* section to start drawing;
+click the active tool again to stop. While drawing is on, dragging with the left
+mouse button draws on the image instead of shuttling frames — panning (middle
+button) and zooming (wheel) are unchanged.
+
+* **Colour** — click the swatch to change it.
+* **Size** — the stroke width, in pixels of the source image. A stroke therefore
+  keeps its position and its weight whatever the zoom, the pan, or the
+  comparison mode, and stays crisp when you zoom in.
+* **Eraser** — removes the whole stroke it touches, not part of it.
+* **Undo** / **Redo** — <kbd>Ctrl+Z</kbd> and <kbd>Ctrl+Shift+Z</kbd>, several
+  levels deep. While you are writing a note, <kbd>Ctrl+Z</kbd> undoes your text
+  instead.
+* **Clear Frame** — removes every stroke on the current frame.
+
+A drawing belongs to one source and appears on **one frame**. In a comparison
+you can draw on either side, and each stroke stays attached to its own source.
+
+### Notes
+
+Write in the *Notes* section and press **Publish Note**: the note records the
+frame you were on and the time you published it. Each card shows its frame as a
+button that takes you back there, and a button to delete the note.
+
+Frames carrying a note or a drawing are marked in the timeline ruler. The marks
+are deliberately alike — they say *there is something here*, not what kind.
+
 ## FFmpeg plugin
 
 The FFmpeg plugin provides support for movie and audio files. Only a limited

--- a/docs/files.md
+++ b/docs/files.md
@@ -102,6 +102,13 @@ Opening a review replaces the current session. File paths are stored relative to
 the `.djvr` when possible, so a review stays valid when moved together with its
 media; any files that cannot be found are reported in the **Messages** tool.
 
+A review written by a newer DJV than the one you are running is refused, with
+the reason given in the **Messages** tool, rather than opened in part. Anything
+else in a review that this version does not understand is left alone: it is
+kept as it stands when you save, so passing a session between different
+versions of DJV does not quietly strip it. The document itself is described in
+[Review file format]({{ site.baseurl }}/review-format.html).
+
 The window title shows the open review's path, with a trailing `*` while it has
 unsaved changes. **Close Review** closes the review and returns DJV to its empty
 startup state; if there are unsaved changes it prompts to save first, as does
@@ -159,6 +166,9 @@ djv session.djvr
 Personal preferences — keyboard shortcuts, style, cache size, and the audio
 device — are deliberately **not** stored in a review, so opening one received
 from someone else does not reconfigure your installation.
+
+Notes and drawings record who made them, taken from your account name on the
+machine, so a session that has been passed around stays readable.
 
 ## Annotating a review
 

--- a/docs/review-format.md
+++ b/docs/review-format.md
@@ -1,0 +1,174 @@
+---
+title: Review file format
+layout: default
+nav_order: 16
+---
+
+# Review file format
+
+A review is a JSON document with the `.djvr` extension. This page describes
+version 1 of that format: what a document contains, and what a program reading
+one is expected to do. For how reviews are used in DJV, see
+[Files]({{ site.baseurl }}/files.html#reviews).
+
+## Version
+
+Every document carries an integer under `djvReview`:
+
+```json
+{ "djvReview": 1 }
+```
+
+The version is incremented **only** when a document can no longer be read
+correctly by an older DJV. Adding a key, or a whole new section, does not
+change it: a reader ignores what it does not recognize, so those changes are
+already safe.
+
+A reader that finds a version higher than the one it knows **refuses the
+document** and says so. It does not read what it can and leave the rest: the
+next save would write that loss back over the author's own file. DJV reports
+this in the **Messages** tool and leaves the current session untouched.
+
+A document with no `djvReview` key is read as version 1.
+
+## What a reader must do
+
+These four rules are what make a review safe to pass between people running
+different versions of DJV.
+
+**Keep an unknown section.** A top-level section the reader does not know is
+carried through a load/save cycle untouched. Opening a review in an older DJV
+and saving it does not strip what a newer one wrote.
+
+**Read each section on its own.** A section that cannot be read costs that
+section and nothing else. In particular it must never cost the `annotations`
+and `notes`, which exist nowhere but in this file — the rest of a review is a
+convenience that can be rebuilt by hand.
+
+**Do not overwrite what you could not read.** A section that failed to load is
+written back exactly as it was found, rather than replaced by the defaults the
+application fell back to.
+
+**Skip, but keep, what you cannot place.** An annotation or a stroke in a
+coordinate space the reader does not know is not drawn — and not deleted
+either. It is written back as it was found, after the items that were
+understood.
+
+## The document
+
+| Key | Contents |
+|---|---|
+| `djvReview` | Format version, integer. |
+| `app` | The application and version that wrote the document, informational. |
+| `created` | When it was written, ISO 8601 UTC. |
+| `files` | The open sources, in tab order. |
+| `compare` | The A/B setup: `aId`, `bIds`, comparison options and time mode. |
+| `view` | Viewport framing, pan and zoom. |
+| `color` | OCIO, LUT, display, background, foreground, aspect ratio and HUD. |
+| `ui` | The active tool panel and the window layout. |
+| `annotations` | Drawings, by source and frame. |
+| `notes` | Timestamped comments. |
+| `ranges` | Named frame ranges. |
+
+`compare`, `view`, `color` and `ui` delegate to serializers shared with the
+application settings, and those require every key they know. They are therefore
+the sections most likely to fail against a document written by a different
+version — which is why the rules above exist.
+
+### Files
+
+```json
+{
+  "id": "ca708ac647f6600300000000",
+  "path": "shots/sh010/sh010_comp_v004.mov",
+  "pathAbsolute": "P:/show/shots/sh010/sh010_comp_v004.mov",
+  "audioPath": "shots/sh010/sh010_mix.wav",
+  "videoLayer": 0,
+  "speed": 24.0,
+  "currentTime": { "value": 168.0, "rate": 24.0 },
+  "inOutRange": {
+    "start":    { "value": 0.0,   "rate": 24.0 },
+    "duration": { "value": 476.0, "rate": 24.0 }
+  }
+}
+```
+
+`id` is what the rest of the document refers to a source by — `compare.aId`,
+`compare.bIds`, `annotations[].sourceId`. Indices are not used anywhere,
+because they do not survive closing or reordering a file.
+
+Paths are stored twice. `path` is relative to the `.djvr` and is tried first,
+so a review stays valid when it travels with its media; `pathAbsolute` is the
+fallback for media that lives outside the review's folder. Separate audio uses
+the same pair, `audioPath` and `audioPathAbsolute`. **All four are stored with
+forward slashes**, on every platform, so a document moves between them
+unchanged.
+
+When neither form resolves, DJV reports the missing sources and offers to look
+for them in a folder you choose.
+
+### Annotations
+
+```json
+{
+  "id": "0eecb7e26602f91b00000000",
+  "sourceId": "ca708ac647f6600300000000",
+  "space": "image",
+  "time": { "value": 168.0, "rate": 24.0 },
+  "author": "matthieu",
+  "created": "2026-08-26T09:01:00Z",
+  "strokes": [
+    {
+      "color": [1.0, 0.365, 0.02, 1.0],
+      "width": 4.0,
+      "widthSpace": "image",
+      "points": [120.5, 340.0, 121.0, 341.5]
+    }
+  ]
+}
+```
+
+An annotation belongs to one source and is visible on one frame only.
+
+`space` and `widthSpace` are both `"image"` in version 1: points and widths are
+expressed in the pixels of the source image, so a drawing keeps its position
+and its weight whatever the zoom, the pan or the comparison mode. A reader that
+meets any other value must not draw the item — the coordinates would land
+somewhere else entirely — and must keep it, per the rules above. An absent
+space means `"image"`.
+
+`points` is a flat `[x, y, x, y, ...]` array, which keeps long strokes compact.
+A trailing odd value is ignored.
+
+### Notes and ranges
+
+```json
+{
+  "id": "b1c2d3e4f5a6b7c800000001",
+  "time": { "value": 96.0, "rate": 24.0 },
+  "created": "2026-08-26T09:00:00Z",
+  "author": "matthieu",
+  "text": "Grade is too cold from here."
+}
+```
+
+A note belongs to the review rather than to a source: the frame locates it. A
+range is an `id`, a free-text `name` and a `range`; selecting one sets the
+timeline in and out points.
+
+### Attribution
+
+`author` is optional on both notes and annotations, and is empty when it is not
+known. DJV has no accounts: it fills the field from the environment —
+`USERNAME` on Windows, `USER` elsewhere — when the item is created. Treat it as
+a label saying who wrote something when a session comes back from someone else,
+not as an identity, and never as a permission.
+
+Identifiers are 64 random bits plus a counter, so items written independently
+by two people do not collide.
+
+## What is not stored
+
+Keyboard shortcuts, style, cache size and the audio device are deliberately
+absent: opening a review someone sends you must not reconfigure your
+installation.

--- a/etc/Icons/DrawTool.svg
+++ b/etc/Icons/DrawTool.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 20 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+    <g id="Layer-1" serif:id="Layer 1" transform="matrix(3.779528,0,0,3.779528,0,-1102.519611)">
+        <g transform="matrix(0.707107,0.707107,-0.707107,0.707107,209.555879,84.984572)">
+            <g transform="matrix(0.264583,0,0,0.264583,-0,291.70831)">
+                <rect x="5.098" y="4" width="2.951" height="9.473" style="fill:rgb(240,240,240);"/>
+            </g>
+            <g transform="matrix(-0.264583,-0,0,-0.264583,3.478296,299.342558)">
+                <path d="M6.573,12.854L8.048,15.115L5.098,15.115L6.573,12.854Z" style="fill:rgb(240,240,240);"/>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/etc/Icons/Eraser.svg
+++ b/etc/Icons/Eraser.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 20 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+    <g id="Layer-1" serif:id="Layer 1" transform="matrix(3.779528,0,0,3.779528,0,-1102.519611)">
+        <g transform="matrix(0.187089,0.187089,-0.187089,0.187089,2.645833,290.61237)">
+            <path d="M6.891,13.324L6.891,4.773C6.891,4.346 7.237,4 7.664,4L12.336,4C12.763,4 13.109,4.346 13.109,4.773L13.109,13.324L6.891,13.324ZM13.109,14.374L13.109,15.227C13.109,15.654 12.763,16 12.336,16L7.664,16C7.237,16 6.891,15.654 6.891,15.227L6.891,14.374L13.109,14.374Z" style="fill:rgb(240,240,240);"/>
+        </g>
+    </g>
+</svg>

--- a/etc/Icons/Review.svg
+++ b/etc/Icons/Review.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 20 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+    <g id="Layer-1" serif:id="Layer 1" transform="matrix(3.779528,0,0,3.779528,0,-1102.519611)">
+        <g>
+            <g transform="matrix(0.264583,0,0,0.264583,-0,291.70831)">
+                <path d="M8.789,11.574L8.479,11.574L8.479,9.294L10.085,9.294C10.539,9.294 10.879,9.186 11.106,8.97C11.333,8.755 11.447,8.443 11.447,8.034C11.447,7.648 11.33,7.345 11.098,7.123C10.865,6.902 10.528,6.791 10.085,6.791L8.479,6.791L8.479,4L10.357,4C11.322,4 12.139,4.167 12.809,4.502C13.478,4.837 13.983,5.296 14.323,5.881C14.664,6.465 14.834,7.121 14.834,7.847C14.834,8.664 14.61,9.382 14.162,10C13.713,10.618 13.058,11.058 12.196,11.319L14.902,16L11.174,16L8.87,11.719L8.789,11.574Z" style="fill:rgb(240,240,240);"/>
+            </g>
+            <g transform="matrix(0.264583,0,0,0.264583,-0,291.70831)">
+                <rect x="5.098" y="4" width="2.951" height="9.473" style="fill:rgb(240,240,240);"/>
+            </g>
+            <g transform="matrix(-0.264583,-0,0,-0.264583,3.478296,299.342558)">
+                <path d="M6.573,12.854L8.048,15.115L5.098,15.115L6.573,12.854Z" style="fill:rgb(240,240,240);"/>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/etc/Icons/ReviewNext.svg
+++ b/etc/Icons/ReviewNext.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<!-- Go to the next review marker: the review "R" followed by the "go to end"
+     glyph. The R is the one from Review.svg, scaled down to leave room. -->
+<svg width="100%" height="100%" viewBox="0 0 20 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xml:space="preserve" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+    <g id="Review" transform="translate(-1.5,3.2) scale(0.62)">
+        <path d="M8.789,11.574L8.479,11.574L8.479,9.294L10.085,9.294C10.539,9.294 10.879,9.186 11.106,8.97C11.333,8.755 11.447,8.443 11.447,8.034C11.447,7.648 11.33,7.345 11.098,7.123C10.865,6.902 10.528,6.791 10.085,6.791L8.479,6.791L8.479,4L10.357,4C11.322,4 12.139,4.167 12.809,4.502C13.478,4.837 13.983,5.296 14.323,5.881C14.664,6.465 14.834,7.121 14.834,7.847C14.834,8.664 14.61,9.382 14.162,10C13.713,10.618 13.058,11.058 12.196,11.319L14.902,16L11.174,16L8.87,11.719L8.789,11.574Z" style="fill:rgb(240,240,240);"/>
+        <rect x="5.098" y="4" width="2.951" height="9.473" style="fill:rgb(240,240,240);"/>
+        <path d="M6.573,15.998L5.098,13.737L8.048,13.737Z" style="fill:rgb(240,240,240);"/>
+    </g>
+    <g id="GotoEnd">
+        <path d="M9.5,5.5L15.5,10L9.5,14.5Z" style="fill:rgb(240,240,240);"/>
+        <rect x="16.5" y="5.5" width="1.4" height="9" style="fill:rgb(240,240,240);"/>
+    </g>
+</svg>

--- a/etc/Icons/ReviewPrev.svg
+++ b/etc/Icons/ReviewPrev.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<!-- Go to the previous review marker: the "go to start" glyph followed by the
+     review "R". The R is the one from Review.svg, scaled down to leave room. -->
+<svg width="100%" height="100%" viewBox="0 0 20 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xml:space="preserve" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+    <g id="GotoStart">
+        <rect x="2.1" y="5.5" width="1.4" height="9" style="fill:rgb(240,240,240);"/>
+        <path d="M10.5,5.5L4.5,10L10.5,14.5Z" style="fill:rgb(240,240,240);"/>
+    </g>
+    <g id="Review" transform="translate(9.05,3.2) scale(0.62)">
+        <path d="M8.789,11.574L8.479,11.574L8.479,9.294L10.085,9.294C10.539,9.294 10.879,9.186 11.106,8.97C11.333,8.755 11.447,8.443 11.447,8.034C11.447,7.648 11.33,7.345 11.098,7.123C10.865,6.902 10.528,6.791 10.085,6.791L8.479,6.791L8.479,4L10.357,4C11.322,4 12.139,4.167 12.809,4.502C13.478,4.837 13.983,5.296 14.323,5.881C14.664,6.465 14.834,7.121 14.834,7.847C14.834,8.664 14.61,9.382 14.162,10C13.713,10.618 13.058,11.058 12.196,11.319L14.902,16L11.174,16L8.87,11.719L8.789,11.574Z" style="fill:rgb(240,240,240);"/>
+        <rect x="5.098" y="4" width="2.951" height="9.473" style="fill:rgb(240,240,240);"/>
+        <path d="M6.573,15.998L5.098,13.737L8.048,13.737Z" style="fill:rgb(240,240,240);"/>
+    </g>
+</svg>

--- a/lib/djv/App/App.cpp
+++ b/lib/djv/App/App.cpp
@@ -197,6 +197,11 @@ namespace djv
             std::shared_ptr<models::RecentFilesModel> recentReviewsModel;
             std::filesystem::path reviewPath;
             nlohmann::json reviewRaw;
+            //! What the open review could not be read from, carried alongside
+            //! the raw document so that saving puts it back rather than
+            //! overwriting it with the defaults we fell back to.
+            std::vector<std::string> reviewUnreadSections;
+            nlohmann::json reviewUnreadItems;
             bool reviewModified = false;
             std::optional<models::ReviewView> pendingReviewView;
             std::shared_ptr<ftk::Timer> reviewViewTimer;
@@ -750,6 +755,19 @@ namespace djv
                 return rel.generic_u8string();
             }
 
+            //! Store a path with forward slashes, whatever the platform wrote.
+            //!
+            //! Windows accepts either separator, so this costs nothing there and
+            //! keeps a document legible -- and diffable -- when it travels.
+            std::string reviewGenericPath(const std::string& value)
+            {
+                if (value.empty())
+                {
+                    return value;
+                }
+                return std::filesystem::u8path(value).generic_u8string();
+            }
+
             //! Does the file exist on disk? A single file is checked exactly; an
             //! image sequence -- whose padded/pattern path is not a literal file
             //! -- is considered present when its directory holds a matching frame.
@@ -788,12 +806,13 @@ namespace djv
                 return false;
             }
 
-            //! Resolve a review file entry to a path on disk, preferring the
-            //! relative form, then the absolute form, then the file's name inside
-            //! an optional substitute root (used by the relocation dialog).
-            //! Reports whether the target exists.
-            std::filesystem::path resolveReviewFile(
-                const models::ReviewFile& rf,
+            //! Resolve a stored relative/absolute path pair to a path on disk,
+            //! preferring the relative form, then the absolute form, then the
+            //! file's name inside an optional substitute root (used by the
+            //! relocation dialog). Reports whether the target exists.
+            std::filesystem::path resolveReviewPath(
+                const std::string& relative,
+                const std::string& absolute,
                 const std::filesystem::path& base,
                 const std::filesystem::path& substituteRoot,
                 const ftk::PathOptions& pathOptions,
@@ -803,20 +822,20 @@ namespace djv
                 {
                     return reviewFilePresent(p, pathOptions);
                 };
-                if (!rf.path.empty())
+                if (!relative.empty())
                 {
                     const std::filesystem::path rel =
-                        (base / std::filesystem::u8path(rf.path)).lexically_normal();
+                        (base / std::filesystem::u8path(relative)).lexically_normal();
                     if (present(rel))
                     {
                         exists = true;
                         return rel;
                     }
                 }
-                if (!rf.pathAbsolute.empty())
+                if (!absolute.empty())
                 {
                     const std::filesystem::path abs =
-                        std::filesystem::u8path(rf.pathAbsolute);
+                        std::filesystem::u8path(absolute);
                     if (present(abs))
                     {
                         exists = true;
@@ -826,13 +845,13 @@ namespace djv
                 if (!substituteRoot.empty())
                 {
                     std::filesystem::path fileName;
-                    if (!rf.path.empty())
+                    if (!relative.empty())
                     {
-                        fileName = std::filesystem::u8path(rf.path).filename();
+                        fileName = std::filesystem::u8path(relative).filename();
                     }
-                    else if (!rf.pathAbsolute.empty())
+                    else if (!absolute.empty())
                     {
-                        fileName = std::filesystem::u8path(rf.pathAbsolute).filename();
+                        fileName = std::filesystem::u8path(absolute).filename();
                     }
                     if (!fileName.empty())
                     {
@@ -845,11 +864,23 @@ namespace djv
                     }
                 }
                 exists = false;
-                if (!rf.path.empty())
+                if (!relative.empty())
                 {
-                    return (base / std::filesystem::u8path(rf.path)).lexically_normal();
+                    return (base / std::filesystem::u8path(relative)).lexically_normal();
                 }
-                return std::filesystem::u8path(rf.pathAbsolute);
+                return std::filesystem::u8path(absolute);
+            }
+
+            //! Resolve a review file entry to a path on disk.
+            std::filesystem::path resolveReviewFile(
+                const models::ReviewFile& rf,
+                const std::filesystem::path& base,
+                const std::filesystem::path& substituteRoot,
+                const ftk::PathOptions& pathOptions,
+                bool& exists)
+            {
+                return resolveReviewPath(
+                    rf.path, rf.pathAbsolute, base, substituteRoot, pathOptions, exists);
             }
         }
 
@@ -884,7 +915,41 @@ namespace djv
                 return;
             }
 
+            if (!models::reviewVersionSupported(review.version))
+            {
+                _context->log(
+                    "djv::app::App",
+                    ftk::Format(
+                        "Cannot read review \"{0}\": it is format version {1}, "
+                        "and this build of DJV reads up to version {2}. Open it "
+                        "with a newer DJV.").
+                        arg(path.u8string()).
+                        arg(review.version).
+                        arg(models::reviewVersion),
+                    ftk::LogType::Error);
+                return;
+            }
+            _logUnreadSections(review, path);
+
             _applyReview(review, path.parent_path(), path, std::filesystem::path());
+        }
+
+        void App::_logUnreadSections(
+            const models::Review& review,
+            const std::filesystem::path& path)
+        {
+            for (const auto& section : review.unreadSections)
+            {
+                _context->log(
+                    "djv::app::App",
+                    ftk::Format(
+                        "Review \"{0}\": the \"{1}\" section could not be read "
+                        "and is left at its defaults. It is kept as it stands "
+                        "when the review is saved, not overwritten.").
+                        arg(path.u8string()).
+                        arg(section),
+                    ftk::LogType::Warning);
+            }
         }
 
         void App::_applyReview(
@@ -914,9 +979,21 @@ namespace djv
                 auto item = std::make_shared<models::FilesModelItem>();
                 item->id = rf.id.empty() ? models::generateId() : rf.id;
                 item->path = ftk::Path(resolved.u8string(), pathOptions);
-                if (!rf.audioPath.empty())
+                if (!rf.audioPath.empty() || !rf.audioPathAbsolute.empty())
                 {
-                    item->audioPath = ftk::Path(rf.audioPath, pathOptions);
+                    bool audioExists = false;
+                    const std::filesystem::path audio = resolveReviewPath(
+                        rf.audioPath,
+                        rf.audioPathAbsolute,
+                        base,
+                        substituteRoot,
+                        pathOptions,
+                        audioExists);
+                    if (!audioExists)
+                    {
+                        missing.push_back(audio.u8string());
+                    }
+                    item->audioPath = ftk::Path(audio.u8string(), pathOptions);
                 }
                 item->videoLayer = static_cast<size_t>(std::max(0, rf.videoLayer));
                 item->speed = rf.speed;
@@ -929,7 +1006,7 @@ namespace djv
 
             // Rebuild the comparison. Order matters: setCompareOptions may pick a
             // "B" of its own when none is set, so clear and rebuild "B" after it,
-            // then set "A". See docs/ROADMAP_REVIEW_SESSIONS.md Â§6.1.
+            // then set "A".
             const auto& files = p.filesModel->getFiles();
             auto indexOfId = [&files](const std::string& id) -> int
             {
@@ -993,6 +1070,8 @@ namespace djv
 
             p.reviewPath = reviewPath;
             p.reviewRaw = review.raw;
+            p.reviewUnreadSections = review.unreadSections;
+            p.reviewUnreadItems = review.unreadItems;
             p.recentReviewsModel->addRecent(reviewPath);
             p.reviewModified = false;
             _updateWindowTitle();
@@ -1109,17 +1188,24 @@ namespace djv
                 arg(p.appInfoModel->getFullName()).
                 arg(p.appInfoModel->getVersion());
             review.created = reviewTimestamp();
-            // Carry any unknown sections from the review we last loaded so a
-            // load/save cycle does not drop them. See Â§4.4.
+            // Carry what the review we last loaded held but we could not use:
+            // the sections we do not know, and the ones we failed to read. The
+            // document is rebuilt from the models, so without this the save
+            // would replace them with whatever we fell back to.
             review.raw = p.reviewRaw;
+            review.unreadSections = p.reviewUnreadSections;
+            review.unreadItems = p.reviewUnreadItems;
 
             for (const auto& file : p.filesModel->getFiles())
             {
                 models::ReviewFile rf;
                 rf.id = file->id;
-                rf.pathAbsolute = file->path.get();
+                rf.pathAbsolute = reviewGenericPath(file->path.get());
                 rf.path = reviewRelativePath(file->path.get(), base);
-                rf.audioPath = file->audioPath.get();
+                // The separate audio travels with the review like the file does:
+                // stored absolute only, it would not survive the move.
+                rf.audioPath = reviewRelativePath(file->audioPath.get(), base);
+                rf.audioPathAbsolute = reviewGenericPath(file->audioPath.get());
                 rf.videoLayer = static_cast<int>(file->videoLayer);
                 rf.speed = file->speed;
                 rf.currentTime = file->currentTime;
@@ -1258,6 +1344,8 @@ namespace djv
             p.annotationsModel->clear();
             p.reviewPath.clear();
             p.reviewRaw = nlohmann::json();
+            p.reviewUnreadSections.clear();
+            p.reviewUnreadItems = nlohmann::json();
             // closeAll / setCompareOptions marked the session modified; clear it
             // last so the empty state is clean.
             p.reviewModified = false;
@@ -1495,6 +1583,18 @@ namespace djv
             try
             {
                 models::Review review = json.get<models::Review>();
+                if (!models::reviewVersionSupported(review.version))
+                {
+                    _context->log(
+                        "djv::app::App",
+                        ftk::Format(
+                            "Cannot recover autosave: it is format version {0}, "
+                            "and this build of DJV reads up to version {1}.").
+                            arg(review.version).
+                            arg(models::reviewVersion),
+                        ftk::LogType::Error);
+                    return;
+                }
                 std::filesystem::path reviewPath;
                 if (json.contains("_autosaveReviewPath"))
                 {
@@ -1503,6 +1603,7 @@ namespace djv
                 }
                 // Keep the internal marker out of any later saved ".djvr".
                 review.raw.erase("_autosaveReviewPath");
+                _logUnreadSections(review, reviewPath);
                 _applyReview(review, reviewPath.parent_path(), reviewPath, std::filesystem::path());
                 // The recovered state is, by definition, unsaved.
                 p.reviewModified = true;

--- a/lib/djv/App/App.cpp
+++ b/lib/djv/App/App.cpp
@@ -14,6 +14,8 @@
 #include <djv/App/MagnifyTool.h>
 #include <djv/App/MainWindow.h>
 #include <djv/App/MessagesTool.h>
+#include <djv/App/ReviewTool.h>
+#include <djv/App/SaveReviewDialog.h>
 #include <djv/App/SecondaryWindow.h>
 #include <djv/App/SettingsTool.h>
 #include <djv/App/Indicator.h>
@@ -21,11 +23,16 @@
 #include <djv/App/ViewTool.h>
 #include <djv/App/Viewport.h>
 #include <djv/UI/SeparateAudioDialog.h>
+#include <djv/Models/AnnotationsModel.h>
 #include <djv/Models/AppInfoModel.h>
 #include <djv/Models/AudioModel.h>
 #include <djv/Models/ColorModel.h>
+#include <djv/Models/DrawModel.h>
 #include <djv/Models/FilesModel.h>
+#include <djv/Models/NotesModel.h>
+#include <djv/Models/RangesModel.h>
 #include <djv/Models/RecentFilesModel.h>
+#include <djv/Models/Review.h>
 #include <djv/Models/TimeUnitsModel.h>
 #include <djv/Models/CommandsModel.h>
 #include <djv/Models/ToolsModel.h>
@@ -33,6 +40,7 @@
 #include <djv/Models/ViewportModel.h>
 
 #include <tlRender/UI/ThumbnailSystem.h>
+#include <tlRender/UI/TimelineWidget.h>
 #include <tlRender/Timeline/ColorOptions.h>
 #include <tlRender/Timeline/CompareOptions.h>
 #include <tlRender/Timeline/Util.h>
@@ -45,6 +53,7 @@
 #include <tlRender/IO/USD.h>
 #endif // TLRENDER_USD
 
+#include <ftk/UI/DialogSystem.h>
 #include <ftk/UI/FileBrowser.h>
 #include <ftk/UI/Settings.h>
 #include <ftk/UI/SysLogModel.h>
@@ -54,7 +63,10 @@
 #include <ftk/Core/OS.h>
 #include <ftk/Core/Timer.h>
 
+#include <ctime>
 #include <filesystem>
+#include <fstream>
+#include <iomanip>
 #include <optional>
 
 namespace djv
@@ -182,6 +194,15 @@ namespace djv
             std::vector<std::shared_ptr<models::FilesModelItem> > files;
             std::vector<std::shared_ptr<models::FilesModelItem> > activeFiles;
             std::shared_ptr<models::RecentFilesModel> recentFilesModel;
+            std::shared_ptr<models::RecentFilesModel> recentReviewsModel;
+            std::filesystem::path reviewPath;
+            nlohmann::json reviewRaw;
+            bool reviewModified = false;
+            std::optional<models::ReviewView> pendingReviewView;
+            std::shared_ptr<ftk::Timer> reviewViewTimer;
+            std::shared_ptr<ftk::Timer> autosaveTimer;
+            std::optional<nlohmann::json> recoveredAutosave;
+            std::shared_ptr<SaveReviewDialog> saveReviewDialog;
             std::vector<std::shared_ptr<tl::Timeline> > timelines;
             std::shared_ptr<ftk::Observable<std::shared_ptr<tl::Player> > > player;
             std::shared_ptr<models::ColorModel> colorModel;
@@ -190,12 +211,23 @@ namespace djv
             bool audioDeviceMute = false;
             std::shared_ptr<models::ToolsModel> toolsModel;
             std::shared_ptr<models::CommandsModel> commandsModel;
+            std::shared_ptr<models::NotesModel> notesModel;
+            std::shared_ptr<models::RangesModel> rangesModel;
+            std::shared_ptr<models::AnnotationsModel> annotationsModel;
+            std::shared_ptr<models::DrawModel> drawModel;
+            std::shared_ptr<ftk::ObservableList<int> > reviewMarkers;
 
             std::shared_ptr<ftk::Observable<bool> > secondaryWindowActive;
             std::shared_ptr<ToolWidgetFactory> toolWidgetFactory;
             std::shared_ptr<MainWindow> mainWindow;
             std::shared_ptr<SecondaryWindow> secondaryWindow;
             std::shared_ptr<ui::SeparateAudioDialog> separateAudioDialog;
+
+            std::shared_ptr<ftk::Observer<tl::CompareOptions> > compareOptionsModifiedObserver;
+            std::shared_ptr<ftk::ListObserver<int> > bIndexesModifiedObserver;
+            std::shared_ptr<ftk::ListObserver<models::ReviewRange> > rangesObserver;
+            std::shared_ptr<ftk::ListObserver<models::ReviewNote> > notesObserver;
+            std::shared_ptr<ftk::ListObserver<models::ReviewAnnotation> > annotationsObserver;
 
             std::shared_ptr<ftk::Observer<tl::PlayerCacheOptions> > cacheObserver;
             std::shared_ptr<ftk::Observer<models::ImageSeqSettings> > imageSeqObserver;
@@ -553,6 +585,60 @@ namespace djv
             return _p->commandsModel;
         }
 
+        const std::shared_ptr<models::NotesModel>& App::getNotesModel() const
+        {
+            return _p->notesModel;
+        }
+
+        const std::shared_ptr<models::AnnotationsModel>& App::getAnnotationsModel() const
+        {
+            return _p->annotationsModel;
+        }
+
+        const std::shared_ptr<models::RangesModel>& App::getRangesModel() const
+        {
+            return _p->rangesModel;
+        }
+
+        const std::shared_ptr<models::DrawModel>& App::getDrawModel() const
+        {
+            return _p->drawModel;
+        }
+
+        std::shared_ptr<ftk::IObservableList<int> > App::observeReviewMarkers() const
+        {
+            return _p->reviewMarkers;
+        }
+
+        void App::seekReviewMarker(bool next)
+        {
+            FTK_P();
+            // The list is sorted and deduplicated by _notesUpdate().
+            const auto& markers = p.reviewMarkers->get();
+            auto player = p.player->get();
+            if (markers.empty() || !player)
+            {
+                return;
+            }
+            const OTIO_NS::RationalTime currentTime = player->getCurrentTime();
+            const int current = static_cast<int>(currentTime.value());
+            int target = 0;
+            if (next)
+            {
+                // The first marker strictly after the playhead, or wrap around
+                // to the first one so the button never becomes a dead end.
+                const auto i = std::upper_bound(markers.begin(), markers.end(), current);
+                target = i != markers.end() ? *i : markers.front();
+            }
+            else
+            {
+                const auto i = std::lower_bound(markers.begin(), markers.end(), current);
+                target = i != markers.begin() ? *(i - 1) : markers.back();
+            }
+            player->stop();
+            player->seek(OTIO_NS::RationalTime(target, currentTime.rate()));
+        }
+
         bool App::getHideSetup() const
         {
             return
@@ -605,6 +691,9 @@ namespace djv
             for (const auto& i : tl::getPaths(_context, path, dirListOptions))
             {
                 auto item = std::make_shared<models::FilesModelItem>();
+                // Annotations reference their source by this identity, so it has
+                // to exist from the moment the file is opened.
+                item->id = models::generateId();
                 item->path = i;
                 if (first && frames.has_value())
                 {
@@ -619,6 +708,812 @@ namespace djv
                 item->audioPath = audioPath;
                 p.filesModel->add(item);
                 p.recentFilesModel->addRecent(std::filesystem::u8path(path.get()));
+            }
+        }
+
+        namespace
+        {
+            const std::string reviewExtension = ".djvr";
+
+            std::string reviewTimestamp()
+            {
+                const std::time_t t = std::time(nullptr);
+                std::tm tm {};
+#if defined(_WIN32)
+                gmtime_s(&tm, &t);
+#else
+                gmtime_r(&t, &tm);
+#endif
+                char buf[32] = {};
+                std::strftime(buf, sizeof(buf), "%Y-%m-%dT%H:%M:%SZ", &tm);
+                return std::string(buf);
+            }
+
+            //! Make an absolute path string relative to the review's directory,
+            //! falling back to the absolute form when no relative path exists
+            //! (e.g. a different drive on Windows).
+            std::string reviewRelativePath(
+                const std::string& absStr,
+                const std::filesystem::path& base)
+            {
+                if (absStr.empty() || base.empty())
+                {
+                    return absStr;
+                }
+                std::error_code ec;
+                const std::filesystem::path rel = std::filesystem::relative(
+                    std::filesystem::u8path(absStr), base, ec);
+                if (ec || rel.empty())
+                {
+                    return absStr;
+                }
+                return rel.generic_u8string();
+            }
+
+            //! Does the file exist on disk? A single file is checked exactly; an
+            //! image sequence -- whose padded/pattern path is not a literal file
+            //! -- is considered present when its directory holds a matching frame.
+            bool reviewFilePresent(
+                const std::filesystem::path& p,
+                const ftk::PathOptions& pathOptions)
+            {
+                std::error_code ec;
+                if (std::filesystem::exists(p, ec))
+                {
+                    return true;
+                }
+                const ftk::Path ftkPath(p.u8string(), pathOptions);
+                if (ftkPath.getNum().empty())
+                {
+                    // Single file: genuinely missing.
+                    return false;
+                }
+                const std::filesystem::path dir = std::filesystem::u8path(ftkPath.getDir());
+                if (!std::filesystem::exists(dir, ec))
+                {
+                    return false;
+                }
+                const std::string base = ftkPath.getBase();
+                const std::string ext = ftkPath.getExt();
+                for (const auto& entry : std::filesystem::directory_iterator(dir, ec))
+                {
+                    const std::string name = entry.path().filename().u8string();
+                    if (name.size() >= base.size() + ext.size() &&
+                        0 == name.compare(0, base.size(), base) &&
+                        0 == name.compare(name.size() - ext.size(), ext.size(), ext))
+                    {
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            //! Resolve a review file entry to a path on disk, preferring the
+            //! relative form, then the absolute form, then the file's name inside
+            //! an optional substitute root (used by the relocation dialog).
+            //! Reports whether the target exists.
+            std::filesystem::path resolveReviewFile(
+                const models::ReviewFile& rf,
+                const std::filesystem::path& base,
+                const std::filesystem::path& substituteRoot,
+                const ftk::PathOptions& pathOptions,
+                bool& exists)
+            {
+                auto present = [&pathOptions](const std::filesystem::path& p)
+                {
+                    return reviewFilePresent(p, pathOptions);
+                };
+                if (!rf.path.empty())
+                {
+                    const std::filesystem::path rel =
+                        (base / std::filesystem::u8path(rf.path)).lexically_normal();
+                    if (present(rel))
+                    {
+                        exists = true;
+                        return rel;
+                    }
+                }
+                if (!rf.pathAbsolute.empty())
+                {
+                    const std::filesystem::path abs =
+                        std::filesystem::u8path(rf.pathAbsolute);
+                    if (present(abs))
+                    {
+                        exists = true;
+                        return abs;
+                    }
+                }
+                if (!substituteRoot.empty())
+                {
+                    std::filesystem::path fileName;
+                    if (!rf.path.empty())
+                    {
+                        fileName = std::filesystem::u8path(rf.path).filename();
+                    }
+                    else if (!rf.pathAbsolute.empty())
+                    {
+                        fileName = std::filesystem::u8path(rf.pathAbsolute).filename();
+                    }
+                    if (!fileName.empty())
+                    {
+                        const std::filesystem::path candidate = substituteRoot / fileName;
+                        if (present(candidate))
+                        {
+                            exists = true;
+                            return candidate;
+                        }
+                    }
+                }
+                exists = false;
+                if (!rf.path.empty())
+                {
+                    return (base / std::filesystem::u8path(rf.path)).lexically_normal();
+                }
+                return std::filesystem::u8path(rf.pathAbsolute);
+            }
+        }
+
+        void App::openReview(const std::filesystem::path& path)
+        {
+            FTK_P();
+
+            std::ifstream f(path);
+            if (!f.is_open())
+            {
+                _context->log(
+                    "djv::app::App",
+                    ftk::Format("Cannot open review: {0}").arg(path.u8string()),
+                    ftk::LogType::Error);
+                return;
+            }
+
+            models::Review review;
+            try
+            {
+                nlohmann::json json;
+                f >> json;
+                review = json.get<models::Review>();
+            }
+            catch (const std::exception& e)
+            {
+                _context->log(
+                    "djv::app::App",
+                    ftk::Format("Cannot read review \"{0}\": {1}").
+                        arg(path.u8string()).arg(e.what()),
+                    ftk::LogType::Error);
+                return;
+            }
+
+            _applyReview(review, path.parent_path(), path, std::filesystem::path());
+        }
+
+        void App::_applyReview(
+            const models::Review& review,
+            const std::filesystem::path& base,
+            const std::filesystem::path& reviewPath,
+            const std::filesystem::path& substituteRoot)
+        {
+            FTK_P();
+
+            ftk::PathOptions pathOptions;
+            pathOptions.seqMaxDigits = p.settingsModel->getImageSeq().maxDigits;
+
+            // Replace the current session.
+            p.filesModel->closeAll();
+
+            std::vector<std::string> missing;
+            for (const auto& rf : review.files)
+            {
+                bool exists = false;
+                const std::filesystem::path resolved =
+                    resolveReviewFile(rf, base, substituteRoot, pathOptions, exists);
+                if (!exists)
+                {
+                    missing.push_back(resolved.u8string());
+                }
+                auto item = std::make_shared<models::FilesModelItem>();
+                item->id = rf.id.empty() ? models::generateId() : rf.id;
+                item->path = ftk::Path(resolved.u8string(), pathOptions);
+                if (!rf.audioPath.empty())
+                {
+                    item->audioPath = ftk::Path(rf.audioPath, pathOptions);
+                }
+                item->videoLayer = static_cast<size_t>(std::max(0, rf.videoLayer));
+                item->speed = rf.speed;
+                item->currentTime = rf.currentTime;
+                item->inOutRange = rf.inOutRange;
+                // Add directly rather than through open(), which would re-expand a
+                // directory entry into multiple files.
+                p.filesModel->add(item);
+            }
+
+            // Rebuild the comparison. Order matters: setCompareOptions may pick a
+            // "B" of its own when none is set, so clear and rebuild "B" after it,
+            // then set "A". See docs/ROADMAP_REVIEW_SESSIONS.md Â§6.1.
+            const auto& files = p.filesModel->getFiles();
+            auto indexOfId = [&files](const std::string& id) -> int
+            {
+                for (int i = 0; i < static_cast<int>(files.size()); ++i)
+                {
+                    if (files[i]->id == id)
+                    {
+                        return i;
+                    }
+                }
+                return -1;
+            };
+            p.filesModel->setCompareOptions(review.compare.options);
+            p.filesModel->clearB();
+            for (const auto& bId : review.compare.bIds)
+            {
+                const int index = indexOfId(bId);
+                if (index >= 0)
+                {
+                    p.filesModel->setB(index, true);
+                }
+            }
+            int aIndex = indexOfId(review.compare.aId);
+            if (aIndex < 0 && !files.empty())
+            {
+                aIndex = 0;
+            }
+            if (aIndex >= 0)
+            {
+                p.filesModel->setA(aIndex);
+            }
+            p.filesModel->setCompareTime(review.compare.time);
+
+            // Color and image display.
+            p.colorModel->setOCIOOptions(review.color.ocio);
+            p.colorModel->setLUTOptions(review.color.lut);
+            p.viewportModel->setDisplayOptions(review.color.display);
+            p.viewportModel->setBackgroundOptions(review.color.background);
+            p.viewportModel->setForegroundOptions(review.color.foreground);
+            p.viewportModel->setAspectRatioOptions(review.color.aspectRatio);
+            p.viewportModel->setHUDOptions(review.color.hud);
+
+            // Interface.
+            if (!review.ui.activeTool.empty())
+            {
+                p.toolsModel->setActiveTool(review.ui.activeTool);
+            }
+            p.settingsModel->setWindow(review.ui.window);
+
+            p.notesModel->setNotes(review.notes);
+            p.rangesModel->setRanges(review.ranges);
+            p.annotationsModel->setAnnotations(review.annotations);
+
+            // View state is applied once the viewport exists and the new player's
+            // initial auto-frame has settled.
+            p.pendingReviewView = review.view;
+            if (p.mainWindow)
+            {
+                _applyReviewView();
+            }
+
+            p.reviewPath = reviewPath;
+            p.reviewRaw = review.raw;
+            p.recentReviewsModel->addRecent(reviewPath);
+            p.reviewModified = false;
+            _updateWindowTitle();
+            // A freshly loaded review supersedes any earlier autosave.
+            _deleteAutosave();
+
+            if (!missing.empty())
+            {
+                _context->log(
+                    "djv::app::App",
+                    ftk::Format("Review \"{0}\": {1} file(s) not found: {2}").
+                        arg(reviewPath.u8string()).
+                        arg(missing.size()).
+                        arg(ftk::join(missing, ", ")),
+                    ftk::LogType::Warning);
+
+                // Offer to relocate on the first pass only (a substitute root
+                // already tried means we shouldn't loop).
+                if (substituteRoot.empty() && p.mainWindow)
+                {
+                    auto dialogSystem = _context->getSystem<ftk::DialogSystem>();
+                    // Pre-wrap with newlines: ftk::Label renders "\n" but cannot
+                    // auto-wrap, so a long single line would scroll horizontally.
+                    dialogSystem->confirm(
+                        "Relocate Files",
+                        ftk::Format("{0} file(s) from this review\n"
+                            "could not be found.\n"
+                            "\n"
+                            "Locate the folder that contains them?").
+                            arg(missing.size()),
+                        p.mainWindow,
+                        [this, review, base, reviewPath](bool value)
+                        {
+                            if (value)
+                            {
+                                auto fileBrowserSystem = _context->getSystem<ftk::FileBrowserSystem>();
+                                fileBrowserSystem->open(
+                                    _p->mainWindow,
+                                    [this, review, base, reviewPath](const ftk::Path& folder)
+                                    {
+                                        _applyReview(
+                                            review,
+                                            base,
+                                            reviewPath,
+                                            std::filesystem::u8path(folder.get()));
+                                    },
+                                    "Locate Files",
+                                    base,
+                                    ftk::FileBrowserMode::Dir);
+                            }
+                        },
+                        "Locate...",
+                        "Ignore");
+                }
+            }
+        }
+
+        void App::_reviewFileDialog(
+            ftk::FileBrowserMode mode,
+            const std::string& title,
+            const std::function<void(const std::filesystem::path&)>& callback)
+        {
+            FTK_P();
+            // Use the shared file browser system so reviews get the same (native
+            // by default) dialog as media, now filtered to ".djvr" with a real
+            // save dialog.
+            auto fileBrowserSystem = _context->getSystem<ftk::FileBrowserSystem>();
+            const std::filesystem::path startPath = p.reviewPath.empty() ?
+                std::filesystem::path() : p.reviewPath.parent_path();
+            fileBrowserSystem->open(
+                p.mainWindow,
+                [callback](const ftk::Path& value)
+                {
+                    callback(std::filesystem::u8path(value.get()));
+                },
+                title,
+                startPath,
+                mode,
+                { reviewExtension },
+                "Review Session");
+        }
+
+        void App::openReviewDialog()
+        {
+            _reviewFileDialog(
+                ftk::FileBrowserMode::Open,
+                "Open Review",
+                [this](const std::filesystem::path& path)
+                {
+                    openReview(path);
+                });
+        }
+
+        void App::saveReview()
+        {
+            FTK_P();
+            if (p.reviewPath.empty())
+            {
+                saveReviewAs();
+            }
+            else
+            {
+                saveReview(p.reviewPath);
+            }
+        }
+
+        models::Review App::_buildReview(const std::filesystem::path& base)
+        {
+            FTK_P();
+
+            models::Review review;
+            review.version = models::reviewVersion;
+            review.app = ftk::Format("{0} {1}").
+                arg(p.appInfoModel->getFullName()).
+                arg(p.appInfoModel->getVersion());
+            review.created = reviewTimestamp();
+            // Carry any unknown sections from the review we last loaded so a
+            // load/save cycle does not drop them. See Â§4.4.
+            review.raw = p.reviewRaw;
+
+            for (const auto& file : p.filesModel->getFiles())
+            {
+                models::ReviewFile rf;
+                rf.id = file->id;
+                rf.pathAbsolute = file->path.get();
+                rf.path = reviewRelativePath(file->path.get(), base);
+                rf.audioPath = file->audioPath.get();
+                rf.videoLayer = static_cast<int>(file->videoLayer);
+                rf.speed = file->speed;
+                rf.currentTime = file->currentTime;
+                rf.inOutRange = file->inOutRange;
+                review.files.push_back(rf);
+            }
+
+            // Persist the live playback state of the active file, which the model
+            // item only receives when the file is switched away from.
+            if (auto player = p.player->get())
+            {
+                const int aIndex = p.filesModel->getAIndex();
+                if (aIndex >= 0 && aIndex < static_cast<int>(review.files.size()))
+                {
+                    review.files[aIndex].speed = player->getSpeed();
+                    review.files[aIndex].currentTime = player->getCurrentTime();
+                    review.files[aIndex].inOutRange = player->getInOutRange();
+                }
+            }
+
+            const auto& files = p.filesModel->getFiles();
+            const int aIndex = p.filesModel->getAIndex();
+            if (aIndex >= 0 && aIndex < static_cast<int>(files.size()))
+            {
+                review.compare.aId = files[aIndex]->id;
+            }
+            for (const int bIndex : p.filesModel->getBIndexes())
+            {
+                if (bIndex >= 0 && bIndex < static_cast<int>(files.size()))
+                {
+                    review.compare.bIds.push_back(files[bIndex]->id);
+                }
+            }
+            review.compare.options = p.filesModel->getCompareOptions();
+            review.compare.time = p.filesModel->getCompareTime();
+
+            if (p.mainWindow)
+            {
+                auto viewport = p.mainWindow->getViewport();
+                review.view.frameView = viewport->hasFrameView();
+                review.view.pos = viewport->getViewPos();
+                review.view.zoom = viewport->getZoom();
+            }
+
+            review.color.ocio = p.colorModel->getOCIOOptions();
+            review.color.lut = p.colorModel->getLUTOptions();
+            review.color.display = p.viewportModel->getDisplayOptions();
+            review.color.background = p.viewportModel->getBackgroundOptions();
+            review.color.foreground = p.viewportModel->getForegroundOptions();
+            review.color.aspectRatio = p.viewportModel->getAspectRatioOptions();
+            review.color.hud = p.viewportModel->getHUDOptions();
+
+            review.ui.activeTool = p.toolsModel->getActiveTool();
+            review.ui.window = p.settingsModel->getWindow();
+
+            review.notes = p.notesModel->getNotes();
+            review.ranges = p.rangesModel->getRanges();
+            review.annotations = p.annotationsModel->getAnnotations();
+
+            return review;
+        }
+
+        void App::saveReview(const std::filesystem::path& path)
+        {
+            FTK_P();
+
+            const models::Review review = _buildReview(path.parent_path());
+
+            nlohmann::json json = review;
+            std::ofstream f(path);
+            if (!f.is_open())
+            {
+                _context->log(
+                    "djv::app::App",
+                    ftk::Format("Cannot save review: {0}").arg(path.u8string()),
+                    ftk::LogType::Error);
+                return;
+            }
+            f << std::setw(4) << json << std::endl;
+
+            p.reviewPath = path;
+            p.reviewRaw = json;
+            p.recentReviewsModel->addRecent(path);
+            p.reviewModified = false;
+            _updateWindowTitle();
+            // The work is safely on disk; drop any crash-recovery backup.
+            _deleteAutosave();
+        }
+
+        void App::saveReviewAs()
+        {
+            _saveReviewAs(nullptr);
+        }
+
+        void App::_saveReviewAs(const std::function<void()>& onSaved)
+        {
+            _reviewFileDialog(
+                ftk::FileBrowserMode::Save,
+                "Save Review",
+                [this, onSaved](const std::filesystem::path& value)
+                {
+                    std::filesystem::path path = value;
+                    if (path.extension() != reviewExtension)
+                    {
+                        // Auto-complete the extension when the user types a bare
+                        // name.
+                        path.replace_extension(reviewExtension);
+                    }
+                    saveReview(path);
+                    if (onSaved)
+                    {
+                        onSaved();
+                    }
+                });
+        }
+
+        void App::closeReview()
+        {
+            confirmClose(
+                [this]
+                {
+                    _closeReview();
+                });
+        }
+
+        void App::_closeReview()
+        {
+            FTK_P();
+            // Reset to the empty startup state.
+            p.filesModel->closeAll();
+            tl::CompareOptions compareOptions;
+            compareOptions.compare = tl::Compare::A;
+            p.filesModel->setCompareOptions(compareOptions);
+            p.notesModel->clear();
+            p.rangesModel->clear();
+            p.annotationsModel->clear();
+            p.reviewPath.clear();
+            p.reviewRaw = nlohmann::json();
+            // closeAll / setCompareOptions marked the session modified; clear it
+            // last so the empty state is clean.
+            p.reviewModified = false;
+            _updateWindowTitle();
+            _deleteAutosave();
+        }
+
+        const std::filesystem::path& App::getReviewPath() const
+        {
+            return _p->reviewPath;
+        }
+
+        const std::shared_ptr<models::RecentFilesModel>& App::getRecentReviewsModel() const
+        {
+            return _p->recentReviewsModel;
+        }
+
+        void App::confirmClose(const std::function<void()>& onProceed)
+        {
+            FTK_P();
+            // Only prompt for a review that is already saved (has a path) and has
+            // unsaved changes -- opening loose media without a review never asks.
+            if (!p.reviewModified ||
+                p.reviewPath.empty() ||
+                p.filesModel->getFiles().empty() ||
+                !p.mainWindow)
+            {
+                onProceed();
+                return;
+            }
+            if (p.saveReviewDialog)
+            {
+                p.saveReviewDialog->close();
+                p.saveReviewDialog.reset();
+            }
+            p.saveReviewDialog = SaveReviewDialog::create(
+                _context,
+                "Save Review",
+                "Save changes to the review before closing?");
+            p.saveReviewDialog->open(p.mainWindow);
+            p.saveReviewDialog->setCallback(
+                [this, onProceed](SaveReviewResult result)
+                {
+                    // Act first, then close: closing resets the dialog (via the
+                    // close callback), which can destroy this closure, so nothing
+                    // captured may be used afterwards.
+                    switch (result)
+                    {
+                    case SaveReviewResult::Save:
+                        // The prompt only appears for an already-saved review, so
+                        // the path is always set here.
+                        saveReview(_p->reviewPath);
+                        onProceed();
+                        break;
+                    case SaveReviewResult::Discard:
+                        // A deliberate discard is not a crash: drop the backup.
+                        _deleteAutosave();
+                        onProceed();
+                        break;
+                    case SaveReviewResult::Cancel:
+                    default:
+                        break;
+                    }
+                    if (_p->saveReviewDialog)
+                    {
+                        _p->saveReviewDialog->close();
+                    }
+                });
+            p.saveReviewDialog->setCloseCallback(
+                [this]
+                {
+                    _p->saveReviewDialog.reset();
+                });
+        }
+
+        void App::_markModified()
+        {
+            FTK_P();
+            if (!p.reviewModified)
+            {
+                p.reviewModified = true;
+                // Reflect the change with a "*" in the title.
+                _updateWindowTitle();
+            }
+        }
+
+        void App::_notesUpdate()
+        {
+            FTK_P();
+            // Mark the frames that carry a note or a drawing in the timeline.
+            // The markers are deliberately undifferentiated -- they say "there
+            // is something here" -- and follow the timeline, which shows "A".
+            std::vector<int> markers;
+            for (const auto& note : p.notesModel->getNotes())
+            {
+                if (note.time.has_value())
+                {
+                    markers.push_back(static_cast<int>(note.time->value()));
+                }
+            }
+            // Every annotation is stamped with the player's time, which is the
+            // timeline's own clock, so a drawing made on a "B" source still
+            // marks the right place. Filtering on the source would drop those.
+            for (const auto& annotation : p.annotationsModel->getAnnotations())
+            {
+                if (annotation.time.has_value())
+                {
+                    markers.push_back(static_cast<int>(annotation.time->value()));
+                }
+            }
+            std::sort(markers.begin(), markers.end());
+            markers.erase(std::unique(markers.begin(), markers.end()), markers.end());
+            p.reviewMarkers->setIfChanged(markers);
+            // The window can still be missing here: the observers fire while a
+            // review passed on the command line is applied. The markers are kept
+            // above regardless, and pushed again once the window exists.
+            if (p.mainWindow)
+            {
+                p.mainWindow->getTimelineWidget()->setFrameMarkers(markers);
+            }
+        }
+
+        void App::_updateWindowTitle()
+        {
+            FTK_P();
+            if (!p.mainWindow)
+            {
+                return;
+            }
+            std::string title = ftk::Format("{0} {1}").
+                arg(p.appInfoModel->getFullName()).
+                arg(p.appInfoModel->getVersion());
+            if (!p.reviewPath.empty())
+            {
+                // Show the active review so the user can tell which one is open,
+                // with a trailing "*" while it has unsaved changes.
+                title += " - " + p.reviewPath.u8string();
+                if (p.reviewModified)
+                {
+                    title += " *";
+                }
+            }
+            p.mainWindow->setTitle(title);
+        }
+
+        void App::_applyReviewView()
+        {
+            FTK_P();
+            if (!p.pendingReviewView.has_value() || !p.mainWindow)
+            {
+                return;
+            }
+            if (p.pendingReviewView->frameView)
+            {
+                p.mainWindow->getViewport()->setFrameView(true);
+                p.pendingReviewView.reset();
+            }
+            else
+            {
+                // Defer past the initial auto-frame that the new player triggers
+                // on the next layout pass. setViewPosAndZoom disables frame view,
+                // so no later re-frame overrides it.
+                if (!p.reviewViewTimer)
+                {
+                    p.reviewViewTimer = ftk::Timer::create(_context);
+                }
+                p.reviewViewTimer->start(
+                    std::chrono::milliseconds(200),
+                    [this]
+                    {
+                        FTK_P();
+                        if (p.pendingReviewView.has_value() && p.mainWindow)
+                        {
+                            p.mainWindow->getViewport()->setViewPosAndZoom(
+                                p.pendingReviewView->pos,
+                                p.pendingReviewView->zoom);
+                            p.pendingReviewView.reset();
+                        }
+                    });
+            }
+        }
+
+        std::filesystem::path App::_autosavePath()
+        {
+            FTK_P();
+            return _appDocsPath() / ftk::Format("{0}.{1}.autosave.djvr").
+                arg(p.appInfoModel->getShortName()).
+                arg(p.appInfoModel->getVersionMajor()).
+                str();
+        }
+
+        void App::_writeAutosave()
+        {
+            FTK_P();
+            // Only a saved review with unsaved changes is worth backing up.
+            if (!p.reviewModified || p.reviewPath.empty())
+            {
+                return;
+            }
+            try
+            {
+                nlohmann::json json = _buildReview(p.reviewPath.parent_path());
+                // Remember which review this backs up, for recovery.
+                json["_autosaveReviewPath"] = p.reviewPath.u8string();
+                std::ofstream f(_autosavePath());
+                if (f.is_open())
+                {
+                    f << std::setw(4) << json << std::endl;
+                }
+            }
+            catch (const std::exception& e)
+            {
+                _context->log(
+                    "djv::app::App",
+                    ftk::Format("Cannot write autosave: {0}").arg(e.what()),
+                    ftk::LogType::Warning);
+            }
+        }
+
+        void App::_deleteAutosave()
+        {
+            std::error_code ec;
+            std::filesystem::remove(_autosavePath(), ec);
+        }
+
+        void App::_recoverAutosave()
+        {
+            FTK_P();
+            if (!p.recoveredAutosave.has_value())
+            {
+                return;
+            }
+            const nlohmann::json json = *p.recoveredAutosave;
+            p.recoveredAutosave.reset();
+            try
+            {
+                models::Review review = json.get<models::Review>();
+                std::filesystem::path reviewPath;
+                if (json.contains("_autosaveReviewPath"))
+                {
+                    reviewPath = std::filesystem::u8path(
+                        json.at("_autosaveReviewPath").get<std::string>());
+                }
+                // Keep the internal marker out of any later saved ".djvr".
+                review.raw.erase("_autosaveReviewPath");
+                _applyReview(review, reviewPath.parent_path(), reviewPath, std::filesystem::path());
+                // The recovered state is, by definition, unsaved.
+                p.reviewModified = true;
+                _updateWindowTitle();
+            }
+            catch (const std::exception& e)
+            {
+                _context->log(
+                    "djv::app::App",
+                    ftk::Format("Cannot recover autosave: {0}").arg(e.what()),
+                    ftk::LogType::Error);
             }
         }
 
@@ -874,6 +1769,24 @@ namespace djv
                 p.settingsFile,
                 p.cmdLine.resetSettings->found());
 
+            // Capture any autosave left by a crashed session before anything can
+            // overwrite or delete it; the recovery prompt is offered once the
+            // main window exists.
+            {
+                std::ifstream f(_autosavePath());
+                if (f.is_open())
+                {
+                    try
+                    {
+                        nlohmann::json json;
+                        f >> json;
+                        p.recoveredAutosave = json;
+                    }
+                    catch (const std::exception&)
+                    {}
+                }
+            }
+
             _modelsInit();
             _observersInit();
             _inputFilesInit();
@@ -1090,6 +2003,9 @@ namespace djv
             p.filesModel = models::FilesModel::create(p.settings);
 
             p.recentFilesModel = models::RecentFilesModel::create(_context, p.settings);
+            // Reviews get their own recent list, so opening a session does not
+            // push its media into the recent files.
+            p.recentReviewsModel = models::RecentFilesModel::create(_context, p.settings, "Review");
             auto fileBrowserSystem = _context->getSystem<ftk::FileBrowserSystem>();
             fileBrowserSystem->getModel()->setExts(tl::getExts(_context));
             ftk::FileBrowserOptions fileBrowserOptions;
@@ -1151,6 +2067,12 @@ namespace djv
             p.toolsModel = models::ToolsModel::create(p.settings);
 
             p.commandsModel = models::CommandsModel::create(_context);
+
+            p.notesModel = models::NotesModel::create();
+            p.rangesModel = models::RangesModel::create();
+            p.annotationsModel = models::AnnotationsModel::create();
+            p.drawModel = models::DrawModel::create(p.settings);
+            p.reviewMarkers = ftk::ObservableList<int>::create();
         }
 
         void App::_observersInit()
@@ -1217,6 +2139,40 @@ namespace djv
                 [this](const std::vector<std::shared_ptr<models::FilesModelItem> >& value)
                 {
                     _activeUpdate(value);
+                });
+            p.notesObserver = ftk::ListObserver<models::ReviewNote>::create(
+                p.notesModel->observeNotes(),
+                [this](const std::vector<models::ReviewNote>&)
+                {
+                    _notesUpdate();
+                    _markModified();
+                });
+            p.annotationsObserver = ftk::ListObserver<models::ReviewAnnotation>::create(
+                p.annotationsModel->observeAnnotations(),
+                [this](const std::vector<models::ReviewAnnotation>&)
+                {
+                    _notesUpdate();
+                    _markModified();
+                });
+            // Ranges carry no timeline marker: they are a selection, not a
+            // point of interest. They only have to reach the review file.
+            p.rangesObserver = ftk::ListObserver<models::ReviewRange>::create(
+                p.rangesModel->observeRanges(),
+                [this](const std::vector<models::ReviewRange>&)
+                {
+                    _markModified();
+                });
+            p.compareOptionsModifiedObserver = ftk::Observer<tl::CompareOptions>::create(
+                p.filesModel->observeCompareOptions(),
+                [this](const tl::CompareOptions&)
+                {
+                    _markModified();
+                });
+            p.bIndexesModifiedObserver = ftk::ListObserver<int>::create(
+                p.filesModel->observeBIndexes(),
+                [this](const std::vector<int>&)
+                {
+                    _markModified();
                 });
             p.layersObserver = ftk::ListObserver<int>::create(
                 p.filesModel->observeLayers(),
@@ -1310,6 +2266,18 @@ namespace djv
             {
                 ftk::PathOptions pathOptions;
                 pathOptions.seqMaxDigits = p.settingsModel->getImageSeq().maxDigits;
+
+                // A review (".djvr") describes an entire session; open it and
+                // ignore any other inputs.
+                {
+                    const std::filesystem::path firstPath = std::filesystem::u8path(
+                        p.cmdLine.inputs->getList().front());
+                    if (firstPath.extension() == reviewExtension)
+                    {
+                        openReview(firstPath);
+                        return;
+                    }
+                }
 
                 if (p.cmdLine.compareFileName->found())
                 {
@@ -1433,6 +2401,7 @@ namespace djv
             p.toolWidgetFactory->addTool("Information", &InfoTool::create);
             p.toolWidgetFactory->addTool("Magnify", &MagnifyTool::create);
             p.toolWidgetFactory->addTool("Messages", &MessagesTool::create);
+            p.toolWidgetFactory->addTool("Review", &ReviewTool::create);
             p.toolWidgetFactory->addTool("Settings", &SettingsTool::create);
             p.toolWidgetFactory->addTool("System Log", &SysLogTool::create);
             p.toolWidgetFactory->addTool("View", &ViewTool::create);
@@ -1473,6 +2442,58 @@ namespace djv
                         _p->mainWindow->getViewport()->getZoom(),
                         value);
                 });
+
+            // Apply any view state from a review opened before the window existed
+            // (e.g. a ".djvr" passed on the command line).
+            _applyReviewView();
+            // Reflect a review opened before the window existed in the title.
+            _updateWindowTitle();
+            // Same for the timeline markers: the notes and annotations observers
+            // fired while there was no window, so _notesUpdate() bailed out.
+            _notesUpdate();
+
+            // Start periodic crash-recovery autosave.
+            p.autosaveTimer = ftk::Timer::create(_context);
+            p.autosaveTimer->setRepeating(true);
+            p.autosaveTimer->start(
+                std::chrono::seconds(30),
+                [this]
+                {
+                    _writeAutosave();
+                });
+
+            // Offer to recover a review from a crashed session, unless files were
+            // already opened this launch (e.g. from the command line).
+            if (p.recoveredAutosave.has_value() && p.filesModel->getFiles().empty())
+            {
+                auto dialogSystem = _context->getSystem<ftk::DialogSystem>();
+                dialogSystem->confirm(
+                    "Recover Review",
+                    "Unsaved review changes from a previous\n"
+                    "session were found.\n"
+                    "\n"
+                    "Recover them?",
+                    p.mainWindow,
+                    [this](bool value)
+                    {
+                        FTK_P();
+                        if (value)
+                        {
+                            _recoverAutosave();
+                        }
+                        else
+                        {
+                            p.recoveredAutosave.reset();
+                            _deleteAutosave();
+                        }
+                    },
+                    "Recover",
+                    "Discard");
+            }
+            else
+            {
+                p.recoveredAutosave.reset();
+            }
         }
 
         void App::_setAudioDeviceMute(bool value)

--- a/lib/djv/App/App.h
+++ b/lib/djv/App/App.h
@@ -8,14 +8,18 @@
 #include <tlRender/Timeline/Player.h>
 
 #include <ftk/UI/App.h>
+#include <ftk/Core/ObservableList.h>
 
 #include <filesystem>
+#include <functional>
 #include <optional>
 
 namespace ftk
 {
     class Settings;
     class SysLogModel;
+
+    enum class FileBrowserMode;
 }
 
 namespace djv
@@ -23,12 +27,17 @@ namespace djv
     namespace models
     {
         struct FilesModelItem;
+        struct Review;
 
+        class AnnotationsModel;
         class AppInfoModel;
         class AudioModel;
         class ColorModel;
         class CommandsModel;
+        class DrawModel;
         class FilesModel;
+        class NotesModel;
+        class RangesModel;
         class RecentFilesModel;
         class TimeUnitsModel;
         class ToolsModel;
@@ -100,6 +109,29 @@ namespace djv
             //! Get the commands model.
             const std::shared_ptr<models::CommandsModel>& getCommandsModel() const;
 
+            //! Get the review notes model.
+            const std::shared_ptr<models::NotesModel>& getNotesModel() const;
+
+            //! Get the review annotations model.
+            const std::shared_ptr<models::AnnotationsModel>& getAnnotationsModel() const;
+
+            //! Get the review ranges model.
+            const std::shared_ptr<models::RangesModel>& getRangesModel() const;
+
+            //! Get the drawing state model.
+            const std::shared_ptr<models::DrawModel>& getDrawModel() const;
+
+            //! Observe the frames that carry a note or a drawing, sorted and
+            //! deduplicated.
+            //!
+            //! The timeline draws them as markers and the playback bar jumps
+            //! between them, so both read the same list.
+            std::shared_ptr<ftk::IObservableList<int> > observeReviewMarkers() const;
+
+            //! Seek to the review marker after (or before) the current frame,
+            //! wrapping around at the ends. Does nothing without a marker.
+            void seekReviewMarker(bool next);
+
             //! Get whether the setup dialog should be hidden. The setup
             //! dialog is hidden by the "-hideSetup" command line flag, by
             //! automation (the "-command" and "-listCommands" flags), and
@@ -123,6 +155,45 @@ namespace djv
 
             //! Open a file and separate audio file dialog.
             void openSeparateAudioDialog();
+
+            //! \name Reviews
+            //! A review (".djvr") is a saved session: the open files, the active
+            //! tab, the comparison setup, and the viewport, color and interface
+            //! state, together with its notes and drawings.
+            ///@{
+
+            //! Open a review, replacing the current session.
+            void openReview(const std::filesystem::path&);
+
+            //! Open a review file dialog.
+            void openReviewDialog();
+
+            //! Save the current session to the active review, prompting for a
+            //! location if none is set.
+            void saveReview();
+
+            //! Save the current session to the given review path.
+            void saveReview(const std::filesystem::path&);
+
+            //! Save the current session to a new review, always prompting.
+            void saveReviewAs();
+
+            //! Close the current review and reset to the empty startup state,
+            //! prompting to save first if there are unsaved changes.
+            void closeReview();
+
+            //! Get the path of the active review, or empty if none.
+            const std::filesystem::path& getReviewPath() const;
+
+            //! Get the recent reviews model.
+            const std::shared_ptr<models::RecentFilesModel>& getRecentReviewsModel() const;
+
+            //! If the review has unsaved changes, prompt the user to save,
+            //! discard, or cancel; otherwise proceed immediately. The proceed
+            //! callback runs when it is safe to close.
+            void confirmClose(const std::function<void()>& onProceed);
+
+            ///@}
 
             //! Reload the active files.
             void reload();
@@ -175,6 +246,28 @@ namespace djv
             void _reloadUpdate(const std::shared_ptr<models::FilesModelItem>&);
             void _layersUpdate(const std::vector<int>&);
             void _audioUpdate();
+
+            void _reviewFileDialog(
+                ftk::FileBrowserMode,
+                const std::string& title,
+                const std::function<void(const std::filesystem::path&)>&);
+            void _saveReviewAs(const std::function<void()>& onSaved);
+            models::Review _buildReview(const std::filesystem::path& base);
+            void _applyReview(
+                const models::Review&,
+                const std::filesystem::path& base,
+                const std::filesystem::path& reviewPath,
+                const std::filesystem::path& substituteRoot);
+            void _closeReview();
+            void _applyReviewView();
+
+            std::filesystem::path _autosavePath();
+            void _writeAutosave();
+            void _deleteAutosave();
+            void _recoverAutosave();
+            void _markModified();
+            void _updateWindowTitle();
+            void _notesUpdate();
 
             FTK_PRIVATE();
         };

--- a/lib/djv/App/App.h
+++ b/lib/djv/App/App.h
@@ -258,6 +258,9 @@ namespace djv
                 const std::filesystem::path& base,
                 const std::filesystem::path& reviewPath,
                 const std::filesystem::path& substituteRoot);
+            void _logUnreadSections(
+                const models::Review&,
+                const std::filesystem::path& reviewPath);
             void _closeReview();
             void _applyReviewView();
 

--- a/lib/djv/App/BottomToolBar.cpp
+++ b/lib/djv/App/BottomToolBar.cpp
@@ -106,6 +106,8 @@ namespace djv
             p.buttons["Prev"]->setRepeatClick(true);
             p.buttons["Next"] = ftk::ToolButton::create(context, actions["Next"]);
             p.buttons["Next"]->setRepeatClick(true);
+            p.buttons["PrevMarker"] = ftk::ToolButton::create(context, actions["PrevMarker"]);
+            p.buttons["NextMarker"] = ftk::ToolButton::create(context, actions["NextMarker"]);
 
             p.frameShuttle = ftk::ShuttleWidget::create(context);
             p.frameShuttle->setTooltip("Frame shuttle. Click and drag to change the current frame.");
@@ -162,6 +164,13 @@ namespace djv
             p.buttons["Next"]->setParent(hLayout2);
             p.buttons["End"]->setParent(hLayout2);
             p.frameShuttle->setParent(hLayout2);
+            // The review jumps sit with the frame navigation: they are the same
+            // gesture, on the frames that carry a note or a drawing.
+            hLayout2 = ftk::HorizontalLayout::create(context, hLayout);
+            hLayout2->setSpacingRole(ftk::SizeRole::None);
+            ftk::setScreenshotTag(hLayout2, "Playback.MarkerControls");
+            p.buttons["PrevMarker"]->setParent(hLayout2);
+            p.buttons["NextMarker"]->setParent(hLayout2);
             p.currentTimeEdit->setParent(hLayout);
             p.durationLabel->setParent(hLayout);
             p.timeUnitsWidget->setParent(hLayout);

--- a/lib/djv/App/CMakeLists.txt
+++ b/lib/djv/App/CMakeLists.txt
@@ -32,6 +32,9 @@ set(HEADERS
     MessagesTool.h
     PlaybackActions.h
     PlaybackMenu.h
+    RangeNameDialog.h
+    ReviewTool.h
+    SaveReviewDialog.h
     SecondaryWindow.h
     SettingsTool.h
     StatusBar.h
@@ -87,6 +90,9 @@ set(SOURCE
     MessagesTool.cpp
     PlaybackActions.cpp
     PlaybackMenu.cpp
+    RangeNameDialog.cpp
+    ReviewTool.cpp
+    SaveReviewDialog.cpp
     SecondaryWindow.cpp
     SettingsTool.cpp
     StatusBar.cpp

--- a/lib/djv/App/FileActions.cpp
+++ b/lib/djv/App/FileActions.cpp
@@ -159,13 +159,66 @@ namespace djv
                 });
 
             _addCommand(
+                "OpenReview",
+                "Open a review, replacing the current session.",
+                [appWeak](const nlohmann::json&)
+                {
+                    if (auto app = appWeak.lock())
+                    {
+                        app->openReviewDialog();
+                    }
+                });
+
+            _addCommand(
+                "SaveReview",
+                "Save the current session as a review.",
+                [appWeak](const nlohmann::json&)
+                {
+                    if (auto app = appWeak.lock())
+                    {
+                        app->saveReview();
+                    }
+                });
+
+            _addCommand(
+                "SaveReviewAs",
+                "Save the current session as a new review.",
+                [appWeak](const nlohmann::json&)
+                {
+                    if (auto app = appWeak.lock())
+                    {
+                        app->saveReviewAs();
+                    }
+                });
+
+            _addCommand(
+                "CloseReview",
+                "Close the review and reset to the startup state.",
+                [appWeak](const nlohmann::json&)
+                {
+                    if (auto app = appWeak.lock())
+                    {
+                        app->closeReview();
+                    }
+                });
+
+            _addCommand(
                 "Exit",
                 "Exit the application.",
                 [appWeak](const nlohmann::json&)
                 {
                     if (auto app = appWeak.lock())
                     {
-                        app->exit();
+                        // Quitting with an unsaved review prompts first, the
+                        // same way closing one does.
+                        app->confirmClose(
+                            [appWeak]
+                            {
+                                if (auto app = appWeak.lock())
+                                {
+                                    app->exit();
+                                }
+                            });
                     }
                 });
 
@@ -178,6 +231,18 @@ namespace djv
                 "Open With Audio",
                 "FileOpenAudio",
                 _command("OpenAudio"));
+            _actions["OpenReview"] = ftk::Action::create(
+                "Open Review",
+                _command("OpenReview"));
+            _actions["SaveReview"] = ftk::Action::create(
+                "Save Review",
+                _command("SaveReview"));
+            _actions["SaveReviewAs"] = ftk::Action::create(
+                "Save Review As...",
+                _command("SaveReviewAs"));
+            _actions["CloseReview"] = ftk::Action::create(
+                "Close Review",
+                _command("CloseReview"));
             _actions["Close"] = ftk::Action::create(
                 "Close",
                 "FileClose",
@@ -223,6 +288,25 @@ namespace djv
                     ftk::Key::O,
                     static_cast<int>(ftk::KeyModifier::Shift) |
                     static_cast<int>(ftk::commandKeyModifier)));
+            // Alt rather than Shift on the command modifier: Shift+Ctrl+O is
+            // "Open with audio", and Shift+Ctrl+S is free but keeping the pair
+            // symmetrical is worth more than reusing it.
+            _addShortcut(
+                "OpenReview",
+                "Open review",
+                ftk::KeyShortcut(
+                    ftk::Key::O,
+                    static_cast<int>(ftk::KeyModifier::Alt) |
+                    static_cast<int>(ftk::commandKeyModifier)));
+            _addShortcut(
+                "SaveReview",
+                "Save review",
+                ftk::KeyShortcut(
+                    ftk::Key::S,
+                    static_cast<int>(ftk::KeyModifier::Alt) |
+                    static_cast<int>(ftk::commandKeyModifier)));
+            _addShortcut("SaveReviewAs", "Save review as");
+            _addShortcut("CloseReview", "Close review");
             _addShortcut("Close", "Close", ftk::KeyShortcut(ftk::Key::E, static_cast<int>(ftk::commandKeyModifier)));
             _addShortcut(
                 "CloseAll",
@@ -256,6 +340,11 @@ namespace djv
                     _actions["Close"]->setEnabled(!value.empty());
                     _actions["CloseAll"]->setEnabled(!value.empty());
                     _actions["Reload"]->setEnabled(!value.empty());
+                    // There is nothing to save, and nothing to close, until a
+                    // file is open. Opening a review stays available.
+                    _actions["SaveReview"]->setEnabled(!value.empty());
+                    _actions["SaveReviewAs"]->setEnabled(!value.empty());
+                    _actions["CloseReview"]->setEnabled(!value.empty());
                     _actions["Next"]->setEnabled(value.size() > 1);
                     _actions["Prev"]->setEnabled(value.size() > 1);
                 });

--- a/lib/djv/App/FileMenu.cpp
+++ b/lib/djv/App/FileMenu.cpp
@@ -35,6 +35,7 @@ namespace djv
             std::shared_ptr<ftk::Observer<int> > aIndexObserver;
             std::shared_ptr<ftk::ListObserver<int> > layersObserver;
             std::shared_ptr<ftk::ListObserver<std::filesystem::path> > recentObserver;
+            std::shared_ptr<ftk::ListObserver<std::filesystem::path> > recentReviewsObserver;
             std::shared_ptr<ftk::Observer<std::shared_ptr<tl::Player> > > playerObserver;
             std::shared_ptr<ftk::Observer<std::string> > mediaReferenceKeyObserver;
         };
@@ -57,10 +58,17 @@ namespace djv
             auto actions = fileActions->getActions();
             addAction(actions["Open"]);
             addAction(actions["OpenAudio"]);
+            p.menus["Recent"] = addSubMenu("Recent");
+            addDivider();
+            addAction(actions["OpenReview"]);
+            addAction(actions["SaveReview"]);
+            addAction(actions["SaveReviewAs"]);
+            addAction(actions["CloseReview"]);
+            p.menus["RecentReviews"] = addSubMenu("Recent Reviews");
+            addDivider();
             addAction(actions["Close"]);
             addAction(actions["CloseAll"]);
             addAction(actions["Reload"]);
-            p.menus["Recent"] = addSubMenu("Recent");
             addDivider();
             p.menus["Current"] = addSubMenu("Current");
             addAction(actions["Next"]);
@@ -115,6 +123,13 @@ namespace djv
                 [this](const std::vector<std::filesystem::path>& value)
                 {
                     _recentUpdate(value);
+                });
+
+            p.recentReviewsObserver = ftk::ListObserver<std::filesystem::path>::create(
+                app->getRecentReviewsModel()->observeRecent(),
+                [this](const std::vector<std::filesystem::path>& value)
+                {
+                    _recentReviewsUpdate(value);
                 });
         }
 
@@ -285,6 +300,31 @@ namespace djv
                 p.menus["MediaReferences"]->setChecked(
                     p.mediaReferencesActions[i],
                     p.mediaReferenceKeys[i] == value);
+            }
+        }
+
+        void FileMenu::_recentReviewsUpdate(const std::vector<std::filesystem::path>& value)
+        {
+            FTK_P();
+            p.menus["RecentReviews"]->clear();
+            for (auto i = value.rbegin(); i != value.rend(); ++i)
+            {
+                const auto path = *i;
+                auto weak = std::weak_ptr<FileMenu>(std::dynamic_pointer_cast<FileMenu>(shared_from_this()));
+                auto action = ftk::Action::create(
+                    path.u8string(),
+                    [weak, path]
+                    {
+                        if (auto widget = weak.lock())
+                        {
+                            if (auto app = widget->_p->app.lock())
+                            {
+                                app->openReview(path);
+                            }
+                            widget->close();
+                        }
+                    });
+                p.menus["RecentReviews"]->addAction(action);
             }
         }
 

--- a/lib/djv/App/FileMenu.h
+++ b/lib/djv/App/FileMenu.h
@@ -52,6 +52,7 @@ namespace djv
             void _aIndexUpdate(int);
             void _layersUpdate(const std::vector<int>&);
             void _recentUpdate(const std::vector<std::filesystem::path>&);
+            void _recentReviewsUpdate(const std::vector<std::filesystem::path>&);
             void _setPlayer(const std::shared_ptr<tl::Player>&);
             void _mediaReferencesUpdate();
             void _mediaReferenceKeyUpdate(const std::string&);

--- a/lib/djv/App/FrameActions.cpp
+++ b/lib/djv/App/FrameActions.cpp
@@ -12,7 +12,11 @@ namespace djv
     {
         struct FrameActions::Private
         {
+            bool hasPlayer = false;
+            bool hasMarkers = false;
+
             std::shared_ptr<ftk::Observer<std::shared_ptr<tl::Player> > > playerObserver;
+            std::shared_ptr<ftk::ListObserver<int> > markersObserver;
         };
 
         void FrameActions::_init(
@@ -137,6 +141,31 @@ namespace djv
                     }
                 });
 
+            // Jump between the frames that carry a note or a drawing. In a
+            // review these are the only frames that matter, and stepping to
+            // them by hand over a long timeline is the slow part.
+            _addCommand(
+                "PrevMarker",
+                "Go to the previous frame with a note or a drawing.",
+                [appWeak](const nlohmann::json&)
+                {
+                    if (auto app = appWeak.lock())
+                    {
+                        app->seekReviewMarker(false);
+                    }
+                });
+
+            _addCommand(
+                "NextMarker",
+                "Go to the next frame with a note or a drawing.",
+                [appWeak](const nlohmann::json&)
+                {
+                    if (auto app = appWeak.lock())
+                    {
+                        app->seekReviewMarker(true);
+                    }
+                });
+
             auto mainWindowWeak = std::weak_ptr<MainWindow>(mainWindow);
             _addCommand(
                 "FocusCurrent",
@@ -178,6 +207,14 @@ namespace djv
             _actions["NextX100"] = ftk::Action::create(
                 "Next Frame X100",
                 _command("NextX100"));
+            _actions["PrevMarker"] = ftk::Action::create(
+                "Previous Review Marker",
+                "ReviewPrev",
+                _command("PrevMarker"));
+            _actions["NextMarker"] = ftk::Action::create(
+                "Next Review Marker",
+                "ReviewNext",
+                _command("NextMarker"));
             _actions["FocusCurrent"] = ftk::Action::create(
                 "Focus Current Frame",
                 _command("FocusCurrent"));
@@ -191,9 +228,21 @@ namespace djv
             _addShortcut("Next", "Next", ftk::Key::Right);
             _addShortcut("NextX10", "Next X10", ftk::KeyShortcut(ftk::Key::Right, static_cast<int>(ftk::KeyModifier::Shift)));
             _addShortcut("NextX100", "Next X100", ftk::KeyShortcut(ftk::Key::Right, static_cast<int>(ftk::KeyModifier::Control)));
+            // Shift and Control on the arrows are already taken by the X10 and
+            // X100 steps.
+            _addShortcut("PrevMarker", "Previous review marker", ftk::KeyShortcut(ftk::Key::Left, static_cast<int>(ftk::KeyModifier::Alt)));
+            _addShortcut("NextMarker", "Next review marker", ftk::KeyShortcut(ftk::Key::Right, static_cast<int>(ftk::KeyModifier::Alt)));
             _addShortcut("FocusCurrent", "Focus current", ftk::KeyShortcut(ftk::Key::F, static_cast<int>(ftk::KeyModifier::Control)));
 
             _shortcutsUpdate(app->getSettingsModel()->getShortcuts());
+
+            p.markersObserver = ftk::ListObserver<int>::create(
+                app->observeReviewMarkers(),
+                [this](const std::vector<int>& value)
+                {
+                    _p->hasMarkers = !value.empty();
+                    _markersUpdate();
+                });
 
             p.playerObserver = ftk::Observer<std::shared_ptr<tl::Player> >::create(
                 app->observePlayer(),
@@ -208,7 +257,19 @@ namespace djv
                     _actions["NextX10"]->setEnabled(value.get());
                     _actions["NextX100"]->setEnabled(value.get());
                     _actions["FocusCurrent"]->setEnabled(value.get());
+                    _p->hasPlayer = value.get();
+                    _markersUpdate();
                 });
+        }
+
+        void FrameActions::_markersUpdate()
+        {
+            FTK_P();
+            // The jumps need both a player and something to jump to, and the
+            // two arrive independently.
+            const bool enabled = p.hasPlayer && p.hasMarkers;
+            _actions["PrevMarker"]->setEnabled(enabled);
+            _actions["NextMarker"]->setEnabled(enabled);
         }
 
         FrameActions::FrameActions() :

--- a/lib/djv/App/FrameActions.h
+++ b/lib/djv/App/FrameActions.h
@@ -33,6 +33,8 @@ namespace djv
                 const std::shared_ptr<MainWindow>&);
 
         private:
+            void _markersUpdate();
+
             FTK_PRIVATE();
         };
     }

--- a/lib/djv/App/FrameMenu.cpp
+++ b/lib/djv/App/FrameMenu.cpp
@@ -28,6 +28,9 @@ namespace djv
             addAction(actions["NextX10"]);
             addAction(actions["NextX100"]);
             addDivider();
+            addAction(actions["PrevMarker"]);
+            addAction(actions["NextMarker"]);
+            addDivider();
             addAction(actions["FocusCurrent"]);
         }
 

--- a/lib/djv/App/MainWindow.cpp
+++ b/lib/djv/App/MainWindow.cpp
@@ -63,6 +63,11 @@
 namespace djv_resource
 {
     extern std::vector<uint8_t> DJV_Icon;
+    extern std::vector<uint8_t> DrawTool;
+    extern std::vector<uint8_t> Eraser;
+    extern std::vector<uint8_t> Review;
+    extern std::vector<uint8_t> ReviewNext;
+    extern std::vector<uint8_t> ReviewPrev;
 }
 
 namespace djv
@@ -181,6 +186,13 @@ namespace djv
             auto iconSystem = context->getSystem<ftk::IconSystem>();
             iconSystem->add("DJV_Icon", djv_resource::DJV_Icon);
             setIcon(iconSystem->get("DJV_Icon", 1.0));
+
+            // DJV's own icons, usable by name like the ftk and tlRender ones.
+            iconSystem->add("DrawTool", djv_resource::DrawTool);
+            iconSystem->add("Eraser", djv_resource::Eraser);
+            iconSystem->add("Review", djv_resource::Review);
+            iconSystem->add("ReviewNext", djv_resource::ReviewNext);
+            iconSystem->add("ReviewPrev", djv_resource::ReviewPrev);
 
             p.app = app;
             p.settingsModel = app->getSettingsModel();
@@ -614,6 +626,25 @@ namespace djv
                 {
                     _p->sysInfoDialog.reset();
                 });
+        }
+
+        void MainWindow::close()
+        {
+            FTK_P();
+            // Intercept the window close (e.g. the title-bar button) to prompt
+            // for saving the review before actually closing.
+            if (auto app = p.app.lock())
+            {
+                app->confirmClose(
+                    [this]
+                    {
+                        ftk::Window::close();
+                    });
+            }
+            else
+            {
+                ftk::Window::close();
+            }
         }
 
         void MainWindow::setGeometry(const ftk::Box2I& value)

--- a/lib/djv/App/MainWindow.h
+++ b/lib/djv/App/MainWindow.h
@@ -85,6 +85,7 @@ namespace djv
             //! Show the system information dialog.
             void showSysInfoDialog();
 
+            void close() override;
             void setGeometry(const ftk::Box2I&) override;
             void keyPressEvent(ftk::KeyEvent&) override;
             void keyReleaseEvent(ftk::KeyEvent&) override;

--- a/lib/djv/App/RangeNameDialog.cpp
+++ b/lib/djv/App/RangeNameDialog.cpp
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the DJV project.
+
+#include <djv/App/RangeNameDialog.h>
+
+#include <ftk/UI/Divider.h>
+#include <ftk/UI/Label.h>
+#include <ftk/UI/LineEdit.h>
+#include <ftk/UI/PushButton.h>
+#include <ftk/UI/RowLayout.h>
+
+namespace djv
+{
+    namespace app
+    {
+        //! Inner widget, following the pattern of SaveReviewDialog.
+        class RangeNameDialogWidget : public ftk::IMouseWidget
+        {
+        protected:
+            void _init(
+                const std::shared_ptr<ftk::Context>&,
+                const std::string& title,
+                const std::string& text,
+                const std::string& name,
+                const std::shared_ptr<IWidget>& parent);
+
+            RangeNameDialogWidget();
+
+        public:
+            virtual ~RangeNameDialogWidget();
+
+            static std::shared_ptr<RangeNameDialogWidget> create(
+                const std::shared_ptr<ftk::Context>&,
+                const std::string& title,
+                const std::string& text,
+                const std::string& name,
+                const std::shared_ptr<IWidget>& parent = nullptr);
+
+            void setCallback(const std::function<void(const std::string&)>&);
+            void setCancelCallback(const std::function<void(void)>&);
+
+            ftk::Size2I getSizeHint() const override;
+            void setGeometry(const ftk::Box2I&) override;
+            void sizeHintEvent(const ftk::SizeHintEvent&) override;
+
+        private:
+            void _accept();
+
+            std::shared_ptr<ftk::Label> _titleLabel;
+            std::shared_ptr<ftk::Label> _label;
+            std::shared_ptr<ftk::LineEdit> _lineEdit;
+            std::shared_ptr<ftk::PushButton> _okButton;
+            std::shared_ptr<ftk::PushButton> _cancelButton;
+            std::shared_ptr<ftk::VerticalLayout> _layout;
+            std::function<void(const std::string&)> _callback;
+            std::function<void(void)> _cancelCallback;
+            int _sizeHint = 0;
+        };
+
+        void RangeNameDialogWidget::_init(
+            const std::shared_ptr<ftk::Context>& context,
+            const std::string& title,
+            const std::string& text,
+            const std::string& name,
+            const std::shared_ptr<IWidget>& parent)
+        {
+            IMouseWidget::_init(context, "djv::app::RangeNameDialogWidget", parent);
+
+            _setMouseHoverEnabled(true);
+            _setMousePressEnabled(true);
+
+            _titleLabel = ftk::Label::create(context, title);
+            _titleLabel->setFontSize(14);
+            _titleLabel->setMarginRole(ftk::SizeRole::Margin);
+            _titleLabel->setBackgroundRole(ftk::ColorRole::Header);
+
+            _label = ftk::Label::create(context, text);
+            _label->setMarginRole(ftk::SizeRole::MarginSmall);
+            _label->setTextRole(ftk::ColorRole::TextDisabled);
+            _label->setAlign(ftk::HAlign::Left, ftk::VAlign::Center);
+
+            _lineEdit = ftk::LineEdit::create(context);
+            _lineEdit->setText(name);
+
+            _okButton = ftk::PushButton::create(context, "OK");
+            _cancelButton = ftk::PushButton::create(context, "Cancel");
+
+            _layout = ftk::VerticalLayout::create(context, shared_from_this());
+            _layout->setSpacingRole(ftk::SizeRole::None);
+            _titleLabel->setParent(_layout);
+            ftk::Divider::create(context, ftk::Orientation::Vertical, _layout);
+            auto vLayout = ftk::VerticalLayout::create(context, _layout);
+            vLayout->setMarginRole(ftk::SizeRole::MarginSmall);
+            vLayout->setSpacingRole(ftk::SizeRole::SpacingSmall);
+            _label->setParent(vLayout);
+            _lineEdit->setParent(vLayout);
+            ftk::Divider::create(context, ftk::Orientation::Vertical, _layout);
+            auto hLayout = ftk::HorizontalLayout::create(context, _layout);
+            hLayout->setMarginRole(ftk::SizeRole::MarginSmall);
+            hLayout->setSpacingRole(ftk::SizeRole::SpacingSmall);
+            hLayout->addSpacer(ftk::SizeRole::None, ftk::Stretch::Expanding);
+            _okButton->setParent(hLayout);
+            _cancelButton->setParent(hLayout);
+
+            // Typing replaces the default, confirming keeps it.
+            _lineEdit->takeKeyFocus();
+            _lineEdit->selectAll();
+
+            // Enter in the field is the same as pressing OK: naming a range is
+            // a keyboard gesture, reaching for the mouse defeats the point.
+            _lineEdit->setCallback(
+                [this](const std::string&)
+                {
+                    _accept();
+                });
+
+            _okButton->setClickedCallback(
+                [this]
+                {
+                    _accept();
+                });
+            _cancelButton->setClickedCallback(
+                [this]
+                {
+                    if (_cancelCallback)
+                    {
+                        _cancelCallback();
+                    }
+                });
+        }
+
+        RangeNameDialogWidget::RangeNameDialogWidget()
+        {}
+
+        RangeNameDialogWidget::~RangeNameDialogWidget()
+        {}
+
+        std::shared_ptr<RangeNameDialogWidget> RangeNameDialogWidget::create(
+            const std::shared_ptr<ftk::Context>& context,
+            const std::string& title,
+            const std::string& text,
+            const std::string& name,
+            const std::shared_ptr<IWidget>& parent)
+        {
+            auto out = std::shared_ptr<RangeNameDialogWidget>(new RangeNameDialogWidget);
+            out->_init(context, title, text, name, parent);
+            return out;
+        }
+
+        void RangeNameDialogWidget::setCallback(const std::function<void(const std::string&)>& value)
+        {
+            _callback = value;
+        }
+
+        void RangeNameDialogWidget::setCancelCallback(const std::function<void(void)>& value)
+        {
+            _cancelCallback = value;
+        }
+
+        void RangeNameDialogWidget::_accept()
+        {
+            if (_callback)
+            {
+                _callback(_lineEdit->getText());
+            }
+        }
+
+        ftk::Size2I RangeNameDialogWidget::getSizeHint() const
+        {
+            ftk::Size2I out = _layout->getSizeHint();
+            out.w = std::max(out.w, _sizeHint * 2);
+            return out;
+        }
+
+        void RangeNameDialogWidget::setGeometry(const ftk::Box2I& value)
+        {
+            IMouseWidget::setGeometry(value);
+            _layout->setGeometry(value);
+        }
+
+        void RangeNameDialogWidget::sizeHintEvent(const ftk::SizeHintEvent& event)
+        {
+            IMouseWidget::sizeHintEvent(event);
+            _sizeHint = event.style->getSizeRole(ftk::SizeRole::ScrollArea, event.displayScale);
+        }
+
+        struct RangeNameDialog::Private
+        {
+            std::shared_ptr<RangeNameDialogWidget> widget;
+            std::function<void(const std::string&)> callback;
+        };
+
+        void RangeNameDialog::_init(
+            const std::shared_ptr<ftk::Context>& context,
+            const std::string& title,
+            const std::string& text,
+            const std::string& name,
+            const std::shared_ptr<IWidget>& parent)
+        {
+            IDialog::_init(context, "djv::app::RangeNameDialog", parent);
+            FTK_P();
+
+            p.widget = RangeNameDialogWidget::create(
+                context, title, text, name, shared_from_this());
+
+            p.widget->setCallback(
+                [this](const std::string& value)
+                {
+                    if (_p->callback)
+                    {
+                        _p->callback(value);
+                    }
+                });
+            p.widget->setCancelCallback(
+                [this]
+                {
+                    close();
+                });
+        }
+
+        RangeNameDialog::RangeNameDialog() :
+            _p(new Private)
+        {}
+
+        RangeNameDialog::~RangeNameDialog()
+        {}
+
+        std::shared_ptr<RangeNameDialog> RangeNameDialog::create(
+            const std::shared_ptr<ftk::Context>& context,
+            const std::string& title,
+            const std::string& text,
+            const std::string& name,
+            const std::shared_ptr<IWidget>& parent)
+        {
+            auto out = std::shared_ptr<RangeNameDialog>(new RangeNameDialog);
+            out->_init(context, title, text, name, parent);
+            return out;
+        }
+
+        void RangeNameDialog::setCallback(const std::function<void(const std::string&)>& value)
+        {
+            _p->callback = value;
+        }
+    }
+}

--- a/lib/djv/App/RangeNameDialog.h
+++ b/lib/djv/App/RangeNameDialog.h
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the DJV project.
+
+#pragma once
+
+#include <ftk/UI/IDialog.h>
+
+namespace djv
+{
+    namespace app
+    {
+        //! A dialog asking for the name of a review range.
+        //!
+        //! The field starts filled with the frame range and selected, so that
+        //! confirming straight away keeps that default and typing replaces it.
+        class RangeNameDialog : public ftk::IDialog
+        {
+            FTK_NON_COPYABLE(RangeNameDialog);
+
+        protected:
+            void _init(
+                const std::shared_ptr<ftk::Context>&,
+                const std::string& title,
+                const std::string& text,
+                const std::string& name,
+                const std::shared_ptr<IWidget>& parent);
+
+            RangeNameDialog();
+
+        public:
+            virtual ~RangeNameDialog();
+
+            static std::shared_ptr<RangeNameDialog> create(
+                const std::shared_ptr<ftk::Context>&,
+                const std::string& title,
+                const std::string& text,
+                const std::string& name,
+                const std::shared_ptr<IWidget>& parent = nullptr);
+
+            //! Called with the name when the dialog is accepted. Cancelling
+            //! closes the dialog without calling back.
+            void setCallback(const std::function<void(const std::string&)>&);
+
+        private:
+            FTK_PRIVATE();
+        };
+    }
+}

--- a/lib/djv/App/ReviewTool.cpp
+++ b/lib/djv/App/ReviewTool.cpp
@@ -1,0 +1,824 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the DJV project.
+
+#include <djv/App/ReviewTool.h>
+
+#include <djv/App/App.h>
+#include <djv/App/RangeNameDialog.h>
+#include <djv/Models/AnnotationsModel.h>
+#include <djv/Models/DrawModel.h>
+#include <djv/Models/FilesModel.h>
+#include <djv/Models/NotesModel.h>
+#include <djv/Models/RangesModel.h>
+
+#include <tlRender/Timeline/Player.h>
+
+#include <ftk/UI/Bellows.h>
+#include <ftk/UI/ColorSwatch.h>
+#include <ftk/UI/Divider.h>
+#include <ftk/UI/FloatEditSlider.h>
+#include <ftk/UI/Label.h>
+#include <ftk/UI/PushButton.h>
+#include <ftk/UI/RowLayout.h>
+#include <ftk/UI/ScrollWidget.h>
+#include <ftk/UI/TextEdit.h>
+#include <ftk/UI/ToolButton.h>
+
+#include <ftk/Core/Format.h>
+#include <ftk/Core/String.h>
+
+#include <ctime>
+#include <stdexcept>
+
+namespace djv
+{
+    namespace app
+    {
+        namespace
+        {
+            //! Format an ISO 8601 timestamp for display, e.g.
+            //! "2026-07-26T17:22:06Z" -> "26/07/2026 - 19:22" at UTC+2. Falls
+            //! back to the raw string if it is not the expected shape.
+            //!
+            //! Notes are stored in UTC so that a review stays unambiguous when
+            //! it travels between time zones, which means the stored digits are
+            //! not the ones to show: they must be converted to the reader's
+            //! local time, or a note published at 19:22 reads 17:22.
+            std::string formatCreated(const std::string& iso)
+            {
+                if (iso.size() < 16 || 'T' != iso[10])
+                {
+                    return iso;
+                }
+                std::tm tm {};
+                try
+                {
+                    tm.tm_year = std::stoi(iso.substr(0, 4)) - 1900;
+                    tm.tm_mon = std::stoi(iso.substr(5, 2)) - 1;
+                    tm.tm_mday = std::stoi(iso.substr(8, 2));
+                    tm.tm_hour = std::stoi(iso.substr(11, 2));
+                    tm.tm_min = std::stoi(iso.substr(14, 2));
+                    tm.tm_sec = iso.size() >= 19 ? std::stoi(iso.substr(17, 2)) : 0;
+                }
+                catch (const std::exception&)
+                {
+                    return iso;
+                }
+                // The input is UTC, so interpret it as such rather than with
+                // std::mktime, which would apply the local offset a second time.
+#if defined(_WIN32)
+                const std::time_t t = _mkgmtime(&tm);
+#else
+                const std::time_t t = timegm(&tm);
+#endif
+                if (static_cast<std::time_t>(-1) == t)
+                {
+                    return iso;
+                }
+                std::tm local {};
+#if defined(_WIN32)
+                localtime_s(&local, &t);
+#else
+                localtime_r(&t, &local);
+#endif
+                char buf[32] = {};
+                std::strftime(buf, sizeof(buf), "%d/%m/%Y - %H:%M", &local);
+                return std::string(buf);
+            }
+
+            //! Format a range as its frame bounds, e.g. "0001-0120". Both ends
+            //! are inclusive: the range reads as the frames you will see, not
+            //! as a half-open interval.
+            std::string formatRange(const OTIO_NS::TimeRange& range)
+            {
+                return ftk::Format("{0}-{1}").
+                    arg(static_cast<int>(range.start_time().value()), 4, '0').
+                    arg(static_cast<int>(range.end_time_inclusive().value()), 4, '0');
+            }
+
+            //! Soft-wrap text to a column. ftk::Label renders newlines but does
+            //! not wrap on its own, so long lines would otherwise overflow.
+            std::string wrapText(const std::string& text, size_t columns)
+            {
+                std::string out;
+                size_t lineLength = 0;
+                for (const auto& line : ftk::split(text, '\n'))
+                {
+                    if (!out.empty())
+                    {
+                        out += "\n";
+                        lineLength = 0;
+                    }
+                    for (const auto& word : ftk::split(line, ' '))
+                    {
+                        if (lineLength > 0 && lineLength + word.size() + 1 > columns)
+                        {
+                            out += "\n";
+                            lineLength = 0;
+                        }
+                        else if (lineLength > 0)
+                        {
+                            out += " ";
+                            ++lineLength;
+                        }
+                        out += word;
+                        lineLength += word.size();
+                    }
+                }
+                return out;
+            }
+        }
+
+        struct ReviewTool::Private
+        {
+            std::shared_ptr<ftk::PushButton> addRangeButton;
+            std::shared_ptr<ftk::VerticalLayout> rangeListLayout;
+            //! The row buttons, by range identifier, so the highlight can be
+            //! moved without rebuilding the list.
+            std::map<std::string, std::shared_ptr<ftk::ToolButton> > rangeButtons;
+            std::vector<models::ReviewRange> ranges;
+            //! The selected range, or empty. Only one can be active: selecting
+            //! is what drives the timeline in/out points.
+            std::string selectedRangeId;
+            std::shared_ptr<RangeNameDialog> rangeNameDialog;
+
+            std::shared_ptr<ftk::ColorSwatch> colorSwatch;
+            std::shared_ptr<ftk::ToolButton> penButton;
+            std::shared_ptr<ftk::ToolButton> eraserButton;
+            std::shared_ptr<ftk::FloatEditSlider> sizeSlider;
+            std::shared_ptr<ftk::ToolButton> undoButton;
+            std::shared_ptr<ftk::ToolButton> redoButton;
+            std::shared_ptr<ftk::PushButton> clearFrameButton;
+
+            std::shared_ptr<ftk::TextEdit> noteEdit;
+            std::shared_ptr<ftk::PushButton> publishButton;
+            std::shared_ptr<ftk::VerticalLayout> noteListLayout;
+            std::map<std::string, std::shared_ptr<ftk::Bellows> > bellows;
+
+            //! The notes of the whole review, and the frame currently shown.
+            //! Only the notes of that frame are listed, so both are needed to
+            //! rebuild the list and either one can change on its own.
+            std::vector<models::ReviewNote> notes;
+            std::optional<OTIO_NS::RationalTime> currentTime;
+
+            std::shared_ptr<tl::Player> player;
+            std::optional<OTIO_NS::TimeRange> inOutRange;
+
+            std::shared_ptr<ftk::ListObserver<models::ReviewNote> > notesObserver;
+            std::shared_ptr<ftk::ListObserver<models::ReviewRange> > rangesObserver;
+            std::shared_ptr<ftk::Observer<std::shared_ptr<tl::Player> > > playerObserver;
+            std::shared_ptr<ftk::Observer<OTIO_NS::RationalTime> > currentTimeObserver;
+            std::shared_ptr<ftk::Observer<OTIO_NS::TimeRange> > inOutRangeObserver;
+            std::shared_ptr<ftk::Observer<models::DrawTool> > toolObserver;
+            std::shared_ptr<ftk::Observer<bool> > enabledObserver;
+            std::shared_ptr<ftk::Observer<ftk::Color4F> > colorObserver;
+            std::shared_ptr<ftk::Observer<float> > sizeObserver;
+            std::shared_ptr<ftk::Observer<bool> > hasUndoObserver;
+            std::shared_ptr<ftk::Observer<bool> > hasRedoObserver;
+        };
+
+        void ReviewTool::_init(
+            const std::shared_ptr<ftk::Context>& context,
+            const std::shared_ptr<App>& app,
+            const std::shared_ptr<MainWindow>& mainWindow,
+            const std::shared_ptr<IWidget>& parent)
+        {
+            IToolWidget::_init(
+                context,
+                app,
+                mainWindow,
+                "Review",
+                "Review",
+                "djv::app::ReviewTool",
+                parent);
+            FTK_P();
+
+            // Review ranges.
+            auto rangesWidget = ftk::VerticalLayout::create(context);
+            rangesWidget->setMarginRole(ftk::SizeRole::MarginSmall);
+            rangesWidget->setSpacingRole(ftk::SizeRole::SpacingSmall);
+
+            p.addRangeButton = ftk::PushButton::create(context, "Add", rangesWidget);
+            p.addRangeButton->setTooltip(
+                "Save the timeline in/out points as a named range.");
+
+            p.rangeListLayout = ftk::VerticalLayout::create(context, rangesWidget);
+            p.rangeListLayout->setSpacingRole(ftk::SizeRole::SpacingSmall);
+
+            // Drawing.
+            auto drawingWidget = ftk::VerticalLayout::create(context);
+            drawingWidget->setMarginRole(ftk::SizeRole::MarginSmall);
+            drawingWidget->setSpacingRole(ftk::SizeRole::SpacingSmall);
+
+            auto drawModel = app->getDrawModel();
+
+            auto toolLayout = ftk::HorizontalLayout::create(context, drawingWidget);
+            toolLayout->setSpacingRole(ftk::SizeRole::SpacingSmall);
+
+            p.colorSwatch = ftk::ColorSwatch::create(context, toolLayout);
+            p.colorSwatch->setEditable(true);
+            p.colorSwatch->setSizeRole(ftk::SizeRole::MarginLarge);
+            p.colorSwatch->setColor(drawModel->getColor());
+            p.colorSwatch->setTooltip("The stroke colour.");
+
+            p.penButton = ftk::ToolButton::create(context, toolLayout);
+            p.penButton->setIcon("DrawTool");
+            // Deliberately not checkable: IButton::click() flips its own checked
+            // state *after* running the callback, which would invert whatever
+            // the model observer had just set. The model stays the only source
+            // of truth and the observer drives the highlight.
+            p.penButton->setTooltip("Draw strokes. Click again to stop drawing.");
+
+            p.eraserButton = ftk::ToolButton::create(context, toolLayout);
+            p.eraserButton->setIcon("Eraser");
+            p.eraserButton->setTooltip("Erase the strokes you touch. Click again to stop.");
+
+            toolLayout->addSpacer(ftk::SizeRole::None, ftk::Stretch::Expanding);
+
+            p.undoButton = ftk::ToolButton::create(context, toolLayout);
+            p.undoButton->setIcon("Undo");
+            p.undoButton->setTooltip("Undo.");
+
+            p.redoButton = ftk::ToolButton::create(context, toolLayout);
+            p.redoButton->setIcon("Redo");
+            p.redoButton->setTooltip("Redo.");
+
+            auto sizeLayout = ftk::HorizontalLayout::create(context, drawingWidget);
+            sizeLayout->setSpacingRole(ftk::SizeRole::SpacingSmall);
+            auto sizeLabel = ftk::Label::create(context, "Size:", sizeLayout);
+            sizeLabel->setVAlign(ftk::VAlign::Center);
+            p.sizeSlider = ftk::FloatEditSlider::create(context, sizeLayout);
+            p.sizeSlider->setRange(1.F, 50.F);
+            p.sizeSlider->setValue(drawModel->getSize());
+            p.sizeSlider->setTooltip("The stroke width, in source pixels.");
+
+            p.clearFrameButton = ftk::PushButton::create(context, "Clear Frame", drawingWidget);
+            p.clearFrameButton->setTooltip("Remove every stroke on this frame.");
+
+            // Notes.
+            auto notesWidget = ftk::VerticalLayout::create(context);
+            notesWidget->setMarginRole(ftk::SizeRole::MarginSmall);
+            notesWidget->setSpacingRole(ftk::SizeRole::SpacingSmall);
+
+            p.noteEdit = ftk::TextEdit::create(context, notesWidget);
+            p.noteEdit->setTooltip("Write a note about the current frame.");
+
+            p.publishButton = ftk::PushButton::create(context, "Publish Note", notesWidget);
+            p.publishButton->setTooltip("Attach the note to the current frame.");
+
+            p.noteListLayout = ftk::VerticalLayout::create(context, notesWidget);
+            p.noteListLayout->setSpacingRole(ftk::SizeRole::SpacingSmall);
+
+            auto layout = ftk::VerticalLayout::create(context);
+            layout->setSpacingRole(ftk::SizeRole::Border);
+            p.bellows["Ranges"] = ftk::Bellows::create(context, "Review Ranges", layout);
+            p.bellows["Ranges"]->setWidget(rangesWidget);
+            p.bellows["Ranges"]->setOpen(true);
+            p.bellows["Drawing"] = ftk::Bellows::create(context, "Drawing", layout);
+            p.bellows["Drawing"]->setWidget(drawingWidget);
+            p.bellows["Drawing"]->setOpen(true);
+            p.bellows["Notes"] = ftk::Bellows::create(context, "Notes", layout);
+            p.bellows["Notes"]->setWidget(notesWidget);
+            p.bellows["Notes"]->setOpen(true);
+
+            auto scrollWidget = ftk::ScrollWidget::create(context);
+            scrollWidget->setBorder(false);
+            scrollWidget->setWidget(layout);
+            _setWidget(scrollWidget);
+
+            auto appWeak = std::weak_ptr<App>(app);
+
+            p.colorSwatch->setCallback(
+                [appWeak](const ftk::Color4F& value)
+                {
+                    if (auto app = appWeak.lock())
+                    {
+                        app->getDrawModel()->setColor(value);
+                    }
+                });
+
+            // Pen and eraser are the only way in and out of drawing: selecting
+            // one turns drawing on, clicking the active one turns it off and
+            // gives the left mouse button back to the frame shuttle.
+            auto toolClicked = [appWeak](models::DrawTool tool)
+            {
+                if (auto app = appWeak.lock())
+                {
+                    auto drawModel = app->getDrawModel();
+                    const bool active =
+                        drawModel->isEnabled() && drawModel->getTool() == tool;
+                    drawModel->setTool(tool);
+                    drawModel->setEnabled(!active);
+                }
+            };
+            p.penButton->setClickedCallback(
+                [toolClicked] { toolClicked(models::DrawTool::Pen); });
+            p.eraserButton->setClickedCallback(
+                [toolClicked] { toolClicked(models::DrawTool::Eraser); });
+
+            p.sizeSlider->setCallback(
+                [appWeak](float value)
+                {
+                    if (auto app = appWeak.lock())
+                    {
+                        app->getDrawModel()->setSize(value);
+                    }
+                });
+
+            p.undoButton->setClickedCallback(
+                [appWeak]
+                {
+                    if (auto app = appWeak.lock())
+                    {
+                        app->getAnnotationsModel()->undo();
+                    }
+                });
+            p.redoButton->setClickedCallback(
+                [appWeak]
+                {
+                    if (auto app = appWeak.lock())
+                    {
+                        app->getAnnotationsModel()->redo();
+                    }
+                });
+
+            p.clearFrameButton->setClickedCallback(
+                [appWeak]
+                {
+                    if (auto app = appWeak.lock())
+                    {
+                        const auto& a = app->getFilesModel()->getA();
+                        auto player = app->observePlayer()->get();
+                        if (a && player)
+                        {
+                            app->getAnnotationsModel()->clearFrame(
+                                a->id,
+                                player->getCurrentTime());
+                        }
+                    }
+                });
+
+            p.toolObserver = ftk::Observer<models::DrawTool>::create(
+                drawModel->observeTool(),
+                [this](models::DrawTool)
+                {
+                    _drawStateUpdate();
+                });
+
+            p.enabledObserver = ftk::Observer<bool>::create(
+                drawModel->observeEnabled(),
+                [this](bool)
+                {
+                    _drawStateUpdate();
+                });
+
+            p.colorObserver = ftk::Observer<ftk::Color4F>::create(
+                drawModel->observeColor(),
+                [this](const ftk::Color4F& value)
+                {
+                    _p->colorSwatch->setColor(value);
+                });
+
+            p.sizeObserver = ftk::Observer<float>::create(
+                drawModel->observeSize(),
+                [this](float value)
+                {
+                    _p->sizeSlider->setValue(value);
+                });
+
+            p.hasUndoObserver = ftk::Observer<bool>::create(
+                app->getAnnotationsModel()->observeHasUndo(),
+                [this](bool value)
+                {
+                    _p->undoButton->setEnabled(value);
+                });
+
+            p.hasRedoObserver = ftk::Observer<bool>::create(
+                app->getAnnotationsModel()->observeHasRedo(),
+                [this](bool value)
+                {
+                    _p->redoButton->setEnabled(value);
+                });
+
+            p.addRangeButton->setClickedCallback(
+                [this]
+                {
+                    _addRange();
+                });
+
+            p.rangesObserver = ftk::ListObserver<models::ReviewRange>::create(
+                app->getRangesModel()->observeRanges(),
+                [this](const std::vector<models::ReviewRange>& value)
+                {
+                    _p->ranges = value;
+                    _rangesUpdate();
+                });
+
+            p.publishButton->setClickedCallback(
+                [this]
+                {
+                    _publish();
+                });
+
+            p.notesObserver = ftk::ListObserver<models::ReviewNote>::create(
+                app->getNotesModel()->observeNotes(),
+                [this](const std::vector<models::ReviewNote>& value)
+                {
+                    _p->notes = value;
+                    _notesUpdate();
+                });
+
+            // A note is shown only on the frame it refers to, like a drawing, so
+            // the list follows the playhead.
+            p.playerObserver = ftk::Observer<std::shared_ptr<tl::Player> >::create(
+                app->observePlayer(),
+                [this](const std::shared_ptr<tl::Player>& value)
+                {
+                    FTK_P();
+                    p.player = value;
+                    if (value)
+                    {
+                        p.currentTimeObserver = ftk::Observer<OTIO_NS::RationalTime>::create(
+                            value->observeCurrentTime(),
+                            [this](const OTIO_NS::RationalTime& value)
+                            {
+                                _p->currentTime = value;
+                                _notesUpdate();
+                            });
+
+                        p.inOutRangeObserver = ftk::Observer<OTIO_NS::TimeRange>::create(
+                            value->observeInOutRange(),
+                            [this](const OTIO_NS::TimeRange& value)
+                            {
+                                _p->inOutRange = value;
+                                _inOutUpdate();
+                            });
+                    }
+                    else
+                    {
+                        p.currentTimeObserver.reset();
+                        p.inOutRangeObserver.reset();
+                        p.currentTime.reset();
+                        p.inOutRange.reset();
+                        _notesUpdate();
+                        _inOutUpdate();
+                    }
+                });
+
+            _loadSettings(p.bellows);
+        }
+
+        ReviewTool::ReviewTool() :
+            _p(new Private)
+        {}
+
+        ReviewTool::~ReviewTool()
+        {
+            _saveSettings(_p->bellows);
+        }
+
+        std::shared_ptr<ReviewTool> ReviewTool::create(
+            const std::shared_ptr<ftk::Context>& context,
+            const std::shared_ptr<App>& app,
+            const std::shared_ptr<MainWindow>& mainWindow,
+            const std::shared_ptr<IWidget>& parent)
+        {
+            auto out = std::shared_ptr<ReviewTool>(new ReviewTool);
+            out->_init(context, app, mainWindow, parent);
+            return out;
+        }
+
+        void ReviewTool::_drawStateUpdate()
+        {
+            FTK_P();
+            if (auto app = _app.lock())
+            {
+                auto drawModel = app->getDrawModel();
+                const bool enabled = drawModel->isEnabled();
+                const models::DrawTool tool = drawModel->getTool();
+                p.penButton->setChecked(enabled && models::DrawTool::Pen == tool);
+                p.eraserButton->setChecked(enabled && models::DrawTool::Eraser == tool);
+            }
+        }
+
+        void ReviewTool::_rangesUpdate()
+        {
+            FTK_P();
+            p.rangeListLayout->clear();
+            p.rangeButtons.clear();
+            auto context = getContext();
+            if (!context)
+            {
+                return;
+            }
+            if (p.ranges.empty())
+            {
+                auto label = ftk::Label::create(
+                    context,
+                    "No ranges yet.",
+                    p.rangeListLayout);
+                label->setMarginRole(ftk::SizeRole::MarginSmall);
+                label->setTextRole(ftk::ColorRole::TextDisabled);
+                return;
+            }
+
+            auto appWeak = _app;
+            std::weak_ptr<ReviewTool> weak(
+                std::dynamic_pointer_cast<ReviewTool>(shared_from_this()));
+            // The model keeps the list sorted by start frame.
+            for (const auto& range : p.ranges)
+            {
+                auto row = ftk::HorizontalLayout::create(context, p.rangeListLayout);
+                row->setSpacingRole(ftk::SizeRole::SpacingSmall);
+
+                // Deliberately not checkable, for the reason given on the pen
+                // button: click() would flip the state after the callback and
+                // fight the highlight set from the selection.
+                auto button = ftk::ToolButton::create(
+                    context,
+                    ftk::Format("{0}  {1}").
+                        arg(range.name).
+                        arg(range.range.has_value() ? formatRange(*range.range) : std::string()),
+                    row);
+                button->setHStretch(ftk::Stretch::Expanding);
+                button->setTooltip(
+                    "Set the timeline in/out points to this range. Click again "
+                    "to clear them.");
+                const std::string id = range.id;
+                button->setClickedCallback(
+                    [weak, id]
+                    {
+                        if (auto widget = weak.lock())
+                        {
+                            widget->_rangeClicked(id);
+                        }
+                    });
+                p.rangeButtons[id] = button;
+
+                auto deleteButton = ftk::ToolButton::create(context, row);
+                deleteButton->setIcon("CloseSmall");
+                deleteButton->setTooltip("Delete this range.");
+                deleteButton->setClickedCallback(
+                    [appWeak, id]
+                    {
+                        if (auto app = appWeak.lock())
+                        {
+                            app->getRangesModel()->remove(id);
+                        }
+                    });
+            }
+            _rangeSelectionUpdate();
+        }
+
+        void ReviewTool::_rangeSelectionUpdate()
+        {
+            FTK_P();
+            for (const auto& i : p.rangeButtons)
+            {
+                i.second->setChecked(i.first == p.selectedRangeId);
+            }
+        }
+
+        void ReviewTool::_rangeClicked(const std::string& id)
+        {
+            FTK_P();
+            if (!p.player)
+            {
+                return;
+            }
+            if (id == p.selectedRangeId)
+            {
+                // Clicking the active range clears the in/out points and gives
+                // the whole timeline back.
+                p.selectedRangeId.clear();
+                p.player->resetInPoint();
+                p.player->resetOutPoint();
+            }
+            else
+            {
+                const auto i = std::find_if(
+                    p.ranges.begin(),
+                    p.ranges.end(),
+                    [&id](const models::ReviewRange& value) { return value.id == id; });
+                if (i == p.ranges.end())
+                {
+                    return;
+                }
+                // Set the selection first: applying the range makes the in/out
+                // observer fire, and it must not read this as a stale highlight.
+                p.selectedRangeId = id;
+                p.player->setInOutRange(*i->range);
+                // Without this the playhead stays outside the range it just set.
+                p.player->seek(i->range->start_time());
+            }
+            _rangeSelectionUpdate();
+        }
+
+        void ReviewTool::_inOutUpdate()
+        {
+            FTK_P();
+            // Adding is only meaningful once the in/out points actually narrow
+            // the timeline.
+            const bool narrowed =
+                p.player &&
+                p.inOutRange.has_value() &&
+                !tl::compareExact(*p.inOutRange, p.player->getTimeRange());
+            p.addRangeButton->setEnabled(narrowed);
+
+            // Drop the highlight as soon as the in/out points stop matching the
+            // selected range, e.g. after dragging them by hand. Otherwise the
+            // next click on that row would read as "clear" when the user meant
+            // "apply it again".
+            if (!p.selectedRangeId.empty())
+            {
+                const auto i = std::find_if(
+                    p.ranges.begin(),
+                    p.ranges.end(),
+                    [this](const models::ReviewRange& value)
+                    {
+                        return value.id == _p->selectedRangeId;
+                    });
+                if (i == p.ranges.end() || !models::sameRange(i->range, p.inOutRange))
+                {
+                    p.selectedRangeId.clear();
+                    _rangeSelectionUpdate();
+                }
+            }
+        }
+
+        void ReviewTool::_addRange()
+        {
+            FTK_P();
+            auto context = getContext();
+            if (!context || !p.player)
+            {
+                return;
+            }
+            if (!p.inOutRange.has_value())
+            {
+                return;
+            }
+            const OTIO_NS::TimeRange range = *p.inOutRange;
+            if (p.rangeNameDialog)
+            {
+                p.rangeNameDialog->close();
+                p.rangeNameDialog.reset();
+            }
+            const std::string defaultName = formatRange(range);
+            p.rangeNameDialog = RangeNameDialog::create(
+                context,
+                "Add Review Range",
+                ftk::Format("Frames {0}").arg(defaultName),
+                defaultName);
+            p.rangeNameDialog->open(getWindow());
+            auto appWeak = _app;
+            std::weak_ptr<ReviewTool> weak(
+                std::dynamic_pointer_cast<ReviewTool>(shared_from_this()));
+            p.rangeNameDialog->setCallback(
+                [weak, appWeak, range, defaultName](const std::string& value)
+                {
+                    if (auto app = appWeak.lock())
+                    {
+                        // An emptied field falls back to the frame range rather
+                        // than producing a nameless row.
+                        app->getRangesModel()->add(
+                            range,
+                            value.empty() ? defaultName : value);
+                    }
+                    // Close last: it resets the dialog, which destroys this
+                    // closure, so nothing captured may be used afterwards.
+                    if (auto widget = weak.lock())
+                    {
+                        if (widget->_p->rangeNameDialog)
+                        {
+                            widget->_p->rangeNameDialog->close();
+                        }
+                    }
+                });
+            p.rangeNameDialog->setCloseCallback(
+                [weak]
+                {
+                    if (auto widget = weak.lock())
+                    {
+                        widget->_p->rangeNameDialog.reset();
+                    }
+                });
+        }
+
+        void ReviewTool::_publish()
+        {
+            FTK_P();
+            const std::string text = ftk::join(p.noteEdit->getText(), '\n');
+            if (text.empty())
+            {
+                return;
+            }
+            if (auto app = _app.lock())
+            {
+                // The note is anchored to the frame shown when it is published.
+                std::optional<OTIO_NS::RationalTime> time;
+                if (auto player = app->observePlayer()->get())
+                {
+                    time = player->getCurrentTime();
+                }
+                app->getNotesModel()->add(time, text);
+                p.noteEdit->clearText();
+            }
+        }
+
+        void ReviewTool::_notesUpdate()
+        {
+            FTK_P();
+            p.noteListLayout->clear();
+            auto context = getContext();
+            if (!context)
+            {
+                return;
+            }
+
+            // Only the notes anchored to the frame on screen, so the panel says
+            // what this frame is about rather than the whole session.
+            std::vector<models::ReviewNote> value;
+            for (const auto& note : p.notes)
+            {
+                if (models::sameTime(note.time, p.currentTime))
+                {
+                    value.push_back(note);
+                }
+            }
+            if (value.empty())
+            {
+                // Without this the section is silently empty, which reads as a
+                // bug rather than as "nothing to say about this frame".
+                auto label = ftk::Label::create(
+                    context,
+                    "No notes on this frame.",
+                    p.noteListLayout);
+                label->setMarginRole(ftk::SizeRole::MarginSmall);
+                label->setTextRole(ftk::ColorRole::TextDisabled);
+                return;
+            }
+
+            auto appWeak = _app;
+            // Newest first: the note just published is the one being read.
+            for (auto i = value.rbegin(); i != value.rend(); ++i)
+            {
+                const models::ReviewNote note = *i;
+
+                auto card = ftk::VerticalLayout::create(context, p.noteListLayout);
+                card->setSpacingRole(ftk::SizeRole::None);
+                card->setBackgroundRole(ftk::ColorRole::Button);
+
+                auto header = ftk::HorizontalLayout::create(context, card);
+                header->setMarginRole(ftk::SizeRole::MarginSmall);
+                header->setSpacingRole(ftk::SizeRole::SpacingSmall);
+
+                // The frame doubles as the button that goes to it.
+                const bool hasTime = note.time.has_value();
+                auto frameButton = ftk::ToolButton::create(
+                    context,
+                    hasTime ?
+                        ftk::Format("Frame {0}").arg(static_cast<int>(note.time->value())).operator std::string() :
+                        std::string("No frame"),
+                    header);
+                frameButton->setEnabled(hasTime);
+                frameButton->setTooltip("Go to the note's frame.");
+                const std::optional<OTIO_NS::RationalTime> time = note.time;
+                frameButton->setClickedCallback(
+                    [appWeak, time]
+                    {
+                        if (auto app = appWeak.lock())
+                        {
+                            if (auto player = app->observePlayer()->get())
+                            {
+                                player->seek(*time);
+                            }
+                        }
+                    });
+
+                auto createdLabel = ftk::Label::create(context, formatCreated(note.created), header);
+                createdLabel->setTextRole(ftk::ColorRole::TextDisabled);
+                createdLabel->setVAlign(ftk::VAlign::Center);
+
+                header->addSpacer(ftk::SizeRole::None, ftk::Stretch::Expanding);
+
+                auto deleteButton = ftk::ToolButton::create(context, header);
+                deleteButton->setIcon("CloseSmall");
+                deleteButton->setTooltip("Delete this note.");
+                const std::string id = note.id;
+                deleteButton->setClickedCallback(
+                    [appWeak, id]
+                    {
+                        if (auto app = appWeak.lock())
+                        {
+                            app->getNotesModel()->remove(id);
+                        }
+                    });
+
+                auto textLabel = ftk::Label::create(context, wrapText(note.text, 40), card);
+                textLabel->setMarginRole(ftk::SizeRole::MarginSmall);
+                textLabel->setAlign(ftk::HAlign::Left, ftk::VAlign::Top);
+            }
+        }
+    }
+}

--- a/lib/djv/App/ReviewTool.h
+++ b/lib/djv/App/ReviewTool.h
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the DJV project.
+
+#pragma once
+
+#include <djv/App/IToolWidget.h>
+
+#include <djv/Models/Review.h>
+
+namespace djv
+{
+    namespace app
+    {
+        //! Review tool: annotations and notes.
+        //!
+        //! The drawing and notes sections share one panel so that marking up a
+        //! frame and commenting on it stay visible together. See
+        //! docs/ROADMAP_REVIEW_SESSIONS.md section 7.2.bis.
+        class ReviewTool : public IToolWidget
+        {
+            FTK_NON_COPYABLE(ReviewTool);
+
+        protected:
+            void _init(
+                const std::shared_ptr<ftk::Context>&,
+                const std::shared_ptr<App>&,
+                const std::shared_ptr<MainWindow>&,
+                const std::shared_ptr<IWidget>& parent);
+
+            ReviewTool();
+
+        public:
+            virtual ~ReviewTool();
+
+            static std::shared_ptr<ReviewTool> create(
+                const std::shared_ptr<ftk::Context>&,
+                const std::shared_ptr<App>&,
+                const std::shared_ptr<MainWindow>&,
+                const std::shared_ptr<IWidget>& parent = nullptr);
+
+        private:
+            void _drawStateUpdate();
+            void _publish();
+            void _notesUpdate();
+            void _rangesUpdate();
+            void _rangeSelectionUpdate();
+            void _rangeClicked(const std::string& id);
+            void _inOutUpdate();
+            void _addRange();
+
+            FTK_PRIVATE();
+        };
+    }
+}

--- a/lib/djv/App/ReviewTool.h
+++ b/lib/djv/App/ReviewTool.h
@@ -14,8 +14,7 @@ namespace djv
         //! Review tool: annotations and notes.
         //!
         //! The drawing and notes sections share one panel so that marking up a
-        //! frame and commenting on it stay visible together. See
-        //! docs/ROADMAP_REVIEW_SESSIONS.md section 7.2.bis.
+        //! frame and commenting on it stay visible together.
         class ReviewTool : public IToolWidget
         {
             FTK_NON_COPYABLE(ReviewTool);

--- a/lib/djv/App/SaveReviewDialog.cpp
+++ b/lib/djv/App/SaveReviewDialog.cpp
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the DJV project.
+
+#include <djv/App/SaveReviewDialog.h>
+
+#include <ftk/UI/Divider.h>
+#include <ftk/UI/Label.h>
+#include <ftk/UI/PushButton.h>
+#include <ftk/UI/RowLayout.h>
+#include <ftk/UI/ScrollWidget.h>
+
+namespace djv
+{
+    namespace app
+    {
+        //! Inner widget, following the pattern of ftk::ConfirmDialog.
+        class SaveReviewDialogWidget : public ftk::IMouseWidget
+        {
+        protected:
+            void _init(
+                const std::shared_ptr<ftk::Context>&,
+                const std::string& title,
+                const std::string& text,
+                const std::shared_ptr<IWidget>& parent);
+
+            SaveReviewDialogWidget();
+
+        public:
+            virtual ~SaveReviewDialogWidget();
+
+            static std::shared_ptr<SaveReviewDialogWidget> create(
+                const std::shared_ptr<ftk::Context>&,
+                const std::string& title,
+                const std::string& text,
+                const std::shared_ptr<IWidget>& parent = nullptr);
+
+            void setCallback(const std::function<void(SaveReviewResult)>&);
+
+            ftk::Size2I getSizeHint() const override;
+            void setGeometry(const ftk::Box2I&) override;
+            void sizeHintEvent(const ftk::SizeHintEvent&) override;
+
+        private:
+            std::shared_ptr<ftk::Label> _titleLabel;
+            std::shared_ptr<ftk::Label> _label;
+            std::shared_ptr<ftk::ScrollWidget> _scrollWidget;
+            std::shared_ptr<ftk::PushButton> _saveButton;
+            std::shared_ptr<ftk::PushButton> _discardButton;
+            std::shared_ptr<ftk::PushButton> _cancelButton;
+            std::shared_ptr<ftk::VerticalLayout> _layout;
+            std::function<void(SaveReviewResult)> _callback;
+            int _sizeHint = 0;
+        };
+
+        void SaveReviewDialogWidget::_init(
+            const std::shared_ptr<ftk::Context>& context,
+            const std::string& title,
+            const std::string& text,
+            const std::shared_ptr<IWidget>& parent)
+        {
+            IMouseWidget::_init(context, "djv::app::SaveReviewDialogWidget", parent);
+
+            _setMouseHoverEnabled(true);
+            _setMousePressEnabled(true);
+
+            _titleLabel = ftk::Label::create(context, title);
+            _titleLabel->setFontSize(14);
+            _titleLabel->setMarginRole(ftk::SizeRole::Margin);
+            _titleLabel->setBackgroundRole(ftk::ColorRole::Header);
+
+            _label = ftk::Label::create(context, text);
+            _label->setMarginRole(ftk::SizeRole::Margin);
+            _label->setAlign(ftk::HAlign::Left, ftk::VAlign::Top);
+
+            _scrollWidget = ftk::ScrollWidget::create(context);
+            _scrollWidget->setBorder(false);
+            _scrollWidget->setSizeHintRole(ftk::SizeRole::ScrollAreaSmall);
+            _scrollWidget->setWidget(_label);
+
+            _saveButton = ftk::PushButton::create(context, "Save");
+            _discardButton = ftk::PushButton::create(context, "Don't Save");
+            _cancelButton = ftk::PushButton::create(context, "Cancel");
+
+            _layout = ftk::VerticalLayout::create(context, shared_from_this());
+            _layout->setSpacingRole(ftk::SizeRole::None);
+            _titleLabel->setParent(_layout);
+            ftk::Divider::create(context, ftk::Orientation::Vertical, _layout);
+            _scrollWidget->setParent(_layout);
+            ftk::Divider::create(context, ftk::Orientation::Vertical, _layout);
+            auto hLayout = ftk::HorizontalLayout::create(context, _layout);
+            hLayout->setMarginRole(ftk::SizeRole::MarginSmall);
+            hLayout->setSpacingRole(ftk::SizeRole::SpacingSmall);
+            hLayout->addSpacer(ftk::SizeRole::None, ftk::Stretch::Expanding);
+            _saveButton->setParent(hLayout);
+            _discardButton->setParent(hLayout);
+            _cancelButton->setParent(hLayout);
+
+            _saveButton->setClickedCallback(
+                [this]
+                {
+                    if (_callback)
+                    {
+                        _callback(SaveReviewResult::Save);
+                    }
+                });
+            _discardButton->setClickedCallback(
+                [this]
+                {
+                    if (_callback)
+                    {
+                        _callback(SaveReviewResult::Discard);
+                    }
+                });
+            _cancelButton->setClickedCallback(
+                [this]
+                {
+                    if (_callback)
+                    {
+                        _callback(SaveReviewResult::Cancel);
+                    }
+                });
+        }
+
+        SaveReviewDialogWidget::SaveReviewDialogWidget()
+        {}
+
+        SaveReviewDialogWidget::~SaveReviewDialogWidget()
+        {}
+
+        std::shared_ptr<SaveReviewDialogWidget> SaveReviewDialogWidget::create(
+            const std::shared_ptr<ftk::Context>& context,
+            const std::string& title,
+            const std::string& text,
+            const std::shared_ptr<IWidget>& parent)
+        {
+            auto out = std::shared_ptr<SaveReviewDialogWidget>(new SaveReviewDialogWidget);
+            out->_init(context, title, text, parent);
+            return out;
+        }
+
+        void SaveReviewDialogWidget::setCallback(const std::function<void(SaveReviewResult)>& value)
+        {
+            _callback = value;
+        }
+
+        ftk::Size2I SaveReviewDialogWidget::getSizeHint() const
+        {
+            ftk::Size2I out = _layout->getSizeHint();
+            out.w = std::max(out.w, _sizeHint * 2);
+            return out;
+        }
+
+        void SaveReviewDialogWidget::setGeometry(const ftk::Box2I& value)
+        {
+            IMouseWidget::setGeometry(value);
+            _layout->setGeometry(value);
+        }
+
+        void SaveReviewDialogWidget::sizeHintEvent(const ftk::SizeHintEvent& event)
+        {
+            IMouseWidget::sizeHintEvent(event);
+            _sizeHint = event.style->getSizeRole(ftk::SizeRole::ScrollArea, event.displayScale);
+        }
+
+        struct SaveReviewDialog::Private
+        {
+            std::shared_ptr<SaveReviewDialogWidget> widget;
+            std::function<void(SaveReviewResult)> callback;
+        };
+
+        void SaveReviewDialog::_init(
+            const std::shared_ptr<ftk::Context>& context,
+            const std::string& title,
+            const std::string& text,
+            const std::shared_ptr<IWidget>& parent)
+        {
+            IDialog::_init(context, "djv::app::SaveReviewDialog", parent);
+            FTK_P();
+
+            p.widget = SaveReviewDialogWidget::create(context, title, text, shared_from_this());
+
+            p.widget->setCallback(
+                [this](SaveReviewResult value)
+                {
+                    if (_p->callback)
+                    {
+                        _p->callback(value);
+                    }
+                });
+        }
+
+        SaveReviewDialog::SaveReviewDialog() :
+            _p(new Private)
+        {}
+
+        SaveReviewDialog::~SaveReviewDialog()
+        {}
+
+        std::shared_ptr<SaveReviewDialog> SaveReviewDialog::create(
+            const std::shared_ptr<ftk::Context>& context,
+            const std::string& title,
+            const std::string& text,
+            const std::shared_ptr<IWidget>& parent)
+        {
+            auto out = std::shared_ptr<SaveReviewDialog>(new SaveReviewDialog);
+            out->_init(context, title, text, parent);
+            return out;
+        }
+
+        void SaveReviewDialog::setCallback(const std::function<void(SaveReviewResult)>& value)
+        {
+            _p->callback = value;
+        }
+    }
+}

--- a/lib/djv/App/SaveReviewDialog.h
+++ b/lib/djv/App/SaveReviewDialog.h
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the DJV project.
+
+#pragma once
+
+#include <ftk/UI/IDialog.h>
+
+namespace djv
+{
+    namespace app
+    {
+        //! The user's choice when prompted to save a review before closing.
+        enum class SaveReviewResult
+        {
+            Save,
+            Discard,
+            Cancel
+        };
+
+        //! A three-button dialog asking whether to save the current review
+        //! before closing: Save, Don't Save, or Cancel.
+        class SaveReviewDialog : public ftk::IDialog
+        {
+            FTK_NON_COPYABLE(SaveReviewDialog);
+
+        protected:
+            void _init(
+                const std::shared_ptr<ftk::Context>&,
+                const std::string& title,
+                const std::string& text,
+                const std::shared_ptr<IWidget>& parent);
+
+            SaveReviewDialog();
+
+        public:
+            virtual ~SaveReviewDialog();
+
+            static std::shared_ptr<SaveReviewDialog> create(
+                const std::shared_ptr<ftk::Context>&,
+                const std::string& title,
+                const std::string& text,
+                const std::shared_ptr<IWidget>& parent = nullptr);
+
+            void setCallback(const std::function<void(SaveReviewResult)>&);
+
+        private:
+            FTK_PRIVATE();
+        };
+    }
+}

--- a/lib/djv/App/ToolsActions.cpp
+++ b/lib/djv/App/ToolsActions.cpp
@@ -4,6 +4,7 @@
 #include <djv/App/ToolsActions.h>
 
 #include <djv/App/App.h>
+#include <djv/Models/AnnotationsModel.h>
 #include <djv/Models/ToolsModel.h>
 
 #include <ftk/Core/Format.h>
@@ -14,7 +15,13 @@ namespace djv
     {
         struct ToolsActions::Private
         {
+            //! The panel tools, which are mutually exclusive. Undo and redo also
+            //! live in this group but are not panels.
+            std::vector<std::string> toolNames;
+
             std::shared_ptr<ftk::Observer<std::string> > activeObserver;
+            std::shared_ptr<ftk::Observer<bool> > hasUndoObserver;
+            std::shared_ptr<ftk::Observer<bool> > hasRedoObserver;
         };
 
         void ToolsActions::_init(
@@ -56,17 +63,80 @@ namespace djv
 
                 // Register the shortcut.
                 _addShortcut(tool.name, tool.name, tool.shortcut);
+
+                p.toolNames.push_back(tool.name);
             }
 
+            // Undo and redo apply to the drawing annotations. A focused text
+            // widget handles Ctrl+Z itself and consumes the event, so writing a
+            // note is unaffected.
+            _addCommand(
+                "Undo",
+                "Undo the last drawing change.",
+                [appWeak](const nlohmann::json&)
+                {
+                    if (auto app = appWeak.lock())
+                    {
+                        app->getAnnotationsModel()->undo();
+                    }
+                });
+            _actions["Undo"] = ftk::Action::create(
+                "Undo",
+                "Undo",
+                _command("Undo"));
+            _addShortcut(
+                "Undo",
+                "Undo",
+                ftk::KeyShortcut(ftk::Key::Z, static_cast<int>(ftk::commandKeyModifier)));
+
+            _addCommand(
+                "Redo",
+                "Redo the last undone drawing change.",
+                [appWeak](const nlohmann::json&)
+                {
+                    if (auto app = appWeak.lock())
+                    {
+                        app->getAnnotationsModel()->redo();
+                    }
+                });
+            _actions["Redo"] = ftk::Action::create(
+                "Redo",
+                "Redo",
+                _command("Redo"));
+            _addShortcut(
+                "Redo",
+                "Redo",
+                ftk::KeyShortcut(
+                    ftk::Key::Z,
+                    static_cast<int>(ftk::KeyModifier::Shift) |
+                    static_cast<int>(ftk::commandKeyModifier)));
+
             _shortcutsUpdate(app->getSettingsModel()->getShortcuts());
+
+            p.hasUndoObserver = ftk::Observer<bool>::create(
+                app->getAnnotationsModel()->observeHasUndo(),
+                [this](bool value)
+                {
+                    _actions["Undo"]->setEnabled(value);
+                });
+
+            p.hasRedoObserver = ftk::Observer<bool>::create(
+                app->getAnnotationsModel()->observeHasRedo(),
+                [this](bool value)
+                {
+                    _actions["Redo"]->setEnabled(value);
+                });
 
             p.activeObserver = ftk::Observer<std::string>::create(
                 app->getToolsModel()->observeActiveTool(),
                 [this](const std::string& value)
                 {
-                    for (auto i : _actions)
+                    FTK_P();
+                    // Only the tool panels are mutually exclusive; undo and redo
+                    // are not panels and must be left alone.
+                    for (const auto& name : p.toolNames)
                     {
-                        i.second->setChecked(i.first == value);
+                        _actions[name]->setChecked(name == value);
                     }
                 });
         }

--- a/lib/djv/App/ToolsMenu.cpp
+++ b/lib/djv/App/ToolsMenu.cpp
@@ -32,6 +32,13 @@ namespace djv
                     addAction(actions[j]);
                 }
             }
+
+            // Undo and redo drive the drawing annotations. They have to be in a
+            // menu: Menu::shortcut() is what dispatches an action's shortcut, so
+            // an action outside every menu would never see its keys.
+            addDivider();
+            addAction(actions["Undo"]);
+            addAction(actions["Redo"]);
         }
 
         ToolsMenu::~ToolsMenu()

--- a/lib/djv/App/ToolsToolBar.cpp
+++ b/lib/djv/App/ToolsToolBar.cpp
@@ -37,6 +37,7 @@ namespace djv
                     }
                 }
             }
+
         }
 
         ToolsToolBar::~ToolsToolBar()

--- a/lib/djv/App/Viewport.cpp
+++ b/lib/djv/App/Viewport.cpp
@@ -4,7 +4,9 @@
 #include <djv/App/Viewport.h>
 
 #include <djv/App/App.h>
+#include <djv/Models/AnnotationsModel.h>
 #include <djv/Models/ColorModel.h>
+#include <djv/Models/DrawModel.h>
 #include <djv/Models/FilesModel.h>
 #include <djv/Models/SettingsModel.h>
 #include <djv/Models/TimeUnitsModel.h>
@@ -24,7 +26,226 @@
 
 #include <algorithm>
 
+#include <cmath>
 #include <regex>
+
+namespace
+{
+    //! Drop points closer together than the given distance.
+    //!
+    //! Freehand input arrives in dense clusters, and clustered control points
+    //! make a Catmull-Rom spline overshoot; thinning first is what keeps the
+    //! curve clean.
+    std::vector<ftk::V2F> simplifyPath(const std::vector<ftk::V2F>& points, float minDistance)
+    {
+        std::vector<ftk::V2F> out;
+        if (points.empty())
+        {
+            return out;
+        }
+        out.push_back(points.front());
+        const float minSquared = minDistance * minDistance;
+        for (size_t i = 1; i + 1 < points.size(); ++i)
+        {
+            const float dx = points[i].x - out.back().x;
+            const float dy = points[i].y - out.back().y;
+            if (dx * dx + dy * dy >= minSquared)
+            {
+                out.push_back(points[i]);
+            }
+        }
+        if (points.size() > 1)
+        {
+            out.push_back(points.back());
+        }
+        return out;
+    }
+
+    //! Smooth a path with a centripetal Catmull-Rom spline.
+    //!
+    //! The curve passes through every control point while rounding the corners.
+    //! The centripetal parameterisation (alpha = 0.5) is what avoids the cusps
+    //! and self-intersections that the uniform form produces on unevenly spaced
+    //! points.
+    std::vector<ftk::V2F> smoothPath(const std::vector<ftk::V2F>& points, int subdivisions)
+    {
+        if (points.size() < 3)
+        {
+            return points;
+        }
+        auto knot = [](float t, const ftk::V2F& a, const ftk::V2F& b)
+        {
+            const float dx = b.x - a.x;
+            const float dy = b.y - a.y;
+            // alpha = 0.5 -> the fourth root of the squared distance.
+            return t + std::pow(std::sqrt(dx * dx + dy * dy), .5F);
+        };
+        std::vector<ftk::V2F> out;
+        out.reserve(points.size() * subdivisions);
+        const size_t size = points.size();
+        for (size_t i = 0; i + 1 < size; ++i)
+        {
+            // Duplicate the ends so the first and last spans are drawn too.
+            const ftk::V2F& p0 = points[i > 0 ? i - 1 : 0];
+            const ftk::V2F& p1 = points[i];
+            const ftk::V2F& p2 = points[i + 1];
+            const ftk::V2F& p3 = points[i + 2 < size ? i + 2 : size - 1];
+
+            const float t0 = 0.F;
+            const float t1 = knot(t0, p0, p1);
+            const float t2 = knot(t1, p1, p2);
+            const float t3 = knot(t2, p2, p3);
+            if (t2 - t1 <= 0.F)
+            {
+                continue;
+            }
+            for (int j = 0; j < subdivisions; ++j)
+            {
+                const float t = t1 + (t2 - t1) * (j / static_cast<float>(subdivisions));
+                // Barry-Goldman pyramidal evaluation, guarding the spans that
+                // collapse when two control points coincide.
+                auto lerp = [](const ftk::V2F& a, const ftk::V2F& b, float ta, float tb, float t)
+                {
+                    const float d = tb - ta;
+                    if (d <= 0.F)
+                    {
+                        return a;
+                    }
+                    const float u = (t - ta) / d;
+                    return ftk::V2F(
+                        a.x + (b.x - a.x) * u,
+                        a.y + (b.y - a.y) * u);
+                };
+                const ftk::V2F a1 = lerp(p0, p1, t0, t1, t);
+                const ftk::V2F a2 = lerp(p1, p2, t1, t2, t);
+                const ftk::V2F a3 = lerp(p2, p3, t2, t3, t);
+                const ftk::V2F b1 = lerp(a1, a2, t0, t2, t);
+                const ftk::V2F b2 = lerp(a2, a3, t1, t3, t);
+                out.push_back(lerp(b1, b2, t1, t2, t));
+            }
+        }
+        out.push_back(points.back());
+        return out;
+    }
+
+    //! Append a filled disc to a mesh, used for the two end caps.
+    //!
+    //! The number of sides follows the radius: a fixed count would show flat
+    //! facets once a stroke is thick or zoomed in. Mesh vertex indices are
+    //! one-based.
+    void addDisc(ftk::TriMesh2F& mesh, const ftk::V2F& center, float radius)
+    {
+        const int segments = std::max(16, std::min(96, static_cast<int>(radius * 2.F)));
+        const size_t centerIndex = mesh.v.size() + 1;
+        mesh.v.push_back(center);
+        for (int i = 0; i < segments; ++i)
+        {
+            const float a = i / static_cast<float>(segments) * 2.F * 3.14159265F;
+            mesh.v.push_back(ftk::V2F(
+                center.x + std::cos(a) * radius,
+                center.y + std::sin(a) * radius));
+        }
+        for (int i = 0; i < segments; ++i)
+        {
+            // Wind the same way as the ribbon quads: the renderer culls back
+            // faces, so a disc wound the other way is simply never drawn.
+            ftk::Triangle2 triangle;
+            triangle.v[0].v = centerIndex;
+            triangle.v[1].v = centerIndex + 1 + ((i + 1) % segments);
+            triangle.v[2].v = centerIndex + 1 + i;
+            mesh.triangles.push_back(triangle);
+        }
+    }
+
+    //! Build a mesh for a stroke as one continuous ribbon.
+    //!
+    //! Consecutive quads share their vertices, so the outline has no gap and no
+    //! overlap anywhere along the path -- that is what removes the notches that
+    //! independent per-segment quads leave on the outside of a curve. Each point
+    //! is offset along the averaged normal of its two neighbouring segments (a
+    //! mitre), lengthened by 1/cos to hold the width through a turn and clamped
+    //! so a sharp corner cannot spike. Round caps close the two ends.
+    ftk::TriMesh2F strokeMesh(const std::vector<ftk::V2F>& points, float width)
+    {
+        ftk::TriMesh2F out;
+        const float radius = std::max(.5F, width / 2.F);
+        if (points.empty())
+        {
+            return out;
+        }
+        if (1 == points.size())
+        {
+            addDisc(out, points[0], radius);
+            return out;
+        }
+
+        auto direction = [](const ftk::V2F& a, const ftk::V2F& b)
+        {
+            const float dx = b.x - a.x;
+            const float dy = b.y - a.y;
+            const float length = std::sqrt(dx * dx + dy * dy);
+            return length > 0.F ?
+                ftk::V2F(dx / length, dy / length) :
+                ftk::V2F(0.F, 0.F);
+        };
+
+        const size_t size = points.size();
+        for (size_t i = 0; i < size; ++i)
+        {
+            const ftk::V2F dirPrev = i > 0 ?
+                direction(points[i - 1], points[i]) :
+                direction(points[0], points[1]);
+            const ftk::V2F dirNext = i + 1 < size ?
+                direction(points[i], points[i + 1]) :
+                direction(points[size - 2], points[size - 1]);
+
+            ftk::V2F tangent(dirPrev.x + dirNext.x, dirPrev.y + dirNext.y);
+            const float length = std::sqrt(tangent.x * tangent.x + tangent.y * tangent.y);
+            if (length > 0.F)
+            {
+                tangent.x /= length;
+                tangent.y /= length;
+            }
+            else
+            {
+                tangent = dirNext;
+            }
+
+            float offset = radius;
+            const float cosHalf = dirNext.x * tangent.x + dirNext.y * tangent.y;
+            if (cosHalf > .25F)
+            {
+                offset = std::min(radius / cosHalf, radius * 3.F);
+            }
+            const ftk::V2F normal(-tangent.y * offset, tangent.x * offset);
+
+            out.v.push_back(ftk::V2F(points[i].x + normal.x, points[i].y + normal.y));
+            out.v.push_back(ftk::V2F(points[i].x - normal.x, points[i].y - normal.y));
+        }
+
+        for (size_t i = 0; i + 1 < size; ++i)
+        {
+            // One-based indices: left(i) = 2i+1, right(i) = 2i+2.
+            const size_t left = i * 2 + 1;
+            const size_t right = left + 1;
+            const size_t leftNext = left + 2;
+            const size_t rightNext = right + 2;
+            ftk::Triangle2 triangle;
+            triangle.v[0].v = left;
+            triangle.v[1].v = leftNext;
+            triangle.v[2].v = rightNext;
+            out.triangles.push_back(triangle);
+            triangle.v[0].v = left;
+            triangle.v[1].v = rightNext;
+            triangle.v[2].v = right;
+            out.triangles.push_back(triangle);
+        }
+
+        addDisc(out, points.front(), radius);
+        addDisc(out, points.back(), radius);
+        return out;
+    }
+}
 
 namespace djv
 {
@@ -50,6 +271,7 @@ namespace djv
             double fps = 0.0;
             size_t droppedFrames = 0;
             size_t videoFramesSize = 0;
+            std::vector<tl::VideoFrame> videoFrames;
             ftk::ImageOptions imageOptions;
             tl::DisplayOptions displayOptions;
             tl::PlayerCacheInfo cacheInfo;
@@ -97,12 +319,15 @@ namespace djv
             std::shared_ptr<ftk::Observer<models::HUDOptions> > hudOptionsObserver;
             std::shared_ptr<ftk::Observer<tl::TimeUnits> > timeUnitsObserver;
             std::shared_ptr<ftk::Observer<models::MouseSettings> > mouseSettingsObserver;
+            std::shared_ptr<ftk::ListObserver<models::ReviewAnnotation> > annotationsObserver;
 
             enum class MouseMode
             {
                 None,
                 Shuttle,
-                Picker
+                Picker,
+                Draw,
+                Erase
             };
             struct MouseData
             {
@@ -111,6 +336,10 @@ namespace djv
                 std::optional<OTIO_NS::RationalTime> shuttleStart;
             };
             MouseData mouse;
+
+            //! The stroke being drawn, in the image pixels of its source.
+            models::ReviewStroke stroke;
+            int strokeSource = -1;
         };
 
         void Viewport::_init(
@@ -349,6 +578,18 @@ namespace djv
                     _hudUpdate();
                 });
 
+            // The overlay is drawn straight from the model, so any change to it
+            // has to ask for a redraw. Drawing does that from the mouse events,
+            // but undo, redo and "Clear Frame" only touch the model: without
+            // this the frame keeps showing stale strokes until some unrelated
+            // event happens to repaint the window.
+            p.annotationsObserver = ftk::ListObserver<models::ReviewAnnotation>::create(
+                app->getAnnotationsModel()->observeAnnotations(),
+                [this](const std::vector<models::ReviewAnnotation>&)
+                {
+                    setDrawUpdate();
+                });
+
             p.mouseSettingsObserver = ftk::Observer<models::MouseSettings>::create(
                 app->getSettingsModel()->observeMouse(),
                 [this](const models::MouseSettings& value)
@@ -525,6 +766,8 @@ namespace djv
                     {
                         _p->currentTime = value;
                         _hudUpdate();
+                        // Annotations are per frame, so the overlay changes.
+                        setDrawUpdate();
                     });
 
                 p.videoObserver = ftk::ListObserver<tl::VideoFrame>::create(
@@ -532,6 +775,9 @@ namespace djv
                     [this](const std::vector<tl::VideoFrame>& value)
                     {
                         _p->videoFramesSize = value.size();
+                        // Kept for the annotation hit test and overlay, which
+                        // need the image sizes to map screen to image pixels.
+                        _p->videoFrames = value;
                         _videoUpdate();
                     });
 
@@ -549,6 +795,7 @@ namespace djv
                 p.ioInfo = tl::IOInfo();
                 p.mediaReferenceKeyObserver.reset();
                 p.currentTime.reset();
+                p.videoFrames.clear();
                 p.currentTimeObserver.reset();
                 p.videoObserver.reset();
                 p.cacheInfo = tl::PlayerCacheInfo();
@@ -584,6 +831,12 @@ namespace djv
             FTK_P();
             switch (p.mouse.mode)
             {
+            case Private::MouseMode::Draw:
+                _drawContinue(event.pos - getGeometry().min);
+                break;
+            case Private::MouseMode::Erase:
+                _erase(event.pos - getGeometry().min);
+                break;
             case Private::MouseMode::Shuttle:
                 if (auto player = getPlayer())
                 {
@@ -630,6 +883,36 @@ namespace djv
         {
             tl::ui::Viewport::mousePressEvent(event);
             FTK_P();
+
+            // Drawing owns the plain left button while it is enabled, which is
+            // why it is an explicit mode: it displaces the frame shuttle.
+            auto app = p.app.lock();
+            if (app &&
+                app->getDrawModel()->isEnabled() &&
+                ftk::MouseButton::Left == event.button &&
+                0 == event.modifiers)
+            {
+                // Claim the button, as the picker and the shuttle do below.
+                // Without this the release never reaches us: the stroke is
+                // never committed, keeps growing on every move, and the undo
+                // that follows has to copy all of it.
+                event.accept = true;
+                takeKeyFocus();
+                const ftk::Box2I& g = getGeometry();
+                const ftk::V2I pos = event.pos - g.min;
+                if (models::DrawTool::Eraser == app->getDrawModel()->getTool())
+                {
+                    p.mouse.mode = Private::MouseMode::Erase;
+                    _erase(pos);
+                }
+                else
+                {
+                    p.mouse.mode = Private::MouseMode::Draw;
+                    _drawBegin(pos);
+                }
+                return;
+            }
+
             if (p.pickBinding.button == event.button &&
                 ftk::checkKeyModifier(p.pickBinding.modifier, event.modifiers))
             {
@@ -666,7 +949,302 @@ namespace djv
         {
             tl::ui::Viewport::mouseReleaseEvent(event);
             FTK_P();
+            if (Private::MouseMode::Draw == p.mouse.mode)
+            {
+                // Commit the stroke as one undoable step.
+                _drawEnd();
+            }
             p.mouse = Private::MouseData();
+        }
+
+        std::vector<ftk::Box2I> Viewport::_sourceBoxes() const
+        {
+            FTK_P();
+            // Mirror what tl::ui::Viewport uses when it draws, so the hit test
+            // and the overlay land exactly where the image does.
+            return tl::getBoxes(
+                getCompareOptions(),
+                p.displayOptions.aspectRatio,
+                p.videoFrames);
+        }
+
+        Viewport::SourceHit Viewport::_hitTest(const ftk::V2I& widgetPos) const
+        {
+            FTK_P();
+            SourceHit out;
+            // Widget -> render space: the inverse of translate(viewPos) * scale.
+            const double zoom = getZoom();
+            if (zoom <= 0.0)
+            {
+                return out;
+            }
+            const ftk::V2I& viewPos = getViewPos();
+            const ftk::V2F render(
+                static_cast<float>((widgetPos.x - viewPos.x) / zoom),
+                static_cast<float>((widgetPos.y - viewPos.y) / zoom));
+
+            const auto boxes = _sourceBoxes();
+            for (size_t i = 0; i < boxes.size() && i < p.videoFrames.size(); ++i)
+            {
+                const ftk::Box2I& box = boxes[i];
+                if (render.x < box.min.x || render.x > box.max.x ||
+                    render.y < box.min.y || render.y > box.max.y ||
+                    box.w() <= 0 || box.h() <= 0)
+                {
+                    continue;
+                }
+                const auto& video = p.videoFrames[i];
+                if (video.layers.empty() || !video.layers[0].image)
+                {
+                    continue;
+                }
+                const ftk::Size2I imageSize = video.layers[0].image->getSize();
+                if (imageSize.w <= 0 || imageSize.h <= 0)
+                {
+                    continue;
+                }
+                // Render space -> the source's own pixels.
+                out.index = static_cast<int>(i);
+                out.pos = ftk::V2F(
+                    (render.x - box.min.x) * imageSize.w / static_cast<float>(box.w()),
+                    (render.y - box.min.y) * imageSize.h / static_cast<float>(box.h()));
+                out.scale = box.w() / static_cast<float>(imageSize.w);
+                break;
+            }
+            return out;
+        }
+
+        ftk::V2F Viewport::_imageToWidget(int index, const ftk::V2F& imagePos) const
+        {
+            FTK_P();
+            const auto boxes = _sourceBoxes();
+            if (index < 0 ||
+                index >= static_cast<int>(boxes.size()) ||
+                index >= static_cast<int>(p.videoFrames.size()))
+            {
+                return ftk::V2F();
+            }
+            const ftk::Box2I& box = boxes[index];
+            const auto& video = p.videoFrames[index];
+            if (video.layers.empty() || !video.layers[0].image)
+            {
+                return ftk::V2F();
+            }
+            const ftk::Size2I imageSize = video.layers[0].image->getSize();
+            if (imageSize.w <= 0 || imageSize.h <= 0)
+            {
+                return ftk::V2F();
+            }
+            const float renderX = box.min.x + imagePos.x * box.w() / static_cast<float>(imageSize.w);
+            const float renderY = box.min.y + imagePos.y * box.h() / static_cast<float>(imageSize.h);
+            const double zoom = getZoom();
+            const ftk::V2I& viewPos = getViewPos();
+            return ftk::V2F(
+                static_cast<float>(viewPos.x + renderX * zoom),
+                static_cast<float>(viewPos.y + renderY * zoom));
+        }
+
+        void Viewport::_drawBegin(const ftk::V2I& widgetPos)
+        {
+            FTK_P();
+            const SourceHit hit = _hitTest(widgetPos);
+            if (hit.index < 0)
+            {
+                return;
+            }
+            if (auto app = p.app.lock())
+            {
+                auto drawModel = app->getDrawModel();
+                p.strokeSource = hit.index;
+                p.stroke = models::ReviewStroke();
+                p.stroke.color = drawModel->getColor();
+                p.stroke.width = drawModel->getSize();
+                p.stroke.points.push_back(hit.pos);
+                setDrawUpdate();
+            }
+        }
+
+        void Viewport::_drawContinue(const ftk::V2I& widgetPos)
+        {
+            FTK_P();
+            if (p.strokeSource < 0)
+            {
+                return;
+            }
+            const SourceHit hit = _hitTest(widgetPos);
+            // Keep the stroke on the source it started on, so dragging across a
+            // comparison boundary does not tear it in two.
+            if (hit.index != p.strokeSource)
+            {
+                return;
+            }
+            if (!p.stroke.points.empty())
+            {
+                const ftk::V2F& last = p.stroke.points.back();
+                const float dx = hit.pos.x - last.x;
+                const float dy = hit.pos.y - last.y;
+                // Drop points the mouse barely moved, to keep strokes compact.
+                if (dx * dx + dy * dy < .25F)
+                {
+                    return;
+                }
+            }
+            p.stroke.points.push_back(hit.pos);
+            setDrawUpdate();
+        }
+
+        void Viewport::_drawEnd()
+        {
+            FTK_P();
+            if (p.strokeSource >= 0 && !p.stroke.points.empty())
+            {
+                if (auto app = p.app.lock())
+                {
+                    const auto& active = app->getFilesModel()->getActive();
+                    if (p.strokeSource < static_cast<int>(active.size()))
+                    {
+                        app->getAnnotationsModel()->addStroke(
+                            active[p.strokeSource]->id,
+                            *p.currentTime,
+                            p.stroke);
+                    }
+                }
+            }
+            p.stroke = models::ReviewStroke();
+            p.strokeSource = -1;
+            setDrawUpdate();
+        }
+
+        void Viewport::_erase(const ftk::V2I& widgetPos)
+        {
+            FTK_P();
+            const SourceHit hit = _hitTest(widgetPos);
+            if (hit.index < 0)
+            {
+                return;
+            }
+            if (auto app = p.app.lock())
+            {
+                const auto& active = app->getFilesModel()->getActive();
+                if (hit.index < static_cast<int>(active.size()))
+                {
+                    // The eraser removes whole strokes it touches; its reach
+                    // follows the tool size.
+                    app->getAnnotationsModel()->eraseStrokes(
+                        active[hit.index]->id,
+                        *p.currentTime,
+                        hit.pos,
+                        app->getDrawModel()->getSize());
+                }
+            }
+        }
+
+        void Viewport::drawEvent(const ftk::Box2I& drawRect, const ftk::DrawEvent& event)
+        {
+            tl::ui::Viewport::drawEvent(drawRect, event);
+            FTK_P();
+
+            auto app = p.app.lock();
+            if (!app)
+            {
+                return;
+            }
+            const ftk::Box2I& g = getGeometry();
+            const double zoom = getZoom();
+            const auto& active = app->getFilesModel()->getActive();
+
+            // Keep the overlay inside the viewport: a stroke zoomed past the
+            // edges would otherwise be painted over the panels and toolbars.
+            const bool clipRectEnabledPrev = event.render->getClipRectEnabled();
+            const ftk::Box2I clipRectPrev = event.render->getClipRect();
+            event.render->setClipRectEnabled(true);
+            event.render->setClipRect(ftk::intersect(g, clipRectPrev));
+
+            // Draw a stroke, converting the stored image pixels back to the
+            // screen so it tracks the zoom, the pan and the comparison mode.
+            auto drawStroke = [this, &event, &g, zoom](
+                int index,
+                const models::ReviewStroke& stroke,
+                float scale)
+            {
+                if (stroke.points.empty())
+                {
+                    return;
+                }
+                // To the screen first, then smooth and thicken there, so the
+                // curve stays smooth at any zoom.
+                std::vector<ftk::V2F> path;
+                path.reserve(stroke.points.size());
+                for (const auto& point : stroke.points)
+                {
+                    ftk::V2F p = _imageToWidget(index, point);
+                    p.x += g.min.x;
+                    p.y += g.min.y;
+                    path.push_back(p);
+                }
+                const float width = std::max(1.F, stroke.width * scale * static_cast<float>(zoom));
+                // Thin the captured points before smoothing, then subdivide:
+                // clustered controls are what make the spline overshoot.
+                event.render->drawMesh(
+                    strokeMesh(smoothPath(simplifyPath(path, 3.F), 12), width),
+                    stroke.color);
+            };
+
+            const auto boxes = _sourceBoxes();
+            auto sourceScale = [this, &boxes](int index) -> float
+            {
+                FTK_P();
+                if (index < 0 ||
+                    index >= static_cast<int>(boxes.size()) ||
+                    index >= static_cast<int>(p.videoFrames.size()))
+                {
+                    return 1.F;
+                }
+                const auto& video = p.videoFrames[index];
+                if (video.layers.empty() || !video.layers[0].image)
+                {
+                    return 1.F;
+                }
+                const int w = video.layers[0].image->getSize().w;
+                return w > 0 ? boxes[index].w() / static_cast<float>(w) : 1.F;
+            };
+
+            // The strokes already committed on this frame.
+            const auto& annotations = app->getAnnotationsModel()->getAnnotations();
+            for (const auto& annotation : annotations)
+            {
+                if (!models::sameTime(annotation.time, p.currentTime))
+                {
+                    continue;
+                }
+                int index = -1;
+                for (size_t i = 0; i < active.size(); ++i)
+                {
+                    if (active[i]->id == annotation.sourceId)
+                    {
+                        index = static_cast<int>(i);
+                        break;
+                    }
+                }
+                if (index < 0)
+                {
+                    continue;
+                }
+                const float scale = sourceScale(index);
+                for (const auto& stroke : annotation.strokes)
+                {
+                    drawStroke(index, stroke, scale);
+                }
+            }
+
+            // The stroke currently under the cursor.
+            if (p.strokeSource >= 0)
+            {
+                drawStroke(p.strokeSource, p.stroke, sourceScale(p.strokeSource));
+            }
+
+            event.render->setClipRectEnabled(clipRectEnabledPrev);
+            event.render->setClipRect(clipRectPrev);
         }
 
         void Viewport::_videoUpdate()

--- a/lib/djv/App/Viewport.h
+++ b/lib/djv/App/Viewport.h
@@ -52,6 +52,7 @@ namespace djv
 
             ftk::Size2I getSizeHint() const override;
             void setGeometry(const ftk::Box2I&) override;
+            void drawEvent(const ftk::Box2I&, const ftk::DrawEvent&) override;
             void mouseMoveEvent(ftk::MouseMoveEvent&) override;
             void mousePressEvent(ftk::MouseClickEvent&) override;
             void mouseReleaseEvent(ftk::MouseClickEvent&) override;
@@ -60,6 +61,36 @@ namespace djv
             bool _getSourceBox(ftk::Box2I&, ftk::Size2I&) const;
             ftk::V2I _toSourcePixel(const ftk::V2I&) const;
             ftk::V2I _fromSourcePixel(const ftk::V2I&) const;
+
+            //! Where a position in the viewport falls in the sources.
+            struct SourceHit
+            {
+                //! Index into the active files, or -1 if the position is outside
+                //! every source.
+                int      index = -1;
+
+                //! The position in the pixels of that source's image.
+                ftk::V2F pos;
+
+                //! Image pixels per render unit, for stroke widths.
+                float    scale = 1.F;
+            };
+
+            //! Map a widget-local position to a source and its image pixels.
+            SourceHit _hitTest(const ftk::V2I& widgetPos) const;
+
+            //! Map a position in a source's image pixels back to widget-local
+            //! coordinates.
+            ftk::V2F _imageToWidget(int index, const ftk::V2F& imagePos) const;
+
+            //! The boxes of the sources in render space, as used for drawing.
+            std::vector<ftk::Box2I> _sourceBoxes() const;
+
+            void _drawBegin(const ftk::V2I& widgetPos);
+            void _drawContinue(const ftk::V2I& widgetPos);
+            void _drawEnd();
+            void _erase(const ftk::V2I& widgetPos);
+
             void _videoUpdate();
             void _toastUpdate();
             void _hudUpdate();

--- a/lib/djv/Models/AnnotationsModel.cpp
+++ b/lib/djv/Models/AnnotationsModel.cpp
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the DJV project.
+
+#include <djv/Models/AnnotationsModel.h>
+
+#include <ftk/Core/Command.h>
+
+#include <algorithm>
+#include <cmath>
+
+namespace djv
+{
+    namespace models
+    {
+        namespace
+        {
+            //! A command that swaps the whole annotation list.
+            //!
+            //! Annotations are small -- a few hundred strokes at most -- so
+            //! snapshotting the list is simpler and safer than tracking
+            //! incremental edits, and it makes every operation undoable the same
+            //! way.
+            class SnapshotCommand : public ftk::ICommand
+            {
+            public:
+                SnapshotCommand(
+                    const std::function<void(const std::vector<ReviewAnnotation>&)>& apply,
+                    const std::vector<ReviewAnnotation>& before,
+                    const std::vector<ReviewAnnotation>& after) :
+                    _apply(apply),
+                    _before(before),
+                    _after(after)
+                {}
+
+                void exec() override { _apply(_after); }
+                void undo() override { _apply(_before); }
+
+            private:
+                std::function<void(const std::vector<ReviewAnnotation>&)> _apply;
+                std::vector<ReviewAnnotation> _before;
+                std::vector<ReviewAnnotation> _after;
+            };
+
+            //! The distance from a point to a segment.
+            float distanceToSegment(
+                const ftk::V2F& p,
+                const ftk::V2F& a,
+                const ftk::V2F& b)
+            {
+                const float dx = b.x - a.x;
+                const float dy = b.y - a.y;
+                const float lengthSquared = dx * dx + dy * dy;
+                float t = 0.F;
+                if (lengthSquared > 0.F)
+                {
+                    t = ((p.x - a.x) * dx + (p.y - a.y) * dy) / lengthSquared;
+                    t = std::max(0.F, std::min(1.F, t));
+                }
+                const float x = a.x + t * dx;
+                const float y = a.y + t * dy;
+                return std::sqrt((p.x - x) * (p.x - x) + (p.y - y) * (p.y - y));
+            }
+
+            //! Does the stroke pass within the radius of the position?
+            bool strokeHit(const ReviewStroke& stroke, const ftk::V2F& pos, float radius)
+            {
+                // Include the stroke's own width, so a thick stroke is as easy to
+                // hit as it looks.
+                const float threshold = radius + stroke.width / 2.F;
+                if (stroke.points.empty())
+                {
+                    return false;
+                }
+                if (1 == stroke.points.size())
+                {
+                    return distanceToSegment(pos, stroke.points[0], stroke.points[0]) <= threshold;
+                }
+                for (size_t i = 0; i + 1 < stroke.points.size(); ++i)
+                {
+                    if (distanceToSegment(pos, stroke.points[i], stroke.points[i + 1]) <= threshold)
+                    {
+                        return true;
+                    }
+                }
+                return false;
+            }
+        }
+
+        struct AnnotationsModel::Private
+        {
+            std::shared_ptr<ftk::ObservableList<ReviewAnnotation> > annotations;
+            std::shared_ptr<ftk::CommandStack> commandStack;
+        };
+
+        void AnnotationsModel::_init()
+        {
+            FTK_P();
+            p.annotations = ftk::ObservableList<ReviewAnnotation>::create();
+            p.commandStack = ftk::CommandStack::create();
+        }
+
+        AnnotationsModel::AnnotationsModel() :
+            _p(new Private)
+        {}
+
+        AnnotationsModel::~AnnotationsModel()
+        {}
+
+        std::shared_ptr<AnnotationsModel> AnnotationsModel::create()
+        {
+            auto out = std::shared_ptr<AnnotationsModel>(new AnnotationsModel);
+            out->_init();
+            return out;
+        }
+
+        const std::vector<ReviewAnnotation>& AnnotationsModel::getAnnotations() const
+        {
+            return _p->annotations->get();
+        }
+
+        std::shared_ptr<ftk::IObservableList<ReviewAnnotation> > AnnotationsModel::observeAnnotations() const
+        {
+            return _p->annotations;
+        }
+
+        std::vector<ReviewStroke> AnnotationsModel::getStrokes(
+            const std::string& sourceId,
+            const OTIO_NS::RationalTime& time) const
+        {
+            FTK_P();
+            for (const auto& annotation : p.annotations->get())
+            {
+                if (annotation.sourceId == sourceId &&
+                    sameTime(annotation.time, time))
+                {
+                    return annotation.strokes;
+                }
+            }
+            return {};
+        }
+
+        void AnnotationsModel::setAnnotations(const std::vector<ReviewAnnotation>& value)
+        {
+            FTK_P();
+            p.commandStack->clear();
+            p.annotations->setIfChanged(value);
+        }
+
+        void AnnotationsModel::addStroke(
+            const std::string& sourceId,
+            const OTIO_NS::RationalTime& time,
+            const ReviewStroke& stroke)
+        {
+            FTK_P();
+            if (stroke.points.empty())
+            {
+                return;
+            }
+            auto annotations = p.annotations->get();
+            const auto i = std::find_if(
+                annotations.begin(),
+                annotations.end(),
+                [&sourceId, &time](const ReviewAnnotation& value)
+                {
+                    return value.sourceId == sourceId && sameTime(value.time, time);
+                });
+            if (i != annotations.end())
+            {
+                i->strokes.push_back(stroke);
+            }
+            else
+            {
+                ReviewAnnotation annotation;
+                annotation.id = generateId();
+                annotation.sourceId = sourceId;
+                annotation.time = time;
+                annotation.strokes.push_back(stroke);
+                annotations.push_back(annotation);
+            }
+            _push(annotations);
+        }
+
+        void AnnotationsModel::eraseStrokes(
+            const std::string& sourceId,
+            const OTIO_NS::RationalTime& time,
+            const ftk::V2F& pos,
+            float radius)
+        {
+            FTK_P();
+            auto annotations = p.annotations->get();
+            bool changed = false;
+            for (auto i = annotations.begin(); i != annotations.end(); )
+            {
+                if (i->sourceId == sourceId && sameTime(i->time, time))
+                {
+                    auto& strokes = i->strokes;
+                    const size_t before = strokes.size();
+                    strokes.erase(
+                        std::remove_if(
+                            strokes.begin(),
+                            strokes.end(),
+                            [&pos, radius](const ReviewStroke& stroke)
+                            {
+                                return strokeHit(stroke, pos, radius);
+                            }),
+                        strokes.end());
+                    changed = changed || strokes.size() != before;
+                }
+                // Drop annotations that no longer hold anything, so they do not
+                // leave a phantom timeline marker.
+                if (i->strokes.empty())
+                {
+                    i = annotations.erase(i);
+                }
+                else
+                {
+                    ++i;
+                }
+            }
+            if (changed)
+            {
+                _push(annotations);
+            }
+        }
+
+        void AnnotationsModel::clearFrame(
+            const std::string& sourceId,
+            const OTIO_NS::RationalTime& time)
+        {
+            FTK_P();
+            auto annotations = p.annotations->get();
+            const size_t before = annotations.size();
+            annotations.erase(
+                std::remove_if(
+                    annotations.begin(),
+                    annotations.end(),
+                    [&sourceId, &time](const ReviewAnnotation& value)
+                    {
+                        return value.sourceId == sourceId && sameTime(value.time, time);
+                    }),
+                annotations.end());
+            if (annotations.size() != before)
+            {
+                _push(annotations);
+            }
+        }
+
+        void AnnotationsModel::clear()
+        {
+            FTK_P();
+            p.commandStack->clear();
+            p.annotations->setIfChanged({});
+        }
+
+        std::shared_ptr<ftk::IObservable<bool> > AnnotationsModel::observeHasUndo() const
+        {
+            return _p->commandStack->observeHasUndo();
+        }
+
+        std::shared_ptr<ftk::IObservable<bool> > AnnotationsModel::observeHasRedo() const
+        {
+            return _p->commandStack->observeHasRedo();
+        }
+
+        void AnnotationsModel::undo()
+        {
+            _p->commandStack->undo();
+        }
+
+        void AnnotationsModel::redo()
+        {
+            _p->commandStack->redo();
+        }
+
+        void AnnotationsModel::_set(const std::vector<ReviewAnnotation>& value)
+        {
+            _p->annotations->setIfChanged(value);
+        }
+
+        void AnnotationsModel::_push(const std::vector<ReviewAnnotation>& value)
+        {
+            FTK_P();
+            p.commandStack->push(std::make_shared<SnapshotCommand>(
+                [this](const std::vector<ReviewAnnotation>& v) { _set(v); },
+                p.annotations->get(),
+                value));
+        }
+    }
+}

--- a/lib/djv/Models/AnnotationsModel.cpp
+++ b/lib/djv/Models/AnnotationsModel.cpp
@@ -174,6 +174,10 @@ namespace djv
                 annotation.id = generateId();
                 annotation.sourceId = sourceId;
                 annotation.time = time;
+                // Attributed once, when the drawing on this frame starts: the
+                // strokes added to it afterwards belong to the same hand.
+                annotation.author = reviewAuthor();
+                annotation.created = timestamp();
                 annotation.strokes.push_back(stroke);
                 annotations.push_back(annotation);
             }

--- a/lib/djv/Models/AnnotationsModel.h
+++ b/lib/djv/Models/AnnotationsModel.h
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the DJV project.
+
+#pragma once
+
+#include <djv/Models/Review.h>
+
+#include <ftk/Core/ObservableList.h>
+#include <ftk/Core/Observable.h>
+
+namespace ftk
+{
+    class CommandStack;
+}
+
+namespace djv
+{
+    namespace models
+    {
+        //! The drawing annotations of a review.
+        //!
+        //! Adding and erasing strokes go through a command stack, so they can be
+        //! undone and redone. Annotations are session state: they live in the
+        //! review file, not in the application settings.
+        class AnnotationsModel : public std::enable_shared_from_this<AnnotationsModel>
+        {
+            FTK_NON_COPYABLE(AnnotationsModel);
+
+        protected:
+            void _init();
+
+            AnnotationsModel();
+
+        public:
+            ~AnnotationsModel();
+
+            //! Create a new model.
+            static std::shared_ptr<AnnotationsModel> create();
+
+            //! Get the annotations.
+            const std::vector<ReviewAnnotation>& getAnnotations() const;
+
+            //! Observe the annotations.
+            std::shared_ptr<ftk::IObservableList<ReviewAnnotation> > observeAnnotations() const;
+
+            //! Get the strokes drawn on the given source and frame, or an empty
+            //! list if there are none.
+            std::vector<ReviewStroke> getStrokes(
+                const std::string& sourceId,
+                const OTIO_NS::RationalTime&) const;
+
+            //! Replace all the annotations, e.g. when a review is opened. This
+            //! clears the undo history.
+            void setAnnotations(const std::vector<ReviewAnnotation>&);
+
+            //! Add a stroke to the given source and frame.
+            void addStroke(
+                const std::string& sourceId,
+                const OTIO_NS::RationalTime&,
+                const ReviewStroke&);
+
+            //! Erase the strokes of the given source and frame whose path passes
+            //! within the radius of the position. The position and the radius are
+            //! in the pixels of the source image.
+            void eraseStrokes(
+                const std::string& sourceId,
+                const OTIO_NS::RationalTime&,
+                const ftk::V2F& pos,
+                float radius);
+
+            //! Remove every stroke of the given source and frame.
+            void clearFrame(
+                const std::string& sourceId,
+                const OTIO_NS::RationalTime&);
+
+            //! Remove all the annotations, clearing the undo history.
+            void clear();
+
+            //! \name Undo
+            ///@{
+
+            std::shared_ptr<ftk::IObservable<bool> > observeHasUndo() const;
+            std::shared_ptr<ftk::IObservable<bool> > observeHasRedo() const;
+            void undo();
+            void redo();
+
+            ///@}
+
+        private:
+            //! Replace the whole list without touching the undo history.
+            void _set(const std::vector<ReviewAnnotation>&);
+
+            //! Push a command that moves from the current list to the given one.
+            void _push(const std::vector<ReviewAnnotation>&);
+
+            FTK_PRIVATE();
+        };
+    }
+}

--- a/lib/djv/Models/CMakeLists.txt
+++ b/lib/djv/Models/CMakeLists.txt
@@ -1,11 +1,16 @@
 set(HEADERS
+    AnnotationsModel.h
     AppInfoModel.h
     AudioModel.h
     ColorModel.h
     CommandsModel.h
+    DrawModel.h
     FilesModel.h
+    NotesModel.h
     OCIOModel.h
+    RangesModel.h
     RecentFilesModel.h
+    Review.h
     SettingsModel.h
     Shortcuts.h
     TimeUnitsModel.h
@@ -15,13 +20,18 @@ set(HEADERS
 set(HEADERS_PRIVATE)
 
 set(SOURCE
+    AnnotationsModel.cpp
     AppInfoModel.cpp
     AudioModel.cpp
     ColorModel.cpp
     CommandsModel.cpp
+    DrawModel.cpp
     FilesModel.cpp
+    NotesModel.cpp
     OCIOModel.cpp
+    RangesModel.cpp
     RecentFilesModel.cpp
+    Review.cpp
     SettingsModel.cpp
     Shortcuts.cpp
     TimeUnitsModel.cpp

--- a/lib/djv/Models/DrawModel.cpp
+++ b/lib/djv/Models/DrawModel.cpp
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the DJV project.
+
+#include <djv/Models/DrawModel.h>
+
+#include <ftk/UI/Settings.h>
+
+namespace djv
+{
+    namespace models
+    {
+        struct DrawModel::Private
+        {
+            std::shared_ptr<ftk::Settings> settings;
+            std::shared_ptr<ftk::Observable<bool> > enabled;
+            std::shared_ptr<ftk::Observable<DrawTool> > tool;
+            std::shared_ptr<ftk::Observable<ftk::Color4F> > color;
+            std::shared_ptr<ftk::Observable<float> > size;
+        };
+
+        void DrawModel::_init(const std::shared_ptr<ftk::Settings>& settings)
+        {
+            FTK_P();
+
+            p.settings = settings;
+
+            // Drawing always starts off: it takes over the left mouse button.
+            p.enabled = ftk::Observable<bool>::create(false);
+            p.tool = ftk::Observable<DrawTool>::create(DrawTool::Pen);
+
+            // A warm orange reads on both dark and bright footage; a dark
+            // default would be invisible on dark shots.
+            ftk::Color4F color(1.F, .365F, .02F, 1.F);
+            p.settings->getT("/Draw/Color", color);
+            p.color = ftk::Observable<ftk::Color4F>::create(color);
+
+            float size = 4.F;
+            p.settings->get("/Draw/Size", size);
+            p.size = ftk::Observable<float>::create(size > 0.F ? size : 4.F);
+        }
+
+        DrawModel::DrawModel() :
+            _p(new Private)
+        {}
+
+        DrawModel::~DrawModel()
+        {
+            FTK_P();
+            p.settings->setT("/Draw/Color", p.color->get());
+            p.settings->set("/Draw/Size", p.size->get());
+        }
+
+        std::shared_ptr<DrawModel> DrawModel::create(
+            const std::shared_ptr<ftk::Settings>& settings)
+        {
+            auto out = std::shared_ptr<DrawModel>(new DrawModel);
+            out->_init(settings);
+            return out;
+        }
+
+        bool DrawModel::isEnabled() const
+        {
+            return _p->enabled->get();
+        }
+
+        std::shared_ptr<ftk::IObservable<bool> > DrawModel::observeEnabled() const
+        {
+            return _p->enabled;
+        }
+
+        void DrawModel::setEnabled(bool value)
+        {
+            _p->enabled->setIfChanged(value);
+        }
+
+        DrawTool DrawModel::getTool() const
+        {
+            return _p->tool->get();
+        }
+
+        std::shared_ptr<ftk::IObservable<DrawTool> > DrawModel::observeTool() const
+        {
+            return _p->tool;
+        }
+
+        void DrawModel::setTool(DrawTool value)
+        {
+            _p->tool->setIfChanged(value);
+        }
+
+        const ftk::Color4F& DrawModel::getColor() const
+        {
+            return _p->color->get();
+        }
+
+        std::shared_ptr<ftk::IObservable<ftk::Color4F> > DrawModel::observeColor() const
+        {
+            return _p->color;
+        }
+
+        void DrawModel::setColor(const ftk::Color4F& value)
+        {
+            _p->color->setIfChanged(value);
+        }
+
+        float DrawModel::getSize() const
+        {
+            return _p->size->get();
+        }
+
+        std::shared_ptr<ftk::IObservable<float> > DrawModel::observeSize() const
+        {
+            return _p->size;
+        }
+
+        void DrawModel::setSize(float value)
+        {
+            // A zero width would draw nothing.
+            _p->size->setIfChanged(std::max(.5F, value));
+        }
+    }
+}

--- a/lib/djv/Models/DrawModel.h
+++ b/lib/djv/Models/DrawModel.h
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the DJV project.
+
+#pragma once
+
+#include <ftk/Core/Observable.h>
+#include <ftk/Core/Color.h>
+
+namespace ftk
+{
+    class Settings;
+}
+
+namespace djv
+{
+    namespace models
+    {
+        //! Drawing tools.
+        enum class DrawTool
+        {
+            Pen,
+            Eraser
+        };
+
+        //! The drawing state: whether drawing is active, and with what.
+        //!
+        //! These are preferences rather than review contents, so they are kept
+        //! in the settings and not in the review file.
+        class DrawModel : public std::enable_shared_from_this<DrawModel>
+        {
+            FTK_NON_COPYABLE(DrawModel);
+
+        protected:
+            void _init(const std::shared_ptr<ftk::Settings>&);
+
+            DrawModel();
+
+        public:
+            ~DrawModel();
+
+            //! Create a new model.
+            static std::shared_ptr<DrawModel> create(
+                const std::shared_ptr<ftk::Settings>&);
+
+            //! Is drawing active? While it is, the viewport draws instead of
+            //! shuttling frames with the left mouse button.
+            bool isEnabled() const;
+            std::shared_ptr<ftk::IObservable<bool> > observeEnabled() const;
+            void setEnabled(bool);
+
+            //! The current tool.
+            DrawTool getTool() const;
+            std::shared_ptr<ftk::IObservable<DrawTool> > observeTool() const;
+            void setTool(DrawTool);
+
+            //! The stroke colour.
+            const ftk::Color4F& getColor() const;
+            std::shared_ptr<ftk::IObservable<ftk::Color4F> > observeColor() const;
+            void setColor(const ftk::Color4F&);
+
+            //! The stroke width, in the pixels of the source image.
+            float getSize() const;
+            std::shared_ptr<ftk::IObservable<float> > observeSize() const;
+            void setSize(float);
+
+        private:
+            FTK_PRIVATE();
+        };
+    }
+}

--- a/lib/djv/Models/FilesModel.h
+++ b/lib/djv/Models/FilesModel.h
@@ -21,6 +21,11 @@ namespace djv
         //! Files model item.
         struct FilesModelItem
         {
+            //! Stable, unique identifier. Assigned when the file is opened so
+            //! that reviews and annotations can reference the file by identity
+            //! rather than by list index. See models::generateId().
+            std::string              id;
+
             ftk::Path                path;
             ftk::Path                audioPath;
 

--- a/lib/djv/Models/NotesModel.cpp
+++ b/lib/djv/Models/NotesModel.cpp
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the DJV project.
+
+#include <djv/Models/NotesModel.h>
+
+#include <algorithm>
+
+namespace djv
+{
+    namespace models
+    {
+        struct NotesModel::Private
+        {
+            std::shared_ptr<ftk::ObservableList<ReviewNote> > notes;
+        };
+
+        void NotesModel::_init()
+        {
+            FTK_P();
+            p.notes = ftk::ObservableList<ReviewNote>::create();
+        }
+
+        NotesModel::NotesModel() :
+            _p(new Private)
+        {}
+
+        NotesModel::~NotesModel()
+        {}
+
+        std::shared_ptr<NotesModel> NotesModel::create()
+        {
+            auto out = std::shared_ptr<NotesModel>(new NotesModel);
+            out->_init();
+            return out;
+        }
+
+        const std::vector<ReviewNote>& NotesModel::getNotes() const
+        {
+            return _p->notes->get();
+        }
+
+        std::shared_ptr<ftk::IObservableList<ReviewNote> > NotesModel::observeNotes() const
+        {
+            return _p->notes;
+        }
+
+        void NotesModel::setNotes(const std::vector<ReviewNote>& value)
+        {
+            _p->notes->setIfChanged(value);
+        }
+
+        void NotesModel::add(const std::optional<OTIO_NS::RationalTime>& time, const std::string& text)
+        {
+            FTK_P();
+            ReviewNote note;
+            note.id = generateId();
+            note.time = time;
+            note.created = timestamp();
+            note.text = text;
+            auto notes = p.notes->get();
+            notes.push_back(note);
+            p.notes->setIfChanged(notes);
+        }
+
+        void NotesModel::remove(const std::string& id)
+        {
+            FTK_P();
+            auto notes = p.notes->get();
+            const auto i = std::find_if(
+                notes.begin(),
+                notes.end(),
+                [id](const ReviewNote& note) { return note.id == id; });
+            if (i != notes.end())
+            {
+                notes.erase(i);
+                p.notes->setIfChanged(notes);
+            }
+        }
+
+        void NotesModel::clear()
+        {
+            _p->notes->setIfChanged({});
+        }
+    }
+}

--- a/lib/djv/Models/NotesModel.cpp
+++ b/lib/djv/Models/NotesModel.cpp
@@ -56,6 +56,7 @@ namespace djv
             note.id = generateId();
             note.time = time;
             note.created = timestamp();
+            note.author = reviewAuthor();
             note.text = text;
             auto notes = p.notes->get();
             notes.push_back(note);

--- a/lib/djv/Models/NotesModel.h
+++ b/lib/djv/Models/NotesModel.h
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the DJV project.
+
+#pragma once
+
+#include <djv/Models/Review.h>
+
+#include <ftk/Core/ObservableList.h>
+
+namespace djv
+{
+    namespace models
+    {
+        //! The review notes.
+        //!
+        //! Notes are session state: they live in the review file, not in the
+        //! application settings.
+        class NotesModel : public std::enable_shared_from_this<NotesModel>
+        {
+            FTK_NON_COPYABLE(NotesModel);
+
+        protected:
+            void _init();
+
+            NotesModel();
+
+        public:
+            ~NotesModel();
+
+            //! Create a new model.
+            static std::shared_ptr<NotesModel> create();
+
+            //! Get the notes.
+            const std::vector<ReviewNote>& getNotes() const;
+
+            //! Observe the notes.
+            std::shared_ptr<ftk::IObservableList<ReviewNote> > observeNotes() const;
+
+            //! Replace all the notes, e.g. when a review is opened.
+            void setNotes(const std::vector<ReviewNote>&);
+
+            //! Add a note. The identifier and creation time are filled in here,
+            //! so callers only provide the frame and the text.
+            void add(const std::optional<OTIO_NS::RationalTime>&, const std::string& text);
+
+            //! Remove the note with the given identifier.
+            void remove(const std::string& id);
+
+            //! Remove all the notes.
+            void clear();
+
+        private:
+            FTK_PRIVATE();
+        };
+    }
+}

--- a/lib/djv/Models/NotesModel.h
+++ b/lib/djv/Models/NotesModel.h
@@ -39,8 +39,8 @@ namespace djv
             //! Replace all the notes, e.g. when a review is opened.
             void setNotes(const std::vector<ReviewNote>&);
 
-            //! Add a note. The identifier and creation time are filled in here,
-            //! so callers only provide the frame and the text.
+            //! Add a note. The identifier, creation time and author are filled
+            //! in here, so callers only provide the frame and the text.
             void add(const std::optional<OTIO_NS::RationalTime>&, const std::string& text);
 
             //! Remove the note with the given identifier.

--- a/lib/djv/Models/RangesModel.cpp
+++ b/lib/djv/Models/RangesModel.cpp
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the DJV project.
+
+#include <djv/Models/RangesModel.h>
+
+#include <algorithm>
+
+namespace djv
+{
+    namespace models
+    {
+        struct RangesModel::Private
+        {
+            std::shared_ptr<ftk::ObservableList<ReviewRange> > ranges;
+        };
+
+        void RangesModel::_init()
+        {
+            FTK_P();
+            p.ranges = ftk::ObservableList<ReviewRange>::create();
+        }
+
+        RangesModel::RangesModel() :
+            _p(new Private)
+        {}
+
+        RangesModel::~RangesModel()
+        {}
+
+        std::shared_ptr<RangesModel> RangesModel::create()
+        {
+            auto out = std::shared_ptr<RangesModel>(new RangesModel);
+            out->_init();
+            return out;
+        }
+
+        const std::vector<ReviewRange>& RangesModel::getRanges() const
+        {
+            return _p->ranges->get();
+        }
+
+        std::shared_ptr<ftk::IObservableList<ReviewRange> > RangesModel::observeRanges() const
+        {
+            return _p->ranges;
+        }
+
+        void RangesModel::setRanges(const std::vector<ReviewRange>& value)
+        {
+            _set(value);
+        }
+
+        void RangesModel::add(const OTIO_NS::TimeRange& range, const std::string& name)
+        {
+            FTK_P();
+            ReviewRange value;
+            value.id = generateId();
+            value.name = name;
+            value.range = range;
+            auto ranges = p.ranges->get();
+            ranges.push_back(value);
+            _set(ranges);
+        }
+
+        void RangesModel::remove(const std::string& id)
+        {
+            FTK_P();
+            auto ranges = p.ranges->get();
+            const auto i = std::find_if(
+                ranges.begin(),
+                ranges.end(),
+                [id](const ReviewRange& range) { return range.id == id; });
+            if (i != ranges.end())
+            {
+                ranges.erase(i);
+                _set(ranges);
+            }
+        }
+
+        void RangesModel::clear()
+        {
+            _set({});
+        }
+
+        void RangesModel::_set(std::vector<ReviewRange> value)
+        {
+            FTK_P();
+            // Sorting here rather than in the panel keeps every reader of the
+            // model in the same order, and survives a load from a hand-edited
+            // review file.
+            std::stable_sort(
+                value.begin(),
+                value.end(),
+                [](const ReviewRange& a, const ReviewRange& b)
+                {
+                    // A range with no bounds cannot be ordered against one that
+                    // has them; park it at the end rather than at frame zero.
+                    if (!a.range.has_value())
+                    {
+                        return false;
+                    }
+                    if (!b.range.has_value())
+                    {
+                        return true;
+                    }
+                    return a.range->start_time() < b.range->start_time();
+                });
+            p.ranges->setIfChanged(value);
+        }
+    }
+}

--- a/lib/djv/Models/RangesModel.h
+++ b/lib/djv/Models/RangesModel.h
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the DJV project.
+
+#pragma once
+
+#include <djv/Models/Review.h>
+
+#include <ftk/Core/ObservableList.h>
+
+namespace djv
+{
+    namespace models
+    {
+        //! The named frame ranges of a review.
+        //!
+        //! Ranges are session state: they live in the review file, not in the
+        //! application settings. The list is kept sorted by start frame, so it
+        //! reads like a shot breakdown rather than like a history.
+        class RangesModel : public std::enable_shared_from_this<RangesModel>
+        {
+            FTK_NON_COPYABLE(RangesModel);
+
+        protected:
+            void _init();
+
+            RangesModel();
+
+        public:
+            ~RangesModel();
+
+            //! Create a new model.
+            static std::shared_ptr<RangesModel> create();
+
+            //! Get the ranges.
+            const std::vector<ReviewRange>& getRanges() const;
+
+            //! Observe the ranges.
+            std::shared_ptr<ftk::IObservableList<ReviewRange> > observeRanges() const;
+
+            //! Replace all the ranges, e.g. when a review is opened.
+            void setRanges(const std::vector<ReviewRange>&);
+
+            //! Add a range. The identifier is filled in here, so callers only
+            //! provide the range and its name.
+            void add(const OTIO_NS::TimeRange&, const std::string& name);
+
+            //! Remove the range with the given identifier.
+            void remove(const std::string& id);
+
+            //! Remove all the ranges.
+            void clear();
+
+        private:
+            //! Sort by start frame, then set.
+            void _set(std::vector<ReviewRange>);
+
+            FTK_PRIVATE();
+        };
+    }
+}

--- a/lib/djv/Models/RecentFilesModel.cpp
+++ b/lib/djv/Models/RecentFilesModel.cpp
@@ -12,20 +12,23 @@ namespace djv
         struct RecentFilesModel::Private
         {
             std::shared_ptr<ftk::Settings> settings;
+            std::string settingsGroup;
         };
 
         void RecentFilesModel::_init(
             const std::shared_ptr<ftk::Context>& context,
-            const std::shared_ptr<ftk::Settings>& settings)
+            const std::shared_ptr<ftk::Settings>& settings,
+            const std::string& settingsGroup)
         {
             ftk::RecentFilesModel::_init(context);
             FTK_P();
 
             p.settings = settings;
+            p.settingsGroup = settingsGroup;
 
             std::vector<std::filesystem::path> recent;
             nlohmann::json json;
-            if (p.settings->get("/Files/Recent", json))
+            if (p.settings->get("/" + p.settingsGroup + "/Recent", json))
             {
                 for (auto i = json.begin(); i != json.end(); ++i)
                 {
@@ -37,7 +40,7 @@ namespace djv
             }
             setRecent(recent);
             size_t max = 10;
-            p.settings->get("/Files/RecentMax", max);
+            p.settings->get("/" + p.settingsGroup + "/RecentMax", max);
             setRecentMax(max);
         }
 
@@ -53,16 +56,17 @@ namespace djv
             {
                 json.push_back(path.u8string());
             }
-            p.settings->set("/Files/Recent", json);
-            p.settings->set("/Files/RecentMax", getRecentMax());
+            p.settings->set("/" + p.settingsGroup + "/Recent", json);
+            p.settings->set("/" + p.settingsGroup + "/RecentMax", getRecentMax());
         }
 
         std::shared_ptr<RecentFilesModel> RecentFilesModel::create(
             const std::shared_ptr<ftk::Context>& context,
-            const std::shared_ptr<ftk::Settings>& settings)
+            const std::shared_ptr<ftk::Settings>& settings,
+            const std::string& settingsGroup)
         {
             auto out = std::shared_ptr<RecentFilesModel>(new RecentFilesModel);
-            out->_init(context, settings);
+            out->_init(context, settings, settingsGroup);
             return out;
         }
     }

--- a/lib/djv/Models/RecentFilesModel.h
+++ b/lib/djv/Models/RecentFilesModel.h
@@ -22,17 +22,20 @@ namespace djv
         protected:
             void _init(
                 const std::shared_ptr<ftk::Context>&,
-                const std::shared_ptr<ftk::Settings>&);
+                const std::shared_ptr<ftk::Settings>&,
+                const std::string& settingsGroup);
 
             RecentFilesModel();
 
         public:
             ~RecentFilesModel();
 
-            //! Create a new model.
+            //! Create a new model. The settings group is the prefix under which
+            //! the recent list is persisted, e.g. "Files" -> "/Files/Recent".
             static std::shared_ptr<RecentFilesModel> create(
                 const std::shared_ptr<ftk::Context>&,
-                const std::shared_ptr<ftk::Settings>&);
+                const std::shared_ptr<ftk::Settings>&,
+                const std::string& settingsGroup = "Files");
 
         private:
             FTK_PRIVATE();

--- a/lib/djv/Models/Review.cpp
+++ b/lib/djv/Models/Review.cpp
@@ -1,0 +1,395 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the DJV project.
+
+#include <djv/Models/Review.h>
+
+#include <atomic>
+#include <ctime>
+#include <iomanip>
+#include <random>
+#include <sstream>
+
+namespace djv
+{
+    namespace models
+    {
+        namespace
+        {
+            nlohmann::json timeToJson(const OTIO_NS::RationalTime& value)
+            {
+                nlohmann::json out;
+                out["value"] = value.value();
+                out["rate"] = value.rate();
+                return out;
+            }
+
+            OTIO_NS::RationalTime jsonToTime(const nlohmann::json& json)
+            {
+                return OTIO_NS::RationalTime(
+                    json.at("value").get<double>(),
+                    json.at("rate").get<double>());
+            }
+
+            nlohmann::json rangeToJson(const OTIO_NS::TimeRange& value)
+            {
+                nlohmann::json out;
+                out["start"] = timeToJson(value.start_time());
+                out["duration"] = timeToJson(value.duration());
+                return out;
+            }
+
+            OTIO_NS::TimeRange jsonToRange(const nlohmann::json& json)
+            {
+                return OTIO_NS::TimeRange(
+                    jsonToTime(json.at("start")),
+                    jsonToTime(json.at("duration")));
+            }
+
+        }
+
+        bool sameTime(
+            const std::optional<OTIO_NS::RationalTime>& a,
+            const std::optional<OTIO_NS::RationalTime>& b)
+        {
+            if (a.has_value() != b.has_value())
+            {
+                return false;
+            }
+            return !a.has_value() || a->strictly_equal(*b);
+        }
+
+        bool sameRange(
+            const std::optional<OTIO_NS::TimeRange>& a,
+            const std::optional<OTIO_NS::TimeRange>& b)
+        {
+            if (a.has_value() != b.has_value())
+            {
+                return false;
+            }
+            return !a.has_value() || tl::compareExact(*a, *b);
+        }
+
+        std::string generateId()
+        {
+            // 64 random bits plus a monotonic counter: random enough to keep two
+            // separately-authored reviews from colliding, and the counter
+            // guarantees uniqueness within a single session even if the engine is
+            // re-seeded to the same value. Not a formal UUID, which is not needed.
+            static std::mt19937_64 engine(std::random_device{}());
+            static std::atomic<uint64_t> counter{ 0 };
+            const uint64_t r = engine();
+            const uint64_t c = counter.fetch_add(1);
+            std::stringstream ss;
+            ss << std::hex << std::setw(16) << std::setfill('0') << r
+               << std::setw(8) << std::setfill('0') << static_cast<uint32_t>(c);
+            return ss.str();
+        }
+
+        std::string timestamp()
+        {
+            const std::time_t t = std::time(nullptr);
+            std::tm tm {};
+#if defined(_WIN32)
+            gmtime_s(&tm, &t);
+#else
+            gmtime_r(&t, &tm);
+#endif
+            char buf[32] = {};
+            std::strftime(buf, sizeof(buf), "%Y-%m-%dT%H:%M:%SZ", &tm);
+            return std::string(buf);
+        }
+
+        void to_json(nlohmann::json& json, const ReviewFile& in)
+        {
+            json = nlohmann::json::object();
+            json["id"] = in.id;
+            json["path"] = in.path;
+            if (!in.pathAbsolute.empty())
+            {
+                json["pathAbsolute"] = in.pathAbsolute;
+            }
+            if (!in.audioPath.empty())
+            {
+                json["audioPath"] = in.audioPath;
+            }
+            json["videoLayer"] = in.videoLayer;
+            if (in.speed >= 0.0)
+            {
+                json["speed"] = in.speed;
+            }
+            if (in.currentTime.has_value())
+            {
+                json["currentTime"] = timeToJson(in.currentTime.value());
+            }
+            if (in.inOutRange.has_value())
+            {
+                json["inOutRange"] = rangeToJson(in.inOutRange.value());
+            }
+        }
+
+        void from_json(const nlohmann::json& json, ReviewFile& out)
+        {
+            if (json.contains("id")) json.at("id").get_to(out.id);
+            if (json.contains("path")) json.at("path").get_to(out.path);
+            if (json.contains("pathAbsolute")) json.at("pathAbsolute").get_to(out.pathAbsolute);
+            if (json.contains("audioPath")) json.at("audioPath").get_to(out.audioPath);
+            if (json.contains("videoLayer")) json.at("videoLayer").get_to(out.videoLayer);
+            if (json.contains("speed")) json.at("speed").get_to(out.speed);
+            if (json.contains("currentTime")) out.currentTime = jsonToTime(json.at("currentTime"));
+            if (json.contains("inOutRange")) out.inOutRange = jsonToRange(json.at("inOutRange"));
+        }
+
+        void to_json(nlohmann::json& json, const ReviewCompare& in)
+        {
+            json = nlohmann::json::object();
+            json["aId"] = in.aId;
+            json["bIds"] = in.bIds;
+            json["options"] = in.options;
+            json["time"] = to_string(in.time);
+        }
+
+        void from_json(const nlohmann::json& json, ReviewCompare& out)
+        {
+            if (json.contains("aId")) json.at("aId").get_to(out.aId);
+            if (json.contains("bIds")) json.at("bIds").get_to(out.bIds);
+            if (json.contains("options")) json.at("options").get_to(out.options);
+            if (json.contains("time"))
+            {
+                std::string s;
+                json.at("time").get_to(s);
+                from_string(s, out.time);
+            }
+        }
+
+        void to_json(nlohmann::json& json, const ReviewView& in)
+        {
+            json = nlohmann::json::object();
+            json["frameView"] = in.frameView;
+            json["pos"] = in.pos;
+            json["zoom"] = in.zoom;
+        }
+
+        void from_json(const nlohmann::json& json, ReviewView& out)
+        {
+            if (json.contains("frameView")) json.at("frameView").get_to(out.frameView);
+            if (json.contains("pos")) json.at("pos").get_to(out.pos);
+            if (json.contains("zoom")) json.at("zoom").get_to(out.zoom);
+        }
+
+        void to_json(nlohmann::json& json, const ReviewColor& in)
+        {
+            json = nlohmann::json::object();
+            json["ocio"] = in.ocio;
+            json["lut"] = in.lut;
+            json["display"] = in.display;
+            json["background"] = in.background;
+            json["foreground"] = in.foreground;
+            json["aspectRatio"] = in.aspectRatio;
+            json["hud"] = in.hud;
+        }
+
+        void from_json(const nlohmann::json& json, ReviewColor& out)
+        {
+            if (json.contains("ocio")) json.at("ocio").get_to(out.ocio);
+            if (json.contains("lut")) json.at("lut").get_to(out.lut);
+            if (json.contains("display")) json.at("display").get_to(out.display);
+            if (json.contains("background")) json.at("background").get_to(out.background);
+            if (json.contains("foreground")) json.at("foreground").get_to(out.foreground);
+            if (json.contains("aspectRatio")) json.at("aspectRatio").get_to(out.aspectRatio);
+            if (json.contains("hud")) json.at("hud").get_to(out.hud);
+        }
+
+        void to_json(nlohmann::json& json, const ReviewUI& in)
+        {
+            json = nlohmann::json::object();
+            json["activeTool"] = in.activeTool;
+            json["window"] = in.window;
+        }
+
+        void from_json(const nlohmann::json& json, ReviewUI& out)
+        {
+            if (json.contains("activeTool")) json.at("activeTool").get_to(out.activeTool);
+            if (json.contains("window")) json.at("window").get_to(out.window);
+        }
+
+        bool ReviewStroke::operator == (const ReviewStroke& other) const
+        {
+            return
+                color == other.color &&
+                width == other.width &&
+                points == other.points;
+        }
+
+        bool ReviewStroke::operator != (const ReviewStroke& other) const
+        {
+            return !(*this == other);
+        }
+
+        bool ReviewAnnotation::operator == (const ReviewAnnotation& other) const
+        {
+            return
+                id == other.id &&
+                sourceId == other.sourceId &&
+                sameTime(time, other.time) &&
+                strokes == other.strokes;
+        }
+
+        bool ReviewAnnotation::operator != (const ReviewAnnotation& other) const
+        {
+            return !(*this == other);
+        }
+
+        void to_json(nlohmann::json& json, const ReviewStroke& in)
+        {
+            json = nlohmann::json::object();
+            json["color"] = in.color;
+            json["width"] = in.width;
+            json["widthSpace"] = "image";
+            // Flat [x, y, x, y, ...] keeps long strokes compact and readable.
+            nlohmann::json points = nlohmann::json::array();
+            for (const auto& point : in.points)
+            {
+                points.push_back(point.x);
+                points.push_back(point.y);
+            }
+            json["points"] = points;
+        }
+
+        void from_json(const nlohmann::json& json, ReviewStroke& out)
+        {
+            if (json.contains("color")) json.at("color").get_to(out.color);
+            if (json.contains("width")) json.at("width").get_to(out.width);
+            out.points.clear();
+            if (json.contains("points"))
+            {
+                const auto& points = json.at("points");
+                for (size_t i = 0; i + 1 < points.size(); i += 2)
+                {
+                    out.points.push_back(ftk::V2F(
+                        points[i].get<float>(),
+                        points[i + 1].get<float>()));
+                }
+            }
+        }
+
+        void to_json(nlohmann::json& json, const ReviewAnnotation& in)
+        {
+            json = nlohmann::json::object();
+            json["id"] = in.id;
+            json["sourceId"] = in.sourceId;
+            json["space"] = "image";
+            if (in.time.has_value())
+            {
+                json["time"] = timeToJson(in.time.value());
+            }
+            json["strokes"] = in.strokes;
+        }
+
+        void from_json(const nlohmann::json& json, ReviewAnnotation& out)
+        {
+            if (json.contains("id")) json.at("id").get_to(out.id);
+            if (json.contains("sourceId")) json.at("sourceId").get_to(out.sourceId);
+            if (json.contains("time")) out.time = jsonToTime(json.at("time"));
+            if (json.contains("strokes")) json.at("strokes").get_to(out.strokes);
+        }
+
+        bool ReviewNote::operator == (const ReviewNote& other) const
+        {
+            return
+                id == other.id &&
+                sameTime(time, other.time) &&
+                created == other.created &&
+                text == other.text;
+        }
+
+        bool ReviewNote::operator != (const ReviewNote& other) const
+        {
+            return !(*this == other);
+        }
+
+        void to_json(nlohmann::json& json, const ReviewNote& in)
+        {
+            json = nlohmann::json::object();
+            json["id"] = in.id;
+            if (in.time.has_value())
+            {
+                json["time"] = timeToJson(in.time.value());
+            }
+            json["created"] = in.created;
+            json["text"] = in.text;
+        }
+
+        void from_json(const nlohmann::json& json, ReviewNote& out)
+        {
+            if (json.contains("id")) json.at("id").get_to(out.id);
+            if (json.contains("time")) out.time = jsonToTime(json.at("time"));
+            if (json.contains("created")) json.at("created").get_to(out.created);
+            if (json.contains("text")) json.at("text").get_to(out.text);
+        }
+
+        bool ReviewRange::operator == (const ReviewRange& other) const
+        {
+            return
+                id == other.id &&
+                name == other.name &&
+                sameRange(range, other.range);
+        }
+
+        bool ReviewRange::operator != (const ReviewRange& other) const
+        {
+            return !(*this == other);
+        }
+
+        void to_json(nlohmann::json& json, const ReviewRange& in)
+        {
+            json = nlohmann::json::object();
+            json["id"] = in.id;
+            json["name"] = in.name;
+            if (in.range.has_value())
+            {
+                json["range"] = rangeToJson(in.range.value());
+            }
+        }
+
+        void from_json(const nlohmann::json& json, ReviewRange& out)
+        {
+            if (json.contains("id")) json.at("id").get_to(out.id);
+            if (json.contains("name")) json.at("name").get_to(out.name);
+            if (json.contains("range")) out.range = jsonToRange(json.at("range"));
+        }
+
+        void to_json(nlohmann::json& json, const Review& in)
+        {
+            // Start from the loaded document so unknown sections (e.g. a future
+            // "annotations"/"notes") survive a load/save round-trip untouched.
+            json = in.raw.is_object() ? in.raw : nlohmann::json::object();
+            json["djvReview"] = in.version;
+            json["app"] = in.app;
+            json["created"] = in.created;
+            json["files"] = in.files;
+            json["compare"] = in.compare;
+            json["view"] = in.view;
+            json["color"] = in.color;
+            json["ui"] = in.ui;
+            json["annotations"] = in.annotations;
+            json["notes"] = in.notes;
+            json["ranges"] = in.ranges;
+        }
+
+        void from_json(const nlohmann::json& json, Review& out)
+        {
+            out.raw = json;
+            if (json.contains("djvReview")) json.at("djvReview").get_to(out.version);
+            if (json.contains("app")) json.at("app").get_to(out.app);
+            if (json.contains("created")) json.at("created").get_to(out.created);
+            if (json.contains("files")) json.at("files").get_to(out.files);
+            if (json.contains("compare")) json.at("compare").get_to(out.compare);
+            if (json.contains("view")) json.at("view").get_to(out.view);
+            if (json.contains("color")) json.at("color").get_to(out.color);
+            if (json.contains("ui")) json.at("ui").get_to(out.ui);
+            if (json.contains("annotations")) json.at("annotations").get_to(out.annotations);
+            if (json.contains("notes")) json.at("notes").get_to(out.notes);
+            if (json.contains("ranges")) json.at("ranges").get_to(out.ranges);
+        }
+    }
+}

--- a/lib/djv/Models/Review.cpp
+++ b/lib/djv/Models/Review.cpp
@@ -3,11 +3,15 @@
 
 #include <djv/Models/Review.h>
 
+#include <ftk/Core/OS.h>
+
+#include <algorithm>
 #include <atomic>
 #include <ctime>
 #include <iomanip>
 #include <random>
 #include <sstream>
+#include <stdexcept>
 
 namespace djv
 {
@@ -45,6 +49,94 @@ namespace djv
                     jsonToTime(json.at("duration")));
             }
 
+            //! The only coordinate space this version knows: the pixels of the
+            //! source image.
+            const std::string imageSpace = "image";
+
+            //! Check a coordinate space, refusing one this version cannot place.
+            //!
+            //! An absent space means the image space, which was not always
+            //! written. Refusing here means the caller keeps the item verbatim
+            //! instead of drawing it in the wrong coordinates.
+            void requireSpace(const nlohmann::json& json, const std::string& key)
+            {
+                const auto i = json.find(key);
+                if (i == json.end())
+                {
+                    return;
+                }
+                if (!i->is_string() || i->get<std::string>() != imageSpace)
+                {
+                    throw std::runtime_error("unknown " + key + ": " + i->dump());
+                }
+            }
+
+            //! Read one top-level section, containing a failure to that section.
+            //!
+            //! The color, compare and interface sections delegate to serializers
+            //! that require every key they know, so a key added upstream makes
+            //! the whole section throw. Letting that reach the caller would cost
+            //! the reader the entire document.
+            template<typename T>
+            void readSection(
+                const nlohmann::json& json,
+                const std::string& key,
+                T& out,
+                Review& review)
+            {
+                const auto i = json.find(key);
+                if (i == json.end())
+                {
+                    return;
+                }
+                try
+                {
+                    i->get_to(out);
+                }
+                catch (const std::exception&)
+                {
+                    // A partial read leaves the section half-written.
+                    out = T();
+                    review.unreadSections.push_back(key);
+                }
+            }
+
+            //! Read a list section, containing a failure to the offending item.
+            //!
+            //! Unlike the sections above, these lists are edited during the
+            //! session, so they must be written back. An item that cannot be
+            //! read is kept verbatim and re-emitted on save rather than dropped:
+            //! it belongs to whoever wrote it.
+            template<typename T>
+            void readList(
+                const nlohmann::json& json,
+                const std::string& key,
+                std::vector<T>& out,
+                Review& review)
+            {
+                const auto i = json.find(key);
+                if (i == json.end())
+                {
+                    return;
+                }
+                if (!i->is_array())
+                {
+                    review.unreadSections.push_back(key);
+                    return;
+                }
+                out.clear();
+                for (const auto& item : *i)
+                {
+                    try
+                    {
+                        out.push_back(item.get<T>());
+                    }
+                    catch (const std::exception&)
+                    {
+                        review.unreadItems[key].push_back(item);
+                    }
+                }
+            }
         }
 
         bool sameTime(
@@ -85,6 +177,22 @@ namespace djv
             return ss.str();
         }
 
+        bool reviewVersionSupported(int version)
+        {
+            return version <= reviewVersion;
+        }
+
+        std::string reviewAuthor()
+        {
+            std::string out;
+#if defined(_WIN32)
+            ftk::getEnv("USERNAME", out);
+#else
+            ftk::getEnv("USER", out);
+#endif
+            return out;
+        }
+
         std::string timestamp()
         {
             const std::time_t t = std::time(nullptr);
@@ -112,6 +220,10 @@ namespace djv
             {
                 json["audioPath"] = in.audioPath;
             }
+            if (!in.audioPathAbsolute.empty())
+            {
+                json["audioPathAbsolute"] = in.audioPathAbsolute;
+            }
             json["videoLayer"] = in.videoLayer;
             if (in.speed >= 0.0)
             {
@@ -133,6 +245,7 @@ namespace djv
             if (json.contains("path")) json.at("path").get_to(out.path);
             if (json.contains("pathAbsolute")) json.at("pathAbsolute").get_to(out.pathAbsolute);
             if (json.contains("audioPath")) json.at("audioPath").get_to(out.audioPath);
+            if (json.contains("audioPathAbsolute")) json.at("audioPathAbsolute").get_to(out.audioPathAbsolute);
             if (json.contains("videoLayer")) json.at("videoLayer").get_to(out.videoLayer);
             if (json.contains("speed")) json.at("speed").get_to(out.speed);
             if (json.contains("currentTime")) out.currentTime = jsonToTime(json.at("currentTime"));
@@ -231,6 +344,8 @@ namespace djv
                 id == other.id &&
                 sourceId == other.sourceId &&
                 sameTime(time, other.time) &&
+                author == other.author &&
+                created == other.created &&
                 strokes == other.strokes;
         }
 
@@ -257,6 +372,7 @@ namespace djv
 
         void from_json(const nlohmann::json& json, ReviewStroke& out)
         {
+            requireSpace(json, "widthSpace");
             if (json.contains("color")) json.at("color").get_to(out.color);
             if (json.contains("width")) json.at("width").get_to(out.width);
             out.points.clear();
@@ -277,19 +393,30 @@ namespace djv
             json = nlohmann::json::object();
             json["id"] = in.id;
             json["sourceId"] = in.sourceId;
-            json["space"] = "image";
+            json["space"] = imageSpace;
             if (in.time.has_value())
             {
                 json["time"] = timeToJson(in.time.value());
+            }
+            if (!in.author.empty())
+            {
+                json["author"] = in.author;
+            }
+            if (!in.created.empty())
+            {
+                json["created"] = in.created;
             }
             json["strokes"] = in.strokes;
         }
 
         void from_json(const nlohmann::json& json, ReviewAnnotation& out)
         {
+            requireSpace(json, "space");
             if (json.contains("id")) json.at("id").get_to(out.id);
             if (json.contains("sourceId")) json.at("sourceId").get_to(out.sourceId);
             if (json.contains("time")) out.time = jsonToTime(json.at("time"));
+            if (json.contains("author")) json.at("author").get_to(out.author);
+            if (json.contains("created")) json.at("created").get_to(out.created);
             if (json.contains("strokes")) json.at("strokes").get_to(out.strokes);
         }
 
@@ -299,6 +426,7 @@ namespace djv
                 id == other.id &&
                 sameTime(time, other.time) &&
                 created == other.created &&
+                author == other.author &&
                 text == other.text;
         }
 
@@ -316,6 +444,10 @@ namespace djv
                 json["time"] = timeToJson(in.time.value());
             }
             json["created"] = in.created;
+            if (!in.author.empty())
+            {
+                json["author"] = in.author;
+            }
             json["text"] = in.text;
         }
 
@@ -324,6 +456,7 @@ namespace djv
             if (json.contains("id")) json.at("id").get_to(out.id);
             if (json.contains("time")) out.time = jsonToTime(json.at("time"));
             if (json.contains("created")) json.at("created").get_to(out.created);
+            if (json.contains("author")) json.at("author").get_to(out.author);
             if (json.contains("text")) json.at("text").get_to(out.text);
         }
 
@@ -360,36 +493,75 @@ namespace djv
 
         void to_json(nlohmann::json& json, const Review& in)
         {
-            // Start from the loaded document so unknown sections (e.g. a future
-            // "annotations"/"notes") survive a load/save round-trip untouched.
+            // Start from the loaded document so unknown sections survive a
+            // load/save round-trip untouched.
             json = in.raw.is_object() ? in.raw : nlohmann::json::object();
+
+            // A section that could not be read is left exactly as it was found.
+            // Overwriting it with the defaults the application fell back to
+            // would destroy state this version merely failed to understand.
+            const auto& unread = in.unreadSections;
+            auto write = [&json, &unread](
+                const std::string& key, nlohmann::json value)
+            {
+                if (std::find(unread.begin(), unread.end(), key) == unread.end())
+                {
+                    json[key] = std::move(value);
+                }
+            };
+
+            // A list is written even when some of its items were not read: it is
+            // edited during the session, so a new note has to reach the file.
+            // Those items are appended back, after the ones this version
+            // understands.
+            auto writeList = [&in, &write](
+                const std::string& key, nlohmann::json value)
+            {
+                if (in.unreadItems.is_object() && in.unreadItems.contains(key))
+                {
+                    for (const auto& item : in.unreadItems.at(key))
+                    {
+                        value.push_back(item);
+                    }
+                }
+                write(key, std::move(value));
+            };
+
             json["djvReview"] = in.version;
             json["app"] = in.app;
             json["created"] = in.created;
-            json["files"] = in.files;
-            json["compare"] = in.compare;
-            json["view"] = in.view;
-            json["color"] = in.color;
-            json["ui"] = in.ui;
-            json["annotations"] = in.annotations;
-            json["notes"] = in.notes;
-            json["ranges"] = in.ranges;
+            writeList("files", in.files);
+            write("compare", in.compare);
+            write("view", in.view);
+            write("color", in.color);
+            write("ui", in.ui);
+            writeList("annotations", in.annotations);
+            writeList("notes", in.notes);
+            writeList("ranges", in.ranges);
         }
 
         void from_json(const nlohmann::json& json, Review& out)
         {
             out.raw = json;
+
+            // The version first: a caller that finds one it does not know must
+            // refuse the document before trusting anything below. See
+            // docs/review-format.md.
             if (json.contains("djvReview")) json.at("djvReview").get_to(out.version);
             if (json.contains("app")) json.at("app").get_to(out.app);
             if (json.contains("created")) json.at("created").get_to(out.created);
-            if (json.contains("files")) json.at("files").get_to(out.files);
-            if (json.contains("compare")) json.at("compare").get_to(out.compare);
-            if (json.contains("view")) json.at("view").get_to(out.view);
-            if (json.contains("color")) json.at("color").get_to(out.color);
-            if (json.contains("ui")) json.at("ui").get_to(out.ui);
-            if (json.contains("annotations")) json.at("annotations").get_to(out.annotations);
-            if (json.contains("notes")) json.at("notes").get_to(out.notes);
-            if (json.contains("ranges")) json.at("ranges").get_to(out.ranges);
+
+            // Every section below is read on its own. The annotations and the
+            // notes are the part of a review that exists nowhere else, and one
+            // stale section elsewhere must not be allowed to cost them.
+            readList(json, "files", out.files, out);
+            readSection(json, "compare", out.compare, out);
+            readSection(json, "view", out.view, out);
+            readSection(json, "color", out.color, out);
+            readSection(json, "ui", out.ui, out);
+            readList(json, "annotations", out.annotations, out);
+            readList(json, "notes", out.notes, out);
+            readList(json, "ranges", out.ranges, out);
         }
     }
 }

--- a/lib/djv/Models/Review.h
+++ b/lib/djv/Models/Review.h
@@ -25,8 +25,21 @@ namespace djv
 {
     namespace models
     {
-        //! Current review file format version. See docs/ROADMAP_REVIEW_SESSIONS.md.
+        //! Current review file format version.
+        //!
+        //! Incremented only when a document this version writes can no longer be
+        //! read correctly by an older DJV. Additive changes -- a new key, a new
+        //! section -- keep the version, because the reader ignores what it does
+        //! not recognize. A reader that meets a higher version refuses the
+        //! document rather than guess at it. See docs/review-format.md.
         constexpr int reviewVersion = 1;
+
+        //! Whether this build can read a review document of the given version.
+        //!
+        //! False means the document was written by a newer DJV. Reading it
+        //! anyway would drop what this build does not understand, and the next
+        //! save would write that loss back over the user's file.
+        bool reviewVersionSupported(int version);
 
         //! \name Optional time comparison
         //! Compare strictly: either both unset, or both set to the same value
@@ -56,13 +69,25 @@ namespace djv
         //! The current UTC time, ISO 8601 (e.g. "2026-07-26T18:05:00Z").
         std::string timestamp();
 
+        //! The current user, for attributing notes and annotations.
+        //!
+        //! Taken from the environment -- USERNAME on Windows, USER elsewhere --
+        //! and empty when neither is set. DJV has no accounts and reviews are
+        //! passed from hand to hand, so this is a label rather than an identity:
+        //! it says who wrote a note when a session comes back from someone else.
+        std::string reviewAuthor();
+
         //! A single file entry in a review.
         struct ReviewFile
         {
             std::string id;
             std::string path;          //!< Preferred: relative to the .djvr.
             std::string pathAbsolute;  //!< Fallback: absolute path.
-            std::string audioPath;     //!< Separate audio, absolute.
+
+            //! Separate audio, resolved like the file above: the relative form
+            //! is preferred, the absolute one is the fallback.
+            std::string audioPath;
+            std::string audioPathAbsolute;
             int         videoLayer = 0;
             double      speed = -1.0;
             std::optional<OTIO_NS::RationalTime> currentTime;
@@ -109,8 +134,9 @@ namespace djv
         //!
         //! The points and the width are expressed in the pixels of the source
         //! image, so a stroke keeps its position and its weight whatever the
-        //! zoom, the pan or the comparison mode. See
-        //! docs/ROADMAP_REVIEW_SESSIONS.md section 7.1.
+        //! zoom, the pan or the comparison mode. Both are written with the space
+        //! they are expressed in, and a stroke in a space this version does not
+        //! know is skipped rather than misplaced. See docs/review-format.md.
         struct ReviewStroke
         {
             ftk::Color4F          color = ftk::Color4F(1.F, .365F, .02F, 1.F);
@@ -133,6 +159,11 @@ namespace djv
             //! frame only.
             std::optional<OTIO_NS::RationalTime> time;
 
+            //! Who drew it, and when, ISO 8601. Both are optional: a document
+            //! written before they existed simply leaves them empty.
+            std::string author;
+            std::string created;
+
             std::vector<ReviewStroke> strokes;
 
             bool operator == (const ReviewAnnotation&) const;
@@ -142,8 +173,7 @@ namespace djv
         //! A timestamped note attached to a frame of the review.
         //!
         //! Notes belong to the review rather than to a source: the frame is
-        //! enough to locate them. See docs/ROADMAP_REVIEW_SESSIONS.md section
-        //! 7.2.bis.
+        //! enough to locate them. See docs/review-format.md.
         struct ReviewNote
         {
             std::string id;
@@ -153,6 +183,9 @@ namespace djv
 
             //! When the note was published, ISO 8601.
             std::string created;
+
+            //! Who wrote it. Optional: empty when the environment does not say.
+            std::string author;
 
             std::string text;
 
@@ -196,9 +229,30 @@ namespace djv
             std::vector<ReviewRange> ranges;
 
             //! The document as loaded, verbatim. Used to carry unknown top-level
-            //! sections (e.g. future "annotations"/"notes") through a load/save
-            //! cycle without loss. See docs/ROADMAP_REVIEW_SESSIONS.md §4.4.
+            //! sections through a load/save cycle without loss. See
+            //! docs/review-format.md.
             nlohmann::json raw;
+
+            //! The top-level sections that were present but could not be read,
+            //! by name.
+            //!
+            //! A section is written by a serializer that requires every key it
+            //! knows, so a single key added upstream makes the whole section
+            //! fail. Letting that failure through would cost the user the rest
+            //! of the document -- the annotations and the notes above all -- so
+            //! the section is skipped instead, and saving copies it back out of the
+            //! raw document untouched rather than overwriting it with defaults.
+            std::vector<std::string> unreadSections;
+
+            //! The items of the annotations, notes, ranges and files lists that
+            //! could not be read, verbatim, keyed by section name.
+            //!
+            //! Those lists are edited during the session, so they cannot simply
+            //! be left alone the way a section above is: a new note has to reach
+            //! the file. The items that were not understood are re-emitted after
+            //! the ones that were, so an annotation drawn by a newer DJV is not
+            //! destroyed by an older one opening the review and saving it.
+            nlohmann::json unreadItems;
         };
 
         //! \name Serialize

--- a/lib/djv/Models/Review.h
+++ b/lib/djv/Models/Review.h
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the DJV project.
+
+#pragma once
+
+#include <djv/Models/SettingsModel.h>
+#include <djv/Models/ViewportModel.h>
+
+#include <tlRender/Timeline/ColorOptions.h>
+#include <tlRender/Timeline/CompareOptions.h>
+#include <tlRender/Timeline/BackgroundOptions.h>
+#include <tlRender/Timeline/DisplayOptions.h>
+#include <tlRender/Timeline/ForegroundOptions.h>
+#include <tlRender/Core/Time.h>
+
+#include <ftk/Core/Vector.h>
+
+#include <nlohmann/json.hpp>
+
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace djv
+{
+    namespace models
+    {
+        //! Current review file format version. See docs/ROADMAP_REVIEW_SESSIONS.md.
+        constexpr int reviewVersion = 1;
+
+        //! \name Optional time comparison
+        //! Compare strictly: either both unset, or both set to the same value
+        //! at the same rate.
+        //!
+        //! std::optional would otherwise use OTIO's operator==, which converts
+        //! between rates -- frame 12 at 24fps would equal frame 24 at 48fps,
+        //! and two annotations on different frames would compare equal.
+        ///@{
+
+        bool sameTime(
+            const std::optional<OTIO_NS::RationalTime>&,
+            const std::optional<OTIO_NS::RationalTime>&);
+        bool sameRange(
+            const std::optional<OTIO_NS::TimeRange>&,
+            const std::optional<OTIO_NS::TimeRange>&);
+
+        ///@}
+
+        //! Generate a stable, unique identifier for a review file entry.
+        //!
+        //! Assigned when a file is opened so that annotations and notes (phase 3)
+        //! can reference a file by identity rather than by list index, which is
+        //! not stable across close/reorder.
+        std::string generateId();
+
+        //! The current UTC time, ISO 8601 (e.g. "2026-07-26T18:05:00Z").
+        std::string timestamp();
+
+        //! A single file entry in a review.
+        struct ReviewFile
+        {
+            std::string id;
+            std::string path;          //!< Preferred: relative to the .djvr.
+            std::string pathAbsolute;  //!< Fallback: absolute path.
+            std::string audioPath;     //!< Separate audio, absolute.
+            int         videoLayer = 0;
+            double      speed = -1.0;
+            std::optional<OTIO_NS::RationalTime> currentTime;
+            std::optional<OTIO_NS::TimeRange>    inOutRange;
+        };
+
+        //! Comparison setup for a review.
+        struct ReviewCompare
+        {
+            std::string              aId;   //!< The "A" file, by ReviewFile::id.
+            std::vector<std::string> bIds;  //!< The "B" files, by ReviewFile::id.
+            tl::CompareOptions       options;
+            tl::CompareTime          time = tl::CompareTime::Relative;
+        };
+
+        //! Viewport view state for a review.
+        struct ReviewView
+        {
+            bool     frameView = true;  //!< If true, pos/zoom are ignored on load.
+            ftk::V2I pos;
+            double   zoom = 1.0;
+        };
+
+        //! Color and image display state for a review.
+        struct ReviewColor
+        {
+            tl::OCIOOptions       ocio;
+            tl::LUTOptions        lut;
+            tl::DisplayOptions    display;
+            tl::BackgroundOptions background;
+            tl::ForegroundOptions foreground;
+            AspectRatioOptions    aspectRatio;
+            HUDOptions            hud;
+        };
+
+        //! Interface state for a review.
+        struct ReviewUI
+        {
+            std::string    activeTool;
+            WindowSettings window;
+        };
+
+        //! A single freehand stroke of an annotation.
+        //!
+        //! The points and the width are expressed in the pixels of the source
+        //! image, so a stroke keeps its position and its weight whatever the
+        //! zoom, the pan or the comparison mode. See
+        //! docs/ROADMAP_REVIEW_SESSIONS.md section 7.1.
+        struct ReviewStroke
+        {
+            ftk::Color4F          color = ftk::Color4F(1.F, .365F, .02F, 1.F);
+            float                 width = 4.F;
+            std::vector<ftk::V2F> points;
+
+            bool operator == (const ReviewStroke&) const;
+            bool operator != (const ReviewStroke&) const;
+        };
+
+        //! The drawing on one frame of one source.
+        struct ReviewAnnotation
+        {
+            std::string id;
+
+            //! The source the drawing belongs to, by ReviewFile::id.
+            std::string sourceId;
+
+            //! The frame the drawing appears on. A drawing is visible on this
+            //! frame only.
+            std::optional<OTIO_NS::RationalTime> time;
+
+            std::vector<ReviewStroke> strokes;
+
+            bool operator == (const ReviewAnnotation&) const;
+            bool operator != (const ReviewAnnotation&) const;
+        };
+
+        //! A timestamped note attached to a frame of the review.
+        //!
+        //! Notes belong to the review rather than to a source: the frame is
+        //! enough to locate them. See docs/ROADMAP_REVIEW_SESSIONS.md section
+        //! 7.2.bis.
+        struct ReviewNote
+        {
+            std::string id;
+
+            //! The frame the note refers to, captured when it is published.
+            std::optional<OTIO_NS::RationalTime> time;
+
+            //! When the note was published, ISO 8601.
+            std::string created;
+
+            std::string text;
+
+            bool operator == (const ReviewNote&) const;
+            bool operator != (const ReviewNote&) const;
+        };
+
+        //! A named range of frames in a review.
+        //!
+        //! Selecting one sets the timeline in/out points. Like notes, a range
+        //! belongs to the review rather than to a source: the frames locate it.
+        struct ReviewRange
+        {
+            std::string id;
+
+            //! Free text, defaulted to the frame range when it is created.
+            std::string name;
+
+            std::optional<OTIO_NS::TimeRange> range;
+
+            bool operator == (const ReviewRange&) const;
+            bool operator != (const ReviewRange&) const;
+        };
+
+        //! A complete review: files, comparison, view, color and interface state.
+        //!
+        //! Serialized to a versioned JSON document with the ".djvr" extension.
+        struct Review
+        {
+            int         version = reviewVersion;
+            std::string app;
+            std::string created;
+
+            std::vector<ReviewFile> files;
+            ReviewCompare           compare;
+            ReviewView              view;
+            ReviewColor             color;
+            ReviewUI                ui;
+            std::vector<ReviewAnnotation> annotations;
+            std::vector<ReviewNote> notes;
+            std::vector<ReviewRange> ranges;
+
+            //! The document as loaded, verbatim. Used to carry unknown top-level
+            //! sections (e.g. future "annotations"/"notes") through a load/save
+            //! cycle without loss. See docs/ROADMAP_REVIEW_SESSIONS.md §4.4.
+            nlohmann::json raw;
+        };
+
+        //! \name Serialize
+        ///@{
+
+        void to_json(nlohmann::json&, const ReviewFile&);
+        void to_json(nlohmann::json&, const ReviewCompare&);
+        void to_json(nlohmann::json&, const ReviewView&);
+        void to_json(nlohmann::json&, const ReviewColor&);
+        void to_json(nlohmann::json&, const ReviewUI&);
+        void to_json(nlohmann::json&, const ReviewStroke&);
+        void to_json(nlohmann::json&, const ReviewAnnotation&);
+        void to_json(nlohmann::json&, const ReviewNote&);
+        void to_json(nlohmann::json&, const ReviewRange&);
+        void to_json(nlohmann::json&, const Review&);
+
+        void from_json(const nlohmann::json&, ReviewFile&);
+        void from_json(const nlohmann::json&, ReviewCompare&);
+        void from_json(const nlohmann::json&, ReviewView&);
+        void from_json(const nlohmann::json&, ReviewColor&);
+        void from_json(const nlohmann::json&, ReviewUI&);
+        void from_json(const nlohmann::json&, ReviewStroke&);
+        void from_json(const nlohmann::json&, ReviewAnnotation&);
+        void from_json(const nlohmann::json&, ReviewNote&);
+        void from_json(const nlohmann::json&, ReviewRange&);
+        void from_json(const nlohmann::json&, Review&);
+
+        ///@}
+    }
+}

--- a/lib/djv/Models/ToolsModel.cpp
+++ b/lib/djv/Models/ToolsModel.cpp
@@ -36,6 +36,7 @@ namespace djv
             p.tools.push_back({ "Magnify", "Magnify", "F", true, ftk::Key::F6 });
             p.tools.push_back({ "Information", "Info", "G", true, ftk::Key::F7 });
             p.tools.push_back({ "Audio", "Audio", "H", true, ftk::Key::F8 });
+            p.tools.push_back({ "Review", "Review", "I", true, ftk::Key::F9 });
             p.tools.push_back({ "Settings", "Settings", "W", true, ftk::Key::F10 });
             p.tools.push_back({ "Messages", "Messages", "X", false, ftk::Key::F11 });
             p.tools.push_back({ "System Log", std::string(), "Y", false, ftk::Key::F12 });

--- a/lib/djv/ModelsTest/AnnotationsModelTest.cpp
+++ b/lib/djv/ModelsTest/AnnotationsModelTest.cpp
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the DJV project.
+
+#include <djv/ModelsTest/AnnotationsModelTest.h>
+
+#include <djv/Models/AnnotationsModel.h>
+
+#include <ftk/Core/Assert.h>
+#include <ftk/Core/Format.h>
+
+namespace djv
+{
+    namespace models_tests
+    {
+        namespace
+        {
+            const OTIO_NS::RationalTime frame(const double value)
+            {
+                return OTIO_NS::RationalTime(value, 24.0);
+            }
+
+            models::ReviewStroke makeStroke(float x0, float y0, float x1, float y1)
+            {
+                models::ReviewStroke out;
+                out.width = 4.F;
+                out.points.push_back(ftk::V2F(x0, y0));
+                out.points.push_back(ftk::V2F(x1, y1));
+                return out;
+            }
+        }
+
+        AnnotationsModelTest::AnnotationsModelTest(const std::shared_ptr<ftk::Context>& context) :
+            ITest(context, "models_tests::AnnotationsModelTest")
+        {}
+
+        std::shared_ptr<AnnotationsModelTest> AnnotationsModelTest::create(
+            const std::shared_ptr<ftk::Context>& context)
+        {
+            return std::shared_ptr<AnnotationsModelTest>(new AnnotationsModelTest(context));
+        }
+
+        void AnnotationsModelTest::run()
+        {
+            _strokes();
+            _erase();
+            _undo();
+            _serialize();
+        }
+
+        void AnnotationsModelTest::_strokes()
+        {
+            auto model = models::AnnotationsModel::create();
+            FTK_ASSERT(model->getAnnotations().empty());
+
+            // Strokes on the same source and frame join one annotation.
+            model->addStroke("srcA", frame(100), makeStroke(0.F, 0.F, 10.F, 10.F));
+            model->addStroke("srcA", frame(100), makeStroke(20.F, 20.F, 30.F, 30.F));
+            FTK_ASSERT(1 == model->getAnnotations().size());
+            FTK_ASSERT(2 == model->getStrokes("srcA", frame(100)).size());
+
+            // A different frame, or a different source, is a separate annotation:
+            // a drawing is visible on its own frame only.
+            model->addStroke("srcA", frame(200), makeStroke(0.F, 0.F, 5.F, 5.F));
+            model->addStroke("srcB", frame(100), makeStroke(0.F, 0.F, 5.F, 5.F));
+            FTK_ASSERT(3 == model->getAnnotations().size());
+            FTK_ASSERT(model->getStrokes("srcA", frame(999)).empty());
+
+            const bool ok =
+                3 == model->getAnnotations().size() &&
+                2 == model->getStrokes("srcA", frame(100)).size() &&
+                1 == model->getStrokes("srcB", frame(100)).size() &&
+                model->getStrokes("srcA", frame(999)).empty();
+            _print(ftk::Format("  strokes grouped per source and frame -> {0}").arg(ok ? "ok" : "FAILED"));
+            if (!ok)
+            {
+                _error("Annotation stroke grouping failed");
+            }
+        }
+
+        void AnnotationsModelTest::_erase()
+        {
+            auto model = models::AnnotationsModel::create();
+            model->addStroke("srcA", frame(100), makeStroke(0.F, 0.F, 10.F, 0.F));
+            model->addStroke("srcA", frame(100), makeStroke(0.F, 100.F, 10.F, 100.F));
+
+            // The eraser deletes whole strokes it touches, and leaves the others.
+            model->eraseStrokes("srcA", frame(100), ftk::V2F(5.F, 0.F), 2.F);
+            const bool erasedOne = 1 == model->getStrokes("srcA", frame(100)).size();
+
+            // Far from any stroke, nothing is erased.
+            model->eraseStrokes("srcA", frame(100), ftk::V2F(500.F, 500.F), 2.F);
+            const bool untouched = 1 == model->getStrokes("srcA", frame(100)).size();
+
+            // Erasing the last stroke drops the annotation, so no phantom marker
+            // is left behind in the timeline.
+            model->eraseStrokes("srcA", frame(100), ftk::V2F(5.F, 100.F), 2.F);
+            const bool dropped = model->getAnnotations().empty();
+
+            FTK_ASSERT(erasedOne);
+            FTK_ASSERT(untouched);
+            FTK_ASSERT(dropped);
+            const bool ok = erasedOne && untouched && dropped;
+            _print(ftk::Format("  eraser removes touched strokes only -> {0}").arg(ok ? "ok" : "FAILED"));
+            if (!ok)
+            {
+                _error("Annotation erase failed");
+            }
+        }
+
+        void AnnotationsModelTest::_undo()
+        {
+            auto model = models::AnnotationsModel::create();
+
+            bool hasUndo = false;
+            auto undoObserver = ftk::Observer<bool>::create(
+                model->observeHasUndo(),
+                [&hasUndo](bool value) { hasUndo = value; });
+
+            FTK_ASSERT(!hasUndo);
+            model->addStroke("srcA", frame(100), makeStroke(0.F, 0.F, 10.F, 10.F));
+            model->addStroke("srcA", frame(100), makeStroke(20.F, 20.F, 30.F, 30.F));
+            FTK_ASSERT(hasUndo);
+            FTK_ASSERT(2 == model->getStrokes("srcA", frame(100)).size());
+
+            // Undo is multi-level: each stroke is its own step.
+            model->undo();
+            const bool oneLeft = 1 == model->getStrokes("srcA", frame(100)).size();
+            model->undo();
+            const bool noneLeft = model->getAnnotations().empty();
+
+            // And redo brings them back.
+            model->redo();
+            const bool redone = 1 == model->getStrokes("srcA", frame(100)).size();
+
+            FTK_ASSERT(oneLeft);
+            FTK_ASSERT(noneLeft);
+            FTK_ASSERT(redone);
+            const bool ok = oneLeft && noneLeft && redone;
+            _print(ftk::Format("  multi-level undo and redo -> {0}").arg(ok ? "ok" : "FAILED"));
+            if (!ok)
+            {
+                _error("Annotation undo/redo failed");
+            }
+        }
+
+        void AnnotationsModelTest::_serialize()
+        {
+            // Annotations must survive the review file, points included.
+            models::ReviewAnnotation annotation;
+            annotation.id = "abc123";
+            annotation.sourceId = "src456";
+            annotation.time = frame(218);
+            annotation.strokes.push_back(makeStroke(812.5F, 430.F, 815.F, 433.5F));
+
+            const nlohmann::json json = annotation;
+            const auto out = json.get<models::ReviewAnnotation>();
+
+            FTK_ASSERT(annotation == out);
+            const bool ok = annotation == out;
+            _print(ftk::Format("  annotation JSON round trip -> {0}").arg(ok ? "ok" : "FAILED"));
+            if (!ok)
+            {
+                _error("ReviewAnnotation JSON round trip failed");
+            }
+        }
+    }
+}

--- a/lib/djv/ModelsTest/AnnotationsModelTest.h
+++ b/lib/djv/ModelsTest/AnnotationsModelTest.h
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the DJV project.
+
+#pragma once
+
+#include <ftk/TestLib/ITest.h>
+
+namespace djv
+{
+    namespace models_tests
+    {
+        class AnnotationsModelTest : public ftk::test::ITest
+        {
+        protected:
+            AnnotationsModelTest(const std::shared_ptr<ftk::Context>&);
+
+        public:
+            static std::shared_ptr<AnnotationsModelTest> create(
+                const std::shared_ptr<ftk::Context>&);
+
+            void run() override;
+
+        private:
+            void _strokes();
+            void _erase();
+            void _undo();
+            void _serialize();
+        };
+    }
+}

--- a/lib/djv/ModelsTest/CMakeLists.txt
+++ b/lib/djv/ModelsTest/CMakeLists.txt
@@ -1,6 +1,8 @@
 set(HEADERS
+    AnnotationsModelTest.h
     AudioModelTest.h
     FilesModelTest.h
+    NotesModelTest.h
     ModelsTestUtil.h
     RecentFilesModelTest.h
     TimeUnitsModelTest.h
@@ -8,8 +10,10 @@ set(HEADERS
     ViewportModelTest.h)
 
 set(SOURCE
+    AnnotationsModelTest.cpp
     AudioModelTest.cpp
     FilesModelTest.cpp
+    NotesModelTest.cpp
     RecentFilesModelTest.cpp
     TimeUnitsModelTest.cpp
     ToolsModelTest.cpp

--- a/lib/djv/ModelsTest/CMakeLists.txt
+++ b/lib/djv/ModelsTest/CMakeLists.txt
@@ -5,6 +5,7 @@ set(HEADERS
     NotesModelTest.h
     ModelsTestUtil.h
     RecentFilesModelTest.h
+    ReviewTest.h
     TimeUnitsModelTest.h
     ToolsModelTest.h
     ViewportModelTest.h)
@@ -15,6 +16,7 @@ set(SOURCE
     FilesModelTest.cpp
     NotesModelTest.cpp
     RecentFilesModelTest.cpp
+    ReviewTest.cpp
     TimeUnitsModelTest.cpp
     ToolsModelTest.cpp
     ViewportModelTest.cpp)

--- a/lib/djv/ModelsTest/FilesModelTest.cpp
+++ b/lib/djv/ModelsTest/FilesModelTest.cpp
@@ -12,6 +12,7 @@
 #include <ftk/UI/Settings.h>
 
 #include <ftk/Core/Assert.h>
+#include <ftk/Core/Format.h>
 #include <ftk/Core/Math.h>
 #include <ftk/Core/Observable.h>
 #include <ftk/Core/ObservableList.h>
@@ -50,6 +51,8 @@ namespace djv
             _files();
             _navigation();
             _compare();
+            _tileCompare();
+            _reviewRestore();
             _frames();
             _persistence();
         }
@@ -169,6 +172,108 @@ namespace djv
             FTK_ASSERT(observed);
         }
 
+        void FilesModelTest::_tileCompare()
+        {
+            auto settings = createTestSettings(_context);
+            auto model = models::FilesModel::create(settings);
+            model->add(makeItem("file0.exr"));
+            model->add(makeItem("file1.exr"));
+            model->add(makeItem("file2.exr"));
+            model->add(makeItem("file3.exr"));
+            model->setA(0);
+
+            // Tile mode is the only mode that keeps several "B" files, so a
+            // review can hold more than two sources there.
+            tl::CompareOptions options;
+            options.compare = tl::Compare::Tile;
+            model->setCompareOptions(options);
+            model->clearB();
+            model->setB(1, true);
+            model->setB(2, true);
+            model->setB(3, true);
+            FTK_ASSERT(std::vector<int>({ 1, 2, 3 }) == model->getBIndexes());
+
+            // "A" stays the master source: it is the first active file, ahead of
+            // every "B", whatever the mode.
+            FTK_ASSERT(4 == model->getActive().size());
+            FTK_ASSERT(model->getA() == model->getActive()[0]);
+
+            // Switching to a single-buffer mode truncates "B" down to one file;
+            // "A" is never dropped.
+            options.compare = tl::Compare::Horizontal;
+            model->setCompareOptions(options);
+            FTK_ASSERT(1 == model->getBIndexes().size());
+            FTK_ASSERT(0 == model->getAIndex());
+            FTK_ASSERT(model->getA() == model->getActive()[0]);
+        }
+
+        void FilesModelTest::_reviewRestore()
+        {
+            // Replay the order used when a review is opened (see
+            // App::_applyReview and docs/ROADMAP_REVIEW_SESSIONS.md section 6.1):
+            // add every file, set the compare options, clear "B", rebuild "B",
+            // then set "A" last. This must hold for every compare mode.
+            const std::vector<tl::Compare> modes =
+            {
+                tl::Compare::A,
+                tl::Compare::B,
+                tl::Compare::Wipe,
+                tl::Compare::Overlay,
+                tl::Compare::Difference,
+                tl::Compare::Horizontal,
+                tl::Compare::Vertical,
+                tl::Compare::Tile
+            };
+            for (const auto mode : modes)
+            {
+                auto settings = createTestSettings(_context);
+                auto model = models::FilesModel::create(settings);
+                for (int i = 0; i < 4; ++i)
+                {
+                    model->add(makeItem("file" + std::to_string(i) + ".exr"));
+                }
+
+                // A review saved with "A" = file0 and "B" = the other three.
+                tl::CompareOptions options;
+                options.compare = mode;
+                model->setCompareOptions(options);
+                model->clearB();
+                model->setB(1, true);
+                model->setB(2, true);
+                model->setB(3, true);
+                model->setA(0);
+
+                // "A" is restored as saved in every mode, and remains the first
+                // active file -- the master the player and the timeline follow.
+                FTK_ASSERT(0 == model->getAIndex());
+                FTK_ASSERT(!model->getActive().empty());
+                FTK_ASSERT(model->getA() == model->getActive()[0]);
+
+                // Only tile mode keeps all three "B" files; the others collapse
+                // to the last one selected.
+                const size_t expectedB = tl::Compare::Tile == mode ? 3 : 1;
+                FTK_ASSERT(expectedB == model->getBIndexes().size());
+
+                // FTK_ASSERT is compiled out in Release builds, so report the
+                // observed state explicitly to keep this meaningful there too.
+                const bool aOk =
+                    0 == model->getAIndex() &&
+                    !model->getActive().empty() &&
+                    model->getA() == model->getActive()[0];
+                const bool bOk = expectedB == model->getBIndexes().size();
+                _print(ftk::Format("  {0}: A index {1}, B count {2} (expected {3}) -> {4}").
+                    arg(tl::getLabel(mode)).
+                    arg(model->getAIndex()).
+                    arg(model->getBIndexes().size()).
+                    arg(expectedB).
+                    arg(aOk && bOk ? "ok" : "FAILED"));
+                if (!aOk || !bOk)
+                {
+                    _error(ftk::Format("Review restore failed for compare mode {0}").
+                        arg(tl::getLabel(mode)));
+                }
+            }
+        }
         void FilesModelTest::_frames()
         {
             auto settings = createTestSettings(_context);

--- a/lib/djv/ModelsTest/FilesModelTest.cpp
+++ b/lib/djv/ModelsTest/FilesModelTest.cpp
@@ -210,7 +210,7 @@ namespace djv
         void FilesModelTest::_reviewRestore()
         {
             // Replay the order used when a review is opened (see
-            // App::_applyReview and docs/ROADMAP_REVIEW_SESSIONS.md section 6.1):
+            // App::_applyReview):
             // add every file, set the compare options, clear "B", rebuild "B",
             // then set "A" last. This must hold for every compare mode.
             const std::vector<tl::Compare> modes =

--- a/lib/djv/ModelsTest/FilesModelTest.h
+++ b/lib/djv/ModelsTest/FilesModelTest.h
@@ -24,6 +24,8 @@ namespace djv
             void _files();
             void _navigation();
             void _compare();
+            void _tileCompare();
+            void _reviewRestore();
             void _frames();
             void _persistence();
         };

--- a/lib/djv/ModelsTest/NotesModelTest.cpp
+++ b/lib/djv/ModelsTest/NotesModelTest.cpp
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the DJV project.
+
+#include <djv/ModelsTest/NotesModelTest.h>
+
+#include <djv/Models/NotesModel.h>
+
+#include <ftk/Core/Assert.h>
+#include <ftk/Core/Format.h>
+
+namespace djv
+{
+    namespace models_tests
+    {
+        NotesModelTest::NotesModelTest(const std::shared_ptr<ftk::Context>& context) :
+            ITest(context, "models_tests::NotesModelTest")
+        {}
+
+        std::shared_ptr<NotesModelTest> NotesModelTest::create(
+            const std::shared_ptr<ftk::Context>& context)
+        {
+            return std::shared_ptr<NotesModelTest>(new NotesModelTest(context));
+        }
+
+        void NotesModelTest::run()
+        {
+            _notes();
+            _serialize();
+        }
+
+        void NotesModelTest::_notes()
+        {
+            auto model = models::NotesModel::create();
+
+            size_t count = 0;
+            auto observer = ftk::ListObserver<models::ReviewNote>::create(
+                model->observeNotes(),
+                [&count](const std::vector<models::ReviewNote>& value) { count = value.size(); });
+
+            FTK_ASSERT(model->getNotes().empty());
+
+            // Adding fills in the identifier and the creation time; the caller
+            // only supplies the frame and the text.
+            model->add(OTIO_NS::RationalTime(128.0, 24.0), "First note.");
+            model->add(OTIO_NS::RationalTime(256.0, 24.0), "Second note.");
+            FTK_ASSERT(2 == model->getNotes().size());
+            FTK_ASSERT(2 == count);
+            const auto& notes = model->getNotes();
+            FTK_ASSERT(!notes[0].id.empty());
+            FTK_ASSERT(!notes[0].created.empty());
+            FTK_ASSERT(notes[0].id != notes[1].id);
+            FTK_ASSERT(128.0 == notes[0].time->value());
+
+            // Removing by identifier leaves the other note alone.
+            const std::string id = notes[0].id;
+            model->remove(id);
+            FTK_ASSERT(1 == model->getNotes().size());
+            FTK_ASSERT("Second note." == model->getNotes()[0].text);
+
+            // Removing an unknown identifier is a no-op.
+            model->remove("does-not-exist");
+            FTK_ASSERT(1 == model->getNotes().size());
+
+            model->clear();
+            FTK_ASSERT(model->getNotes().empty());
+
+            const bool ok =
+                0 == model->getNotes().size() &&
+                0 == count;
+            _print(ftk::Format("  notes add/remove/clear -> {0}").arg(ok ? "ok" : "FAILED"));
+            if (!ok)
+            {
+                _error("NotesModel add/remove/clear failed");
+            }
+        }
+
+        void NotesModelTest::_serialize()
+        {
+            // A note must survive a round trip through the review file, since
+            // that is how it is persisted.
+            models::ReviewNote note;
+            note.id = "abc123";
+            note.time = OTIO_NS::RationalTime(218.0, 24.0);
+            note.created = "2026-07-26T18:05:00Z";
+            note.text = "Line one.\nLine two.";
+
+            const nlohmann::json json = note;
+            const auto out = json.get<models::ReviewNote>();
+
+            FTK_ASSERT(note == out);
+
+            const bool ok = note == out;
+            _print(ftk::Format("  note JSON round trip -> {0}").arg(ok ? "ok" : "FAILED"));
+            if (!ok)
+            {
+                _error("ReviewNote JSON round trip failed");
+            }
+        }
+    }
+}

--- a/lib/djv/ModelsTest/NotesModelTest.h
+++ b/lib/djv/ModelsTest/NotesModelTest.h
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the DJV project.
+
+#pragma once
+
+#include <ftk/TestLib/ITest.h>
+
+namespace djv
+{
+    namespace models_tests
+    {
+        class NotesModelTest : public ftk::test::ITest
+        {
+        protected:
+            NotesModelTest(const std::shared_ptr<ftk::Context>&);
+
+        public:
+            static std::shared_ptr<NotesModelTest> create(
+                const std::shared_ptr<ftk::Context>&);
+
+            void run() override;
+
+        private:
+            void _notes();
+            void _serialize();
+        };
+    }
+}

--- a/lib/djv/ModelsTest/ReviewTest.cpp
+++ b/lib/djv/ModelsTest/ReviewTest.cpp
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the DJV project.
+
+#include <djv/ModelsTest/ReviewTest.h>
+
+#include <djv/Models/Review.h>
+
+#include <ftk/Core/Assert.h>
+#include <ftk/Core/Format.h>
+
+namespace djv
+{
+    namespace models_tests
+    {
+        ReviewTest::ReviewTest(const std::shared_ptr<ftk::Context>& context) :
+            ITest(context, "models_tests::ReviewTest")
+        {}
+
+        std::shared_ptr<ReviewTest> ReviewTest::create(
+            const std::shared_ptr<ftk::Context>& context)
+        {
+            return std::shared_ptr<ReviewTest>(new ReviewTest(context));
+        }
+
+        void ReviewTest::run()
+        {
+            _version();
+            _roundTrip();
+            _unreadableSection();
+            _unknownSpace();
+            _unknownKeys();
+        }
+
+        void ReviewTest::_version()
+        {
+            FTK_ASSERT(models::reviewVersionSupported(models::reviewVersion));
+            FTK_ASSERT(models::reviewVersionSupported(models::reviewVersion - 1));
+
+            // A document from a newer DJV is refused rather than read in part:
+            // a best-effort read followed by a save would write the loss back
+            // over the author's own file.
+            FTK_ASSERT(!models::reviewVersionSupported(models::reviewVersion + 1));
+        }
+
+        void ReviewTest::_roundTrip()
+        {
+            models::Review review;
+
+            models::ReviewNote note;
+            note.id = "n0";
+            note.time = OTIO_NS::RationalTime(24.0, 24.0);
+            note.created = "2026-08-26T09:00:00Z";
+            note.author = "reviewer";
+            note.text = "Too dark here.";
+            review.notes.push_back(note);
+
+            models::ReviewStroke stroke;
+            stroke.width = 8.F;
+            stroke.points.push_back(ftk::V2F(1.F, 2.F));
+            stroke.points.push_back(ftk::V2F(3.F, 4.F));
+
+            models::ReviewAnnotation annotation;
+            annotation.id = "a0";
+            annotation.sourceId = "s0";
+            annotation.time = OTIO_NS::RationalTime(48.0, 24.0);
+            annotation.author = "reviewer";
+            annotation.created = "2026-08-26T09:01:00Z";
+            annotation.strokes.push_back(stroke);
+            review.annotations.push_back(annotation);
+
+            models::ReviewRange range;
+            range.id = "r0";
+            range.name = "Opening";
+            range.range = OTIO_NS::TimeRange(
+                OTIO_NS::RationalTime(0.0, 24.0),
+                OTIO_NS::RationalTime(48.0, 24.0));
+            review.ranges.push_back(range);
+
+            const nlohmann::json json = review;
+            const auto out = json.get<models::Review>();
+
+            FTK_ASSERT(out.unreadSections.empty());
+            FTK_ASSERT(1 == out.notes.size());
+            FTK_ASSERT(note == out.notes[0]);
+            FTK_ASSERT(1 == out.annotations.size());
+            FTK_ASSERT(annotation == out.annotations[0]);
+            FTK_ASSERT(1 == out.ranges.size());
+            FTK_ASSERT(range == out.ranges[0]);
+
+            // The author and the time are what make a review readable when it
+            // comes back from someone else; they must survive the trip.
+            FTK_ASSERT("reviewer" == out.notes[0].author);
+            FTK_ASSERT("reviewer" == out.annotations[0].author);
+            FTK_ASSERT("2026-08-26T09:01:00Z" == out.annotations[0].created);
+        }
+
+        void ReviewTest::_unreadableSection()
+        {
+            // "color" delegates to serializers that require every key they know,
+            // so an incomplete one throws. That must cost the color state and
+            // nothing else: the annotations and the notes exist nowhere but here.
+            models::Review review;
+            models::ReviewNote note;
+            note.id = "n0";
+            note.created = "2026-08-26T09:00:00Z";
+            note.text = "Kept.";
+            review.notes.push_back(note);
+
+            nlohmann::json json = review;
+            nlohmann::json brokenColor = nlohmann::json::object();
+            brokenColor["display"] = nlohmann::json::object();
+            json["color"] = brokenColor;
+
+            const auto out = json.get<models::Review>();
+
+            FTK_ASSERT(1 == out.unreadSections.size());
+            FTK_ASSERT("color" == out.unreadSections[0]);
+            FTK_ASSERT(1 == out.notes.size());
+            FTK_ASSERT(note == out.notes[0]);
+
+            // Saving leaves the section exactly as it was found. Writing the
+            // defaults the application fell back to would destroy state this
+            // build merely failed to understand.
+            const nlohmann::json saved = out;
+            FTK_ASSERT(saved.contains("color"));
+            FTK_ASSERT(brokenColor == saved.at("color"));
+        }
+
+        void ReviewTest::_unknownSpace()
+        {
+            // An annotation in a coordinate space this build does not know
+            // cannot be drawn, and drawing it anyway would put it in the wrong
+            // place. It is skipped -- and kept, so that an older DJV opening a
+            // newer review does not quietly delete someone else's work.
+            models::ReviewAnnotation known;
+            known.id = "a0";
+            known.sourceId = "s0";
+            known.strokes.push_back(models::ReviewStroke());
+
+            nlohmann::json foreign = nlohmann::json::object();
+            foreign["id"] = "a1";
+            foreign["sourceId"] = "s0";
+            foreign["space"] = "screen";
+            foreign["strokes"] = nlohmann::json::array();
+
+            models::Review review;
+            review.annotations.push_back(known);
+            nlohmann::json json = review;
+            json["annotations"].push_back(foreign);
+
+            const auto out = json.get<models::Review>();
+
+            FTK_ASSERT(1 == out.annotations.size());
+            FTK_ASSERT("a0" == out.annotations[0].id);
+            FTK_ASSERT(out.unreadSections.empty());
+
+            const nlohmann::json saved = out;
+            FTK_ASSERT(2 == saved.at("annotations").size());
+            FTK_ASSERT(foreign == saved.at("annotations")[1]);
+
+            // The same holds for a stroke width in an unknown space: the
+            // annotation carrying it is kept whole rather than half-read.
+            nlohmann::json foreignWidth = nlohmann::json::object();
+            foreignWidth["id"] = "a2";
+            foreignWidth["sourceId"] = "s0";
+            nlohmann::json strokes = nlohmann::json::array();
+            nlohmann::json strokeJson = nlohmann::json::object();
+            strokeJson["width"] = 4.F;
+            strokeJson["widthSpace"] = "screen";
+            strokes.push_back(strokeJson);
+            foreignWidth["strokes"] = strokes;
+
+            nlohmann::json json2 = nlohmann::json(models::Review());
+            json2["annotations"] = nlohmann::json::array();
+            json2["annotations"].push_back(foreignWidth);
+
+            const auto out2 = json2.get<models::Review>();
+            FTK_ASSERT(out2.annotations.empty());
+            const nlohmann::json saved2 = out2;
+            FTK_ASSERT(1 == saved2.at("annotations").size());
+            FTK_ASSERT(foreignWidth == saved2.at("annotations")[0]);
+        }
+
+        void ReviewTest::_unknownKeys()
+        {
+            // A section this version knows nothing about survives a load/save
+            // cycle untouched, so a review edited by an older DJV keeps whatever
+            // a newer one put in it.
+            nlohmann::json json = nlohmann::json(models::Review());
+            nlohmann::json future = nlohmann::json::object();
+            future["something"] = 42;
+            json["playlists"] = future;
+
+            const auto out = json.get<models::Review>();
+            const nlohmann::json saved = out;
+
+            FTK_ASSERT(saved.contains("playlists"));
+            FTK_ASSERT(future == saved.at("playlists"));
+        }
+    }
+}

--- a/lib/djv/ModelsTest/ReviewTest.h
+++ b/lib/djv/ModelsTest/ReviewTest.h
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the DJV project.
+
+#pragma once
+
+#include <ftk/TestLib/ITest.h>
+
+namespace djv
+{
+    namespace models_tests
+    {
+        class ReviewTest : public ftk::test::ITest
+        {
+        protected:
+            ReviewTest(const std::shared_ptr<ftk::Context>&);
+
+        public:
+            static std::shared_ptr<ReviewTest> create(
+                const std::shared_ptr<ftk::Context>&);
+
+            void run() override;
+
+        private:
+            void _version();
+            void _roundTrip();
+            void _unreadableSection();
+            void _unknownSpace();
+            void _unknownKeys();
+        };
+    }
+}

--- a/lib/djv/Resource/CMakeLists.txt
+++ b/lib/djv/Resource/CMakeLists.txt
@@ -1,7 +1,12 @@
 set(HEADERS)
 set(SOURCE)
 set(RESOURCES
-    etc/Icons/DJV_Icon.svg)
+    etc/Icons/DJV_Icon.svg
+    etc/Icons/DrawTool.svg
+    etc/Icons/Eraser.svg
+    etc/Icons/Review.svg
+    etc/Icons/ReviewNext.svg
+    etc/Icons/ReviewPrev.svg)
 foreach(RESOURCE ${RESOURCES})
     get_filename_component(RESOURCE_BASE ${RESOURCE} NAME_WE)
     add_custom_command(

--- a/tests/djv-test/djv-test.cpp
+++ b/tests/djv-test/djv-test.cpp
@@ -7,6 +7,7 @@
 #include <djv/ModelsTest/AudioModelTest.h>
 #include <djv/ModelsTest/FilesModelTest.h>
 #include <djv/ModelsTest/NotesModelTest.h>
+#include <djv/ModelsTest/ReviewTest.h>
 #include <djv/ModelsTest/RecentFilesModelTest.h>
 #include <djv/ModelsTest/TimeUnitsModelTest.h>
 #include <djv/ModelsTest/ToolsModelTest.h>
@@ -59,6 +60,7 @@ namespace djv
             p.tests.push_back(models_tests::AudioModelTest::create(context));
             p.tests.push_back(models_tests::FilesModelTest::create(context));
             p.tests.push_back(models_tests::NotesModelTest::create(context));
+            p.tests.push_back(models_tests::ReviewTest::create(context));
             p.tests.push_back(models_tests::RecentFilesModelTest::create(context));
             p.tests.push_back(models_tests::TimeUnitsModelTest::create(context));
             p.tests.push_back(models_tests::ToolsModelTest::create(context));

--- a/tests/djv-test/djv-test.cpp
+++ b/tests/djv-test/djv-test.cpp
@@ -3,8 +3,10 @@
 
 #include "djv-test.h"
 
+#include <djv/ModelsTest/AnnotationsModelTest.h>
 #include <djv/ModelsTest/AudioModelTest.h>
 #include <djv/ModelsTest/FilesModelTest.h>
+#include <djv/ModelsTest/NotesModelTest.h>
 #include <djv/ModelsTest/RecentFilesModelTest.h>
 #include <djv/ModelsTest/TimeUnitsModelTest.h>
 #include <djv/ModelsTest/ToolsModelTest.h>
@@ -53,8 +55,10 @@ namespace djv
             tl::init(context);
 
             // Models tests.
+            p.tests.push_back(models_tests::AnnotationsModelTest::create(context));
             p.tests.push_back(models_tests::AudioModelTest::create(context));
             p.tests.push_back(models_tests::FilesModelTest::create(context));
+            p.tests.push_back(models_tests::NotesModelTest::create(context));
             p.tests.push_back(models_tests::RecentFilesModelTest::create(context));
             p.tests.push_back(models_tests::TimeUnitsModelTest::create(context));
             p.tests.push_back(models_tests::ToolsModelTest::create(context));


### PR DESCRIPTION
Adds review sessions: saving a whole session to a `.djvr` and reopening it
later, with drawing annotations, notes anchored to frames, and named frame
ranges.

**This needs grizzlypeak3d/feather-tk#4 first.** It calls the extended
`FileBrowserSystem::open()` signature for the `.djvr` dialogs, so it will not
build until that lands and the `deps/tlRender` pointer follows. The submodule
bump is deliberately not in this branch, since it would point at a commit that
does not exist yet on your side.

## What a review holds

The open files with their audio, layer, speed, current frame and in/out range;
the active tab and the comparison setup; the viewport framing, pan and zoom;
OCIO, LUT, display, background, foreground, aspect ratio and HUD; the active
tool panel and the window layout. Plus the marks made on top: drawings, notes
and ranges.

Paths are stored relative to the `.djvr` when possible, so a review stays valid
when it travels with its media. Files that cannot be found are not a dead end —
a dialog offers to point at their new location and the session is restored
around them.

Personal preferences are deliberately left out — shortcuts, style, cache size,
audio device — so opening a review received from someone else does not
reconfigure their installation.

## The marks

A drawing belongs to one source and one frame. Strokes are expressed in the
pixels of the source image, so they keep their position and their weight
whatever the zoom, the pan or the comparison mode. Undo and redo go through a
command stack.

A note is anchored to the frame it was published on and shown only there. It is
stored in UTC and displayed in local time, so a review stays unambiguous when it
travels between time zones.

A range is a named span of frames, captured from the in/out points and recalled
with a click.

Frames carrying a note or a drawing are marked in the timeline ruler, and two
buttons in the playback bar jump between them.

## Structure

Two commits. The first adds the document format and its models with their
tests, and builds and tests on its own. The second wires it into the
application.

The tests cover the JSON round trip for each kind of mark, the eraser, and
multi-level undo. They also check that "A" is restored as saved and stays the
first active file across all eight comparison modes — the player and the
timeline follow it, so a review that restores the wrong "A" plays against the
wrong source.

Two supporting changes worth flagging: `FilesModelItem` gains a stable
identifier so a drawing can reference its source by identity rather than by list
index, and `RecentFilesModel` takes a settings group so reviews keep their own
recent list.

Happy to split this differently, or to drop parts of it, if you would rather
review it another way.
